### PR TITLE
Improves CMake settings to ease use in other projects

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: soh-mac
-        path: build-cmake/src/*.a
+        path: build-cmake/lib/*.a
         if-no-files-found: error
   build-linux:
     runs-on: ubuntu-latest
@@ -63,7 +63,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: soh-linux
-        path: build-cmake/src/*.a
+        path: build-cmake/lib/*.a
         if-no-files-found: error
   build-windows:
     runs-on: windows-latest
@@ -88,5 +88,5 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: soh-windows
-        path: build-cmake/src/**/*.lib
+        path: build-cmake/lib/**/*.lib
         if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,19 +34,20 @@ include (GNUInstallDirs)
 
 install(TARGETS libultraship ImGui tinyxml2 storm StrHash64 Mercury nlohmann_json ZAPDUtils
     EXPORT libultraship-targets
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Runtime
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime
 )
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/libultraship
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT Development
 )
 
 install(EXPORT libultraship-targets
     FILE libultraship-targets.cmake
     NAMESPACE libultraship::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libultraship
+    COMPONENT Development
 )
 
 include (CMakePackageConfigHelpers)
@@ -68,6 +69,7 @@ install(
         ${CMAKE_BINARY_DIR}/cmake/libultraship-config.cmake
         ${CMAKE_BINARY_DIR}/cmake/libultraship-config-version.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libultraship
+    COMPONENT Development
 )
 
 export(EXPORT libultraship-targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,3 +24,47 @@ endif()
 add_subdirectory("extern")
 add_subdirectory("src")
 
+include (GNUInstallDirs)
+
+install(TARGETS libultraship ImGui tinyxml2 storm StrHash64 Mercury nlohmann_json ZAPDUtils
+    EXPORT libultraship-targets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/libultraship
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(EXPORT libultraship-targets
+    FILE libultraship-targets.cmake
+    NAMESPACE libultraship::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libultraship
+)
+
+include (CMakePackageConfigHelpers)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/libultraship-config.cmake.in
+    ${CMAKE_BINARY_DIR}/cmake/libultraship-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libultraship
+)
+
+# write_basic_package_version_file(
+#     ${CMAKE_BINARY_DIR}/cmake/libultraship-config-version.cmake
+#     VERSION ${LIBULTRASHIP_VERSION}
+#     COMPATIBILITY AnyNewerVersion
+# )
+
+install(
+    FILES
+        ${CMAKE_BINARY_DIR}/cmake/libultraship-config.cmake
+        ${CMAKE_BINARY_DIR}/cmake/libultraship-config-version.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libultraship
+)
+
+export(EXPORT libultraship-targets
+    FILE ${CMAKE_BINARY_DIR}/cmake/libultraship-targets.cmake
+    NAMESPACE libultraship::
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,12 @@ endif()
 add_subdirectory("extern")
 add_subdirectory("src")
 
+set_target_properties(libultraship PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
 include (GNUInstallDirs)
 
 install(TARGETS libultraship ImGui tinyxml2 storm StrHash64 Mercury nlohmann_json ZAPDUtils
@@ -51,10 +57,11 @@ configure_package_config_file(
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libultraship
 )
 
+# Uncomment when a version is present in the project()
 # write_basic_package_version_file(
 #     ${CMAKE_BINARY_DIR}/cmake/libultraship-config-version.cmake
 #     VERSION ${LIBULTRASHIP_VERSION}
-#     COMPATIBILITY AnyNewerVersion
+#     COMPATIBILITY SameMajorVersion
 # )
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ install(TARGETS libultraship ImGui tinyxml2 storm StrHash64 Mercury nlohmann_jso
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/libultraship
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/libultraship
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
@@ -57,12 +57,11 @@ configure_package_config_file(
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libultraship
 )
 
-# Uncomment when a version is present in the project()
-# write_basic_package_version_file(
-#     ${CMAKE_BINARY_DIR}/cmake/libultraship-config-version.cmake
-#     VERSION ${LIBULTRASHIP_VERSION}
-#     COMPATIBILITY SameMajorVersion
-# )
+write_basic_package_version_file(
+    ${CMAKE_BINARY_DIR}/cmake/libultraship-config-version.cmake
+    VERSION 0.9.0 # Placeholder, replace with ${LIBULTRASHIP_VERSION} when a proper version is supplied to project()
+    COMPATIBILITY SameMajorVersion
+)
 
 install(
     FILES

--- a/cmake/DefaultCXX.cmake
+++ b/cmake/DefaultCXX.cmake
@@ -1,6 +1,6 @@
 include("${CMAKE_CURRENT_LIST_DIR}/Default.cmake")
 
-set_config_specific_property("OUTPUT_DIRECTORY" "${CMAKE_SOURCE_DIR}$<$<NOT:$<STREQUAL:${CMAKE_VS_PLATFORM_NAME},Win32>>:/${CMAKE_VS_PLATFORM_NAME}>/${PROPS_CONFIG}")
+# set_config_specific_property("OUTPUT_DIRECTORY" "${CMAKE_SOURCE_DIR}$<$<NOT:$<STREQUAL:${CMAKE_VS_PLATFORM_NAME},Win32>>:/${CMAKE_VS_PLATFORM_NAME}>/${PROPS_CONFIG}")
 
 if(MSVC)
     create_property_reader("DEFAULT_CXX_EXCEPTION_HANDLING")

--- a/cmake/libultraship-config.cmake.in
+++ b/cmake/libultraship-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+if(NOT TARGET libultraship::libultraship)
+    include(${CMAKE_CURRENT_LIST_DIR}/libultraship-targets.cmake)
+endif()

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -63,7 +63,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
     )
 endif()
 
-target_include_directories(ImGui PUBLIC ${IMGUI_DIR} ${IMGUI_DIR}/backends PRIVATE ${SDL2_INCLUDE_DIRS})
+target_include_directories(ImGui PUBLIC $<BUILD_INTERFACE:${IMGUI_DIR}> $<BUILD_INTERFACE:${IMGUI_DIR}/backends> PRIVATE ${SDL2_INCLUDE_DIRS})
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_link_libraries(ImGui PUBLIC SDL2::SDL2 SDL2::SDL2main)
@@ -90,7 +90,7 @@ set(TINYXML2_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tinyxml2)
 add_library(tinyxml2 STATIC)
 
 target_sources(tinyxml2 PRIVATE ${TINYXML2_DIR}/tinyxml2.cpp)
-target_include_directories(tinyxml2 PUBLIC ${TINYXML2_DIR})
+target_include_directories(tinyxml2 PUBLIC $<BUILD_INTERFACE:${TINYXML2_DIR}>)
 
 #=================== ZAPDUtils ===================
 
@@ -111,7 +111,7 @@ add_library(Mercury STATIC)
 set_property(TARGET Mercury PROPERTY CXX_STANDARD 20)
 
 target_sources(Mercury PRIVATE ${MERCURY_DIR}/Mercury.cpp)
-target_include_directories(Mercury PUBLIC ${MERCURY_DIR} ${ZAPDUTILS_DIR})
+target_include_directories(Mercury PUBLIC $<BUILD_INTERFACE:${MERCURY_DIR}> $<BUILD_INTERFACE:${ZAPDUTILS_DIR}>)
 
 target_link_libraries(Mercury PUBLIC ZAPDUtils nlohmann_json::nlohmann_json)
 
@@ -122,4 +122,4 @@ add_library(StrHash64 STATIC)
 
 target_sources(StrHash64 PRIVATE ${STRHASH64_DIR}/StrHash64.cpp)
 
-target_include_directories(StrHash64 PUBLIC ${STRHASH64_DIR})
+target_include_directories(StrHash64 PUBLIC $<BUILD_INTERFACE:${STRHASH64_DIR}>)

--- a/extern/StormLib/CMakeLists.txt
+++ b/extern/StormLib/CMakeLists.txt
@@ -334,7 +334,7 @@ endif()
 
 target_link_libraries(${LIBRARY_NAME} ${LINK_LIBS})
 target_compile_definitions(${LIBRARY_NAME} INTERFACE STORMLIB_NO_AUTO_LINK) #CMake will take care of the linking
-target_include_directories(${LIBRARY_NAME} PUBLIC src/)
+target_include_directories(${LIBRARY_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/>)
 set_target_properties(${LIBRARY_NAME} PROPERTIES PUBLIC_HEADER "src/StormLib.h;src/StormPort.h")
 if(BUILD_SHARED_LIBS)
     message(STATUS "Linking against dependent libraries dynamically")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(libultraship STATIC)
+add_library(libultraship::libultraship ALIAS libultraship)
 set_property(TARGET libultraship PROPERTY CXX_STANDARD 20)
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
@@ -344,7 +345,7 @@ target_sources(libultraship PRIVATE ${Source_Files__Lib__stb})
 
 target_include_directories(libultraship
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../extern
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../extern/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/../extern/stb
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${INCLUDE_DIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../extern/spdlog/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../extern/stb>
 )
 
 if (CMAKE_SYSTEM_NAME STREQUAL "CafeOS")


### PR DESCRIPTION
This could probably be taken further, but for now this adds the necessary installs and exports to let libultraship play nicer while being used by other apps conforming to modern cmake best practices.

For example, now instead of needing to `FetchContent` libultraship directly in the toplevel `OTRIzer` library of SequenceOTRizer, I can just do a `find_package` of libultraship there and do the `FetchContent` in the `CMakeLists.txt` of SequenceOTRizer directly. Or, if libultraship was previously installed to the system or the CMake User Registry on my computer, I wouldn't even need to `FetchContent`. Speaking of, this part needs some testing, but this _should_ make libultraship installable/packageable as a deb or vcpkg or something.