### PR TITLE
Adds new constructors for BinaryReader and BinaryWriter

### DIFF
--- a/src/binarytools/BinaryReader.cpp
+++ b/src/binarytools/BinaryReader.cpp
@@ -1,6 +1,11 @@
 #include "BinaryReader.h"
+#include "MemoryStream.h"
 #include <cmath>
 #include <stdexcept>
+
+Ship::BinaryReader::BinaryReader(char* nBuffer, size_t nBufferSize) {
+    mStream = std::make_shared<MemoryStream>(nBuffer, nBufferSize);
+}
 
 Ship::BinaryReader::BinaryReader(Stream* nStream) {
     mStream.reset(nStream);

--- a/src/binarytools/BinaryReader.h
+++ b/src/binarytools/BinaryReader.h
@@ -16,6 +16,7 @@ namespace Ship {
 
 class BinaryReader {
   public:
+    BinaryReader(char* nBuffer, size_t nBufferSize);
     BinaryReader(Stream* nStream);
     BinaryReader(std::shared_ptr<Stream> nStream);
 

--- a/src/binarytools/BinaryWriter.cpp
+++ b/src/binarytools/BinaryWriter.cpp
@@ -1,4 +1,9 @@
 #include "BinaryWriter.h"
+#include "MemoryStream.h"
+
+Ship::BinaryWriter::BinaryWriter() {
+    mStream = std::make_shared<MemoryStream>();
+}
 
 Ship::BinaryWriter::BinaryWriter(Stream* nStream) {
     mStream.reset(nStream);

--- a/src/binarytools/BinaryWriter.h
+++ b/src/binarytools/BinaryWriter.h
@@ -10,6 +10,7 @@
 namespace Ship {
 class BinaryWriter {
   public:
+    BinaryWriter();
     BinaryWriter(Stream* nStream);
     BinaryWriter(std::shared_ptr<Stream> nStream);
 


### PR DESCRIPTION
These constructors instantiate a MemoryStream, as opposed to the calling code having to provide one separately. This allows consumers of the library to utilize the BinaryTools without us needing to export MemoryStream.