### PR TITLE
Adds ToVector to Stream abstract and exposes it in BinaryReader/Writer.

### DIFF
--- a/src/binarytools/BinaryReader.cpp
+++ b/src/binarytools/BinaryReader.cpp
@@ -191,3 +191,7 @@ std::string Ship::BinaryReader::ReadString() {
     }
     return res;
 }
+
+std::vector<char> Ship::BinaryReader::ToVector() {
+    return mStream->ToVector();
+}

--- a/src/binarytools/BinaryReader.h
+++ b/src/binarytools/BinaryReader.h
@@ -47,6 +47,8 @@ class BinaryReader {
     Color3b ReadColor3b();
     std::string ReadString();
 
+    std::vector<char> ToVector();
+
   protected:
     std::shared_ptr<Stream> mStream;
     Endianness mEndianness = Endianness::Native;

--- a/src/binarytools/BinaryWriter.cpp
+++ b/src/binarytools/BinaryWriter.cpp
@@ -144,3 +144,7 @@ void Ship::BinaryWriter::Write(const std::string& str) {
 void Ship::BinaryWriter::Write(char* srcBuffer, size_t length) {
     mStream->Write(srcBuffer, length);
 }
+
+std::vector<char> Ship::BinaryWriter::ToVector() {
+    return mStream->ToVector();
+}

--- a/src/binarytools/BinaryWriter.h
+++ b/src/binarytools/BinaryWriter.h
@@ -36,6 +36,8 @@ class BinaryWriter {
     void Write(const std::string& str);
     void Write(char* srcBuffer, size_t length);
 
+    std::vector<char> ToVector();
+
   protected:
     std::shared_ptr<Stream> mStream;
     Endianness mEndianness = Endianness::Native;

--- a/src/binarytools/Stream.h
+++ b/src/binarytools/Stream.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 namespace Ship {
 enum class SeekOffsetType { Start, Current, End };
@@ -20,6 +21,8 @@ class Stream {
 
     virtual void Write(char* destBuffer, size_t length) = 0;
     virtual void WriteByte(int8_t value) = 0;
+
+    virtual std::vector<char> ToVector() = 0;
 
     virtual void Flush() = 0;
     virtual void Close() = 0;


### PR DESCRIPTION
For getting stream contents in consuming code without exposing MemoryStream.h directly.