### PR TITLE
Added support for switch controllers using native api

### DIFF
--- a/extern/ImGui/imgui.h
+++ b/extern/ImGui/imgui.h
@@ -1046,7 +1046,8 @@ enum ImGuiInputTextFlags_
     ImGuiInputTextFlags_NoUndoRedo          = 1 << 16,  // Disable undo/redo. Note that input text owns the text data while active, if you want to provide your own undo/redo stack you need e.g. to call ClearActiveID().
     ImGuiInputTextFlags_CharsScientific     = 1 << 17,  // Allow 0123456789.+-*/eE (Scientific notation input)
     ImGuiInputTextFlags_CallbackResize      = 1 << 18,  // Callback on buffer capacity changes request (beyond 'buf_size' parameter value), allowing the string to grow. Notify when the string wants to be resized (for string types which hold a cache of their Size). You will be provided a new BufSize in the callback and NEED to honor it. (see misc/cpp/imgui_stdlib.h for an example of using this)
-    ImGuiInputTextFlags_CallbackEdit        = 1 << 19   // Callback on any edit (note that InputText() already returns true on edit, the callback is useful mainly to manipulate the underlying buffer while focus is active)
+    ImGuiInputTextFlags_CallbackEdit        = 1 << 19,  // Callback on any edit (note that InputText() already returns true on edit, the callback is useful mainly to manipulate the underlying buffer while focus is active)
+    ImGuiInputTextFlags_NoPlusMinusButtons  = 1 << 20   // Disable increment/decrement buttons
 
     // Obsolete names (will be removed soon)
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS

--- a/extern/ImGui/imgui_widgets.cpp
+++ b/extern/ImGui/imgui_widgets.cpp
@@ -3456,17 +3456,19 @@ bool ImGui::InputScalar(const char* label, ImGuiDataType data_type, void* p_data
         ImGuiButtonFlags button_flags = ImGuiButtonFlags_Repeat | ImGuiButtonFlags_DontClosePopups;
         if (flags & ImGuiInputTextFlags_ReadOnly)
             BeginDisabled();
-        SameLine(0, style.ItemInnerSpacing.x);
-        if (ButtonEx("-", ImVec2(button_size, button_size), button_flags))
-        {
-            DataTypeApplyOp(data_type, '-', p_data, p_data, g.IO.KeyCtrl && p_step_fast ? p_step_fast : p_step);
-            value_changed = true;
-        }
-        SameLine(0, style.ItemInnerSpacing.x);
-        if (ButtonEx("+", ImVec2(button_size, button_size), button_flags))
-        {
-            DataTypeApplyOp(data_type, '+', p_data, p_data, g.IO.KeyCtrl && p_step_fast ? p_step_fast : p_step);
-            value_changed = true;
+        if(!(flags & ImGuiInputTextFlags_NoPlusMinusButtons)) {
+            SameLine(0, style.ItemInnerSpacing.x);
+            if (ButtonEx("-", ImVec2(button_size, button_size), button_flags))
+            {
+                DataTypeApplyOp(data_type, '-', p_data, p_data, g.IO.KeyCtrl && p_step_fast ? p_step_fast : p_step);
+                value_changed = true;
+            }
+            SameLine(0, style.ItemInnerSpacing.x);
+            if (ButtonEx("+", ImVec2(button_size, button_size), button_flags))
+            {
+                DataTypeApplyOp(data_type, '+', p_data, p_data, g.IO.KeyCtrl && p_step_fast ? p_step_fast : p_step);
+                value_changed = true;
+            }
         }
         if (flags & ImGuiInputTextFlags_ReadOnly)
             EndDisabled();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,6 +171,8 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch")
     set(Source_Files__Port
         ${CMAKE_CURRENT_SOURCE_DIR}/port/switch/SwitchImpl.h
         ${CMAKE_CURRENT_SOURCE_DIR}/port/switch/SwitchImpl.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/port/switch/SwitchController.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/port/switch/SwitchController.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/port/switch/SwitchPerformanceProfiles.h
     )
 endif()

--- a/src/menu/InputEditor.cpp
+++ b/src/menu/InputEditor.cpp
@@ -75,6 +75,9 @@ void InputEditor::DrawControllerSelect(int32_t currentPort) {
 
     if (ImGui::BeginCombo("##ControllerEntries", controllerName.c_str())) {
         for (uint8_t i = 0; i < controlDeck->GetNumPhysicalDevices(); i++) {
+            if(!controlDeck->GetPhysicalDevice(i)->Connected()) {
+                continue;
+            }
             std::string deviceName = controlDeck->GetPhysicalDevice(i)->GetControllerName();
             if (deviceName != "Keyboard" && deviceName != "Auto") {
                 deviceName += "##" + std::to_string(i);

--- a/src/menu/InputEditor.cpp
+++ b/src/menu/InputEditor.cpp
@@ -87,6 +87,12 @@ void InputEditor::DrawControllerSelect(int32_t currentPort) {
     if (ImGui::Button("Refresh")) {
         controlDeck->ScanPhysicalDevices();
     }
+
+    ImGui::SameLine();
+
+    if (ImGui::Button("Defaults")){
+        GetControllerPerSlot(currentPort)->CreateDefaultBinding(mCurrentPort);
+    }
 }
 
 void InputEditor::DrawVirtualStick(const char* label, ImVec2 stick) {

--- a/src/menu/InputEditor.cpp
+++ b/src/menu/InputEditor.cpp
@@ -69,14 +69,18 @@ void InputEditor::DrawControllerSelect(int32_t currentPort) {
     auto controlDeck = Ship::Window::GetInstance()->GetControlDeck();
     std::string controllerName = controlDeck->GetPhysicalDeviceFromVirtualSlot(currentPort)->GetControllerName();
 
+#ifdef __SWITCH__
+    ImGui::PushItemWidth(320.0f);
+#endif
+
     if (ImGui::BeginCombo("##ControllerEntries", controllerName.c_str())) {
         for (uint8_t i = 0; i < controlDeck->GetNumPhysicalDevices(); i++) {
             std::string deviceName = controlDeck->GetPhysicalDevice(i)->GetControllerName();
             if (deviceName != "Keyboard" && deviceName != "Auto") {
                 deviceName += "##" + std::to_string(i);
             }
-            if (ImGui::Selectable(deviceName.c_str(), i == controlDeck->GetVirtualDevice(currentPort),
-                                  ImGuiSelectableFlags_SpanAvailWidth)) {
+
+            if (ImGui::Selectable(deviceName.c_str(), i == controlDeck->GetVirtualDevice(currentPort))) {
                 controlDeck->SetPhysicalDevice(currentPort, i);
             }
         }

--- a/src/menu/InputEditor.cpp
+++ b/src/menu/InputEditor.cpp
@@ -90,7 +90,7 @@ void InputEditor::DrawControllerSelect(int32_t currentPort) {
 
     ImGui::SameLine();
 
-    if (ImGui::Button("Defaults")){
+    if (ImGui::Button("Defaults")) {
         GetControllerPerSlot(currentPort)->CreateDefaultBinding(mCurrentPort);
     }
 }

--- a/src/menu/InputEditor.cpp
+++ b/src/menu/InputEditor.cpp
@@ -75,7 +75,7 @@ void InputEditor::DrawControllerSelect(int32_t currentPort) {
             if (deviceName != "Keyboard" && deviceName != "Auto") {
                 deviceName += "##" + std::to_string(i);
             }
-            if (ImGui::Selectable(deviceName.c_str(), i == controlDeck->GetVirtualDevice(currentPort))) {
+            if (ImGui::Selectable(deviceName.c_str(), i == controlDeck->GetVirtualDevice(currentPort), ImGuiSelectableFlags_SpanAvailWidth)) {
                 controlDeck->SetPhysicalDevice(currentPort, i);
             }
         }
@@ -120,10 +120,11 @@ void InputEditor::DrawControllerSchema() {
     auto backend = Ship::Window::GetInstance()->GetControlDeck()->GetPhysicalDeviceFromVirtualSlot(mCurrentPort);
     auto profile = backend->getProfile(mCurrentPort);
     bool isKeyboard = backend->GetGuid() == "Keyboard" || backend->GetGuid() == "Auto" || !backend->Connected();
+    uint32_t panelWidth = 150;
 
     DrawControllerSelect(mCurrentPort);
 
-    SohImGui::BeginGroupPanel("Buttons", ImVec2(150, 20));
+    SohImGui::BeginGroupPanel("Buttons", ImVec2(panelWidth, 20));
     DrawButton("A", BTN_A, mCurrentPort, &mBtnReading);
     DrawButton("B", BTN_B, mCurrentPort, &mBtnReading);
     DrawButton("L", BTN_L, mCurrentPort, &mBtnReading);
@@ -137,7 +138,7 @@ void InputEditor::DrawControllerSchema() {
     SohImGui::EndGroupPanel(isKeyboard ? 7.0f : 48.0f);
 #endif
     ImGui::SameLine();
-    SohImGui::BeginGroupPanel("Digital Pad", ImVec2(150, 20));
+    SohImGui::BeginGroupPanel("Digital Pad", ImVec2(panelWidth, 20));
     DrawButton("Up", BTN_DUP, mCurrentPort, &mBtnReading);
     DrawButton("Down", BTN_DDOWN, mCurrentPort, &mBtnReading);
     DrawButton("Left", BTN_DLEFT, mCurrentPort, &mBtnReading);
@@ -149,7 +150,7 @@ void InputEditor::DrawControllerSchema() {
     SohImGui::EndGroupPanel(isKeyboard ? 53.0f : 94.0f);
 #endif
     ImGui::SameLine();
-    SohImGui::BeginGroupPanel("Analog Stick", ImVec2(150, 20));
+    SohImGui::BeginGroupPanel("Analog Stick", ImVec2(panelWidth, 20));
     DrawButton("Up", BTN_STICKUP, mCurrentPort, &mBtnReading);
     DrawButton("Down", BTN_STICKDOWN, mCurrentPort, &mBtnReading);
     DrawButton("Left", BTN_STICKLEFT, mCurrentPort, &mBtnReading);
@@ -169,7 +170,7 @@ void InputEditor::DrawControllerSchema() {
         ImGui::BeginChild("##MSInput", ImVec2(90, 50), false);
 #endif
         ImGui::Text("Deadzone");
-#ifdef __WIIU__
+#if __WIIU__ || __SWITCH__
         ImGui::PushItemWidth(80 * 2);
 #else
         ImGui::PushItemWidth(80);
@@ -178,7 +179,11 @@ void InputEditor::DrawControllerSchema() {
         // set the deadzone for both left stick axes here
         // SDL_CONTROLLER_AXIS_LEFTX: 0
         // SDL_CONTROLLER_AXIS_LEFTY: 1
-        ImGui::InputFloat("##MDZone", &profile->AxisDeadzones[0], 1.0f, 0.0f, "%.0f");
+        ImGui::InputFloat("##MDZone", &profile->AxisDeadzones[0], 1.0f, 0.0f, "%.0f"
+#ifdef __SWITCH__
+            , ImGuiInputTextFlags_NoPlusMinusButtons
+#endif
+        );
         profile->AxisDeadzones[1] = profile->AxisDeadzones[0];
         ImGui::PopItemWidth();
         ImGui::EndChild();
@@ -214,7 +219,7 @@ void InputEditor::DrawControllerSchema() {
         ImGui::BeginChild("##CSInput", ImVec2(90, 85), false);
 #endif
         ImGui::Text("Deadzone");
-#ifdef __WIIU__
+#if __WIIU__ || __SWITCH__
         ImGui::PushItemWidth(80 * 2);
 #else
         ImGui::PushItemWidth(80);
@@ -223,7 +228,11 @@ void InputEditor::DrawControllerSchema() {
         // set the deadzone for both right stick axes here
         // SDL_CONTROLLER_AXIS_RIGHTX: 2
         // SDL_CONTROLLER_AXIS_RIGHTY: 3
-        ImGui::InputFloat("##MDZone", &profile->AxisDeadzones[2], 1.0f, 0.0f, "%.0f");
+        ImGui::InputFloat("##MDZone", &profile->AxisDeadzones[2], 1.0f, 0.0f, "%.0f"
+#ifdef __SWITCH__
+            , ImGuiInputTextFlags_NoPlusMinusButtons
+#endif
+        );
         profile->AxisDeadzones[3] = profile->AxisDeadzones[2];
         ImGui::PopItemWidth();
         ImGui::EndChild();
@@ -270,20 +279,28 @@ void InputEditor::DrawControllerSchema() {
         ImGui::BeginChild("##GyInput", ImVec2(90, 85), false);
 #endif
         ImGui::Text("Drift X");
-#ifdef __WIIU__
+#if __WIIU__ || __SWITCH__
         ImGui::PushItemWidth(80 * 2);
 #else
         ImGui::PushItemWidth(80);
 #endif
-        ImGui::InputFloat("##GDriftX", &profile->GyroData[DRIFT_X], 1.0f, 0.0f, "%.1f");
+        ImGui::InputFloat("##GDriftX", &profile->GyroData[DRIFT_X], 1.0f, 0.0f, "%.1f"
+#ifdef __SWITCH__
+            , ImGuiInputTextFlags_NoPlusMinusButtons
+#endif
+        );
         ImGui::PopItemWidth();
         ImGui::Text("Drift Y");
-#ifdef __WIIU__
+#if __WIIU__ || __SWITCH__
         ImGui::PushItemWidth(80 * 2);
 #else
         ImGui::PushItemWidth(80);
 #endif
-        ImGui::InputFloat("##GDriftY", &profile->GyroData[DRIFT_Y], 1.0f, 0.0f, "%.1f");
+        ImGui::InputFloat("##GDriftY", &profile->GyroData[DRIFT_Y], 1.0f, 0.0f, "%.1f"
+#ifdef __SWITCH__
+            , ImGuiInputTextFlags_NoPlusMinusButtons
+#endif
+        );
         ImGui::PopItemWidth();
         ImGui::EndChild();
 #ifdef __SWITCH__

--- a/src/menu/InputEditor.cpp
+++ b/src/menu/InputEditor.cpp
@@ -75,7 +75,8 @@ void InputEditor::DrawControllerSelect(int32_t currentPort) {
             if (deviceName != "Keyboard" && deviceName != "Auto") {
                 deviceName += "##" + std::to_string(i);
             }
-            if (ImGui::Selectable(deviceName.c_str(), i == controlDeck->GetVirtualDevice(currentPort), ImGuiSelectableFlags_SpanAvailWidth)) {
+            if (ImGui::Selectable(deviceName.c_str(), i == controlDeck->GetVirtualDevice(currentPort),
+                                  ImGuiSelectableFlags_SpanAvailWidth)) {
                 controlDeck->SetPhysicalDevice(currentPort, i);
             }
         }
@@ -181,7 +182,8 @@ void InputEditor::DrawControllerSchema() {
         // SDL_CONTROLLER_AXIS_LEFTY: 1
         ImGui::InputFloat("##MDZone", &profile->AxisDeadzones[0], 1.0f, 0.0f, "%.0f"
 #ifdef __SWITCH__
-            , ImGuiInputTextFlags_NoPlusMinusButtons
+                          ,
+                          ImGuiInputTextFlags_NoPlusMinusButtons
 #endif
         );
         profile->AxisDeadzones[1] = profile->AxisDeadzones[0];
@@ -230,7 +232,8 @@ void InputEditor::DrawControllerSchema() {
         // SDL_CONTROLLER_AXIS_RIGHTY: 3
         ImGui::InputFloat("##MDZone", &profile->AxisDeadzones[2], 1.0f, 0.0f, "%.0f"
 #ifdef __SWITCH__
-            , ImGuiInputTextFlags_NoPlusMinusButtons
+                          ,
+                          ImGuiInputTextFlags_NoPlusMinusButtons
 #endif
         );
         profile->AxisDeadzones[3] = profile->AxisDeadzones[2];
@@ -286,7 +289,8 @@ void InputEditor::DrawControllerSchema() {
 #endif
         ImGui::InputFloat("##GDriftX", &profile->GyroData[DRIFT_X], 1.0f, 0.0f, "%.1f"
 #ifdef __SWITCH__
-            , ImGuiInputTextFlags_NoPlusMinusButtons
+                          ,
+                          ImGuiInputTextFlags_NoPlusMinusButtons
 #endif
         );
         ImGui::PopItemWidth();
@@ -298,7 +302,8 @@ void InputEditor::DrawControllerSchema() {
 #endif
         ImGui::InputFloat("##GDriftY", &profile->GyroData[DRIFT_Y], 1.0f, 0.0f, "%.1f"
 #ifdef __SWITCH__
-            , ImGuiInputTextFlags_NoPlusMinusButtons
+                          ,
+                          ImGuiInputTextFlags_NoPlusMinusButtons
 #endif
         );
         ImGui::PopItemWidth();

--- a/src/menu/InputEditor.cpp
+++ b/src/menu/InputEditor.cpp
@@ -75,7 +75,7 @@ void InputEditor::DrawControllerSelect(int32_t currentPort) {
 
     if (ImGui::BeginCombo("##ControllerEntries", controllerName.c_str())) {
         for (uint8_t i = 0; i < controlDeck->GetNumPhysicalDevices(); i++) {
-            if(!controlDeck->GetPhysicalDevice(i)->Connected()) {
+            if (!controlDeck->GetPhysicalDevice(i)->Connected()) {
                 continue;
             }
             std::string deviceName = controlDeck->GetPhysicalDevice(i)->GetControllerName();

--- a/src/port/switch/SwitchController.cpp
+++ b/src/port/switch/SwitchController.cpp
@@ -213,22 +213,21 @@ void SwitchController::ReadFromSource(int32_t virtualSlot) {
 }
 
 void SwitchController::WriteToSource(int32_t virtualSlot, ControllerCallback* controller) {
-    if (getProfile(virtualSlot)->UseRumble) {
-        PadState* state = &mController->State;
-        float rumbleStrength = getProfile(virtualSlot)->RumbleStrength;
-        HidVibrationValue vibrationValues[2];
+    bool useRumble = getProfile(virtualSlot)->UseRumble;
+    float rumbleStrength = getProfile(virtualSlot)->RumbleStrength;
+    PadState* state = &mController->State;
+    HidVibrationValue vibrationValues[2];
 
-        for (int i = 0; i < 2; i++) {
-            float amp = controller->rumble > 0 ? rumbleStrength : 0.0f;
-            vibrationValues[i].amp_low = amp;
-            vibrationValues[i].amp_high = amp;
-            vibrationValues[i].freq_low = 160.0f;
-            vibrationValues[i].freq_high = 320.0f;
-        }
-
-        hidSendVibrationValues(mController->Handles[padIsHandheld(state) ? 0 : 1], vibrationValues, 2);
-        padUpdate(state);
+    for (int i = 0; i < 2; i++) {
+        float amp = controller->rumble > 0 && useRumble ? rumbleStrength : 0.0f;
+        vibrationValues[i].amp_low = amp;
+        vibrationValues[i].amp_high = amp;
+        vibrationValues[i].freq_low = 160.0f;
+        vibrationValues[i].freq_high = 320.0f;
     }
+
+    hidSendVibrationValues(mController->Handles[padIsHandheld(state) ? 0 : 1], vibrationValues, 2);
+    padUpdate(state);
 }
 
 int32_t SwitchController::ReadRawPress() {

--- a/src/port/switch/SwitchController.cpp
+++ b/src/port/switch/SwitchController.cpp
@@ -6,6 +6,8 @@
 #include <spdlog/spdlog.h>
 #include <Utils/StringHelper.h>
 
+#define CONTROLLER_MASK 1UL
+
 namespace Ship {
 
 SwitchController::SwitchController(int32_t physicalSlot) : Controller(), mPhysicalSlot(physicalSlot) {
@@ -15,7 +17,7 @@ SwitchController::SwitchController(int32_t physicalSlot) : Controller(), mPhysic
 
 bool SwitchController::Open() {
     mConnected = true;
-    padInitializeDefault(&mController->State);
+    padInitializeWithMask(&mController->State, CONTROLLER_MASK << mPhysicalSlot);
 
     // Initialize vibration devices
 
@@ -283,7 +285,7 @@ const std::string SwitchController::GetButtonName(int32_t virtualSlot, int n64Bu
 }
 
 const std::string SwitchController::GetControllerName() {
-    return "Switch Controller #" + std::to_string(mPhysicalSlot) + " (" + GetControllerExtensionName() + ")";
+    return "Switch Controller #" + std::to_string(mPhysicalSlot + 1) + " (" + GetControllerExtensionName() + ")";
 }
 
 void SwitchController::CreateDefaultBinding(int32_t virtualSlot) {
@@ -343,6 +345,7 @@ void SwitchController::UpdateSixAxisSensor(HidSixAxisSensorState& state) {
 }
 
 std::string SwitchController::GetControllerExtensionName() {
+    padUpdate(&mController->State);
     u32 tagStyle = padGetStyleSet(&mController->State);
 
     if (tagStyle & HidNpadStyleTag_NpadFullKey) {

--- a/src/port/switch/SwitchController.cpp
+++ b/src/port/switch/SwitchController.cpp
@@ -7,7 +7,7 @@
 
 extern "C" uint8_t __osMaxControllers;
 
-namespace Ship{
+namespace Ship {
 
 SwitchController::SwitchController(int32_t physicalSlot) : Controller(), mPhysicalSlot(physicalSlot) {
     connected = false;
@@ -27,8 +27,8 @@ bool SwitchController::Open() {
     // Initialize six axis sensors
 
     hidGetSixAxisSensorHandles(&mController->sensors[0], 1, HidNpadIdType_Handheld, HidNpadStyleTag_NpadHandheld);
-    hidGetSixAxisSensorHandles(&mController->sensors[1], 1, HidNpadIdType_No1,      HidNpadStyleTag_NpadFullKey);
-    hidGetSixAxisSensorHandles(&mController->sensors[2], 2, HidNpadIdType_No1,      HidNpadStyleTag_NpadJoyDual);
+    hidGetSixAxisSensorHandles(&mController->sensors[1], 1, HidNpadIdType_No1, HidNpadStyleTag_NpadFullKey);
+    hidGetSixAxisSensorHandles(&mController->sensors[2], 2, HidNpadIdType_No1, HidNpadStyleTag_NpadJoyDual);
 
     for (int i = 0; i < 4; i++) {
         hidStartSixAxisSensor(mController->sensors[i]);
@@ -53,7 +53,8 @@ void SwitchController::Close() {
     }
 }
 
-void SwitchController::NormalizeStickAxis(int32_t virtualSlot, float x, float y, int16_t axisThreshold, bool isRightStick) {
+void SwitchController::NormalizeStickAxis(int32_t virtualSlot, float x, float y, int16_t axisThreshold,
+                                          bool isRightStick) {
     auto profile = getProfile(virtualSlot);
 
     auto ax = x * 85.0f / 32767.0f;
@@ -113,7 +114,8 @@ void SwitchController::ReadFromSource(int32_t virtualSlot) {
     int16_t camY = 0;
     for (uint32_t id = 0; id < 35; id++) {
         uint32_t btn = BIT(id);
-        if (!profile->Mappings.contains(btn)) continue;
+        if (!profile->Mappings.contains(btn))
+            continue;
 
         const auto pBtn = profile->Mappings[btn];
 
@@ -154,8 +156,8 @@ void SwitchController::ReadFromSource(int32_t virtualSlot) {
         NormalizeStickAxis(virtualSlot, camX, camY, profile->AxisDeadzones[2], true);
     }
 
-    if(profile->UseGyro){
-        HidSixAxisSensorState sixaxis = {0};
+    if (profile->UseGyro) {
+        HidSixAxisSensorState sixaxis = { 0 };
         UpdateSixAxisSensor(sixaxis);
 
         float gyroX = sixaxis.angular_velocity.x * -8.0f;
@@ -389,4 +391,4 @@ std::string SwitchController::GetControllerExtensionName() {
 
     return "Dual Joy-Con";
 }
-}
+} // namespace Ship

--- a/src/port/switch/SwitchController.cpp
+++ b/src/port/switch/SwitchController.cpp
@@ -9,13 +9,12 @@
 namespace Ship {
 
 SwitchController::SwitchController(int32_t physicalSlot) : Controller(), mPhysicalSlot(physicalSlot) {
+    mController = new NXControllerState();
     mConnected = false;
-    mControllerName = "Switch Controller #" + std::to_string(mPhysicalSlot) + " (Disconnected)";
 }
 
 bool SwitchController::Open() {
     mConnected = true;
-    mController = new NXControllerState();
     padInitializeDefault(&mController->State);
 
     // Initialize vibration devices
@@ -34,7 +33,6 @@ bool SwitchController::Open() {
     }
 
     mGuid = StringHelper::Sprintf("NXInternal:%d", mPhysicalSlot);
-    mControllerName = "Switch Controller #" + std::to_string(mPhysicalSlot) + " (" + GetControllerExtensionName() + ")";
     return true;
 }
 
@@ -285,7 +283,7 @@ const std::string SwitchController::GetButtonName(int32_t virtualSlot, int n64Bu
 }
 
 const std::string SwitchController::GetControllerName() {
-    return mControllerName;
+    return "Switch Controller #" + std::to_string(mPhysicalSlot) + " (" + GetControllerExtensionName() + ")";
 }
 
 void SwitchController::CreateDefaultBinding(int32_t virtualSlot) {
@@ -363,7 +361,11 @@ std::string SwitchController::GetControllerExtensionName() {
         return "Right Joy-Con";
     }
 
-    return "Dual Joy-Con";
+    if (tagStyle & HidNpadStyleTag_NpadJoyDual) {
+        return "Dual Joy-Con";
+    }
+
+    return "Disconnected";
 }
 } // namespace Ship
 #endif

--- a/src/port/switch/SwitchController.cpp
+++ b/src/port/switch/SwitchController.cpp
@@ -40,7 +40,7 @@ bool SwitchController::Open() {
         hidStartSixAxisSensor(mController->Sensors[i]);
     }
 
-    mGuid = StringHelper::Sprintf("NXInternal:%d", mPhysicalSlot);
+    mGuid = std::string(Switch::GetControllerUUID(mPhysicalSlot));
     mConnected = padIsConnected(&mController->State);
     return true;
 }
@@ -168,7 +168,7 @@ void SwitchController::ReadFromSource(int32_t virtualSlot) {
         UpdateSixAxisSensor(sixaxis);
 
         float gyroX = sixaxis.angular_velocity.x * -8.0f;
-        float gyroY = sixaxis.angular_velocity.y * 8.0f;
+        float gyroY = sixaxis.angular_velocity.z * 8.0f;
 
         float gyroDriftX = profile->GyroData[DRIFT_X] / 100.0f;
         float gyroDriftY = profile->GyroData[DRIFT_Y] / 100.0f;
@@ -215,7 +215,7 @@ void SwitchController::WriteToSource(int32_t virtualSlot, ControllerCallback* co
 int32_t SwitchController::ReadRawPress() {
     PadState* state = &mController->State;
     padUpdate(state);
-    u64 kDown = padGetButtonsDown(state);
+    u64 kDown = padGetButtons(state);
     for (uint32_t i = 0; i < 35; i++) {
         if (kDown & BIT(i)) {
             return BIT(i);

--- a/src/port/switch/SwitchController.cpp
+++ b/src/port/switch/SwitchController.cpp
@@ -16,9 +16,8 @@ SwitchController::SwitchController(int32_t physicalSlot) : Controller(), mPhysic
 }
 
 bool SwitchController::Open() {
-    mConnected = true;
     padInitializeWithMask(&mController->State, CONTROLLER_MASK << mPhysicalSlot);
-
+    padUpdate(&mController->State);
     // Initialize vibration devices
 
     hidInitializeVibrationDevices(mController->Handles[1], 2, HidNpadIdType_No1, HidNpadStyleTag_NpadJoyDual);
@@ -35,6 +34,7 @@ bool SwitchController::Open() {
     }
 
     mGuid = StringHelper::Sprintf("NXInternal:%d", mPhysicalSlot);
+    mConnected = padIsConnected(&mController->State);
     return true;
 }
 

--- a/src/port/switch/SwitchController.cpp
+++ b/src/port/switch/SwitchController.cpp
@@ -1,3 +1,4 @@
+#ifdef __SWITCH__
 #include "SwitchController.h"
 #include "core/Window.h"
 #include "menu/ImGuiImpl.h"
@@ -365,3 +366,4 @@ std::string SwitchController::GetControllerExtensionName() {
     return "Dual Joy-Con";
 }
 } // namespace Ship
+#endif

--- a/src/port/switch/SwitchController.cpp
+++ b/src/port/switch/SwitchController.cpp
@@ -16,7 +16,14 @@ SwitchController::SwitchController(int32_t physicalSlot) : Controller(), mPhysic
 }
 
 bool SwitchController::Open() {
-    padInitializeWithMask(&mController->State, CONTROLLER_MASK << mPhysicalSlot);
+    u64 mPadMask = CONTROLLER_MASK << mPhysicalSlot;
+
+    // Add handheld controller if it's the first controller
+    if (mPhysicalSlot == 0) {
+        mPadMask |= CONTROLLER_MASK << HidNpadIdType_Handheld;
+    }
+
+    padInitializeWithMask(&mController->State, mPadMask);
     padUpdate(&mController->State);
     // Initialize vibration devices
 
@@ -161,7 +168,7 @@ void SwitchController::ReadFromSource(int32_t virtualSlot) {
         UpdateSixAxisSensor(sixaxis);
 
         float gyroX = sixaxis.angular_velocity.x * -8.0f;
-        float gyroY = sixaxis.angular_velocity.y * -8.0f;
+        float gyroY = sixaxis.angular_velocity.y * 8.0f;
 
         float gyroDriftX = profile->GyroData[DRIFT_X] / 100.0f;
         float gyroDriftY = profile->GyroData[DRIFT_Y] / 100.0f;

--- a/src/port/switch/SwitchController.cpp
+++ b/src/port/switch/SwitchController.cpp
@@ -219,7 +219,7 @@ void SwitchController::WriteToSource(int32_t virtualSlot, ControllerCallback* co
         HidVibrationValue vibrationValues[2];
 
         for (int i = 0; i < 2; i++) {
-            float amp = controller->rumble > 0 ? 0xFFFF * rumbleStrength : 0.0f;
+            float amp = controller->rumble > 0 ? rumbleStrength : 0.0f;
             vibrationValues[i].amp_low = amp;
             vibrationValues[i].amp_high = amp;
             vibrationValues[i].freq_low = 160.0f;

--- a/src/port/switch/SwitchController.cpp
+++ b/src/port/switch/SwitchController.cpp
@@ -1,0 +1,392 @@
+#include "SwitchController.h"
+#include "core/Window.h"
+#include "menu/ImGuiImpl.h"
+#include "SwitchImpl.h"
+#include <spdlog/spdlog.h>
+#include <Utils/StringHelper.h>
+
+extern "C" uint8_t __osMaxControllers;
+
+namespace Ship{
+
+SwitchController::SwitchController(int32_t physicalSlot) : Controller(), mPhysicalSlot(physicalSlot) {
+    connected = false;
+    mControllerName = "Switch Controller #" + std::to_string(mPhysicalSlot) + " (Disconnected)";
+}
+
+bool SwitchController::Open() {
+    connected = true;
+    mController = new NXControllerState();
+    padInitializeDefault(&mController->state);
+
+    // Initialize vibration devices
+
+    hidInitializeVibrationDevices(mController->handles[1], 2, HidNpadIdType_No1, HidNpadStyleTag_NpadJoyDual);
+    hidInitializeVibrationDevices(mController->handles[0], 2, HidNpadIdType_Handheld, HidNpadStyleTag_NpadHandheld);
+
+    // Initialize six axis sensors
+
+    hidGetSixAxisSensorHandles(&mController->sensors[0], 1, HidNpadIdType_Handheld, HidNpadStyleTag_NpadHandheld);
+    hidGetSixAxisSensorHandles(&mController->sensors[1], 1, HidNpadIdType_No1,      HidNpadStyleTag_NpadFullKey);
+    hidGetSixAxisSensorHandles(&mController->sensors[2], 2, HidNpadIdType_No1,      HidNpadStyleTag_NpadJoyDual);
+
+    for (int i = 0; i < 4; i++) {
+        hidStartSixAxisSensor(mController->sensors[i]);
+    }
+
+    mGuid = StringHelper::Sprintf("NXInternal:%d", mPhysicalSlot);
+    mControllerName = "Switch Controller #" + std::to_string(mPhysicalSlot) + " (" + GetControllerExtensionName() + ")";
+    return true;
+}
+
+void SwitchController::Close() {
+    connected = false;
+
+    for (int i = 0; i < MAXCONTROLLERS; i++) {
+        getPressedButtons(i) = 0;
+        getLeftStickX(i) = 0;
+        getLeftStickY(i) = 0;
+        getRightStickX(i) = 0;
+        getRightStickY(i) = 0;
+        getGyroX(i) = 0;
+        getGyroY(i) = 0;
+    }
+}
+
+void SwitchController::NormalizeStickAxis(int32_t virtualSlot, float x, float y, int16_t axisThreshold, bool isRightStick) {
+    auto profile = getProfile(virtualSlot);
+
+    auto ax = x * 85.0f / 32767.0f;
+    auto ay = y * 85.0f / 32767.0f;
+
+    // create scaled circular dead-zone in range {-15 ... +15}
+    auto len = sqrt(ax * ax + ay * ay);
+    if (len < axisThreshold) {
+        len = 0.0f;
+    } else if (len > 85.0) {
+        len = 85.0f / len;
+    } else {
+        len = (len - axisThreshold) * 85.0f / (85.0f - axisThreshold) / len;
+    }
+    ax *= len;
+    ay *= len;
+
+    // bound diagonals to an octagonal range {-68 ... +68}
+    if (ax != 0.0f && ay != 0.0f) {
+        auto slope = ay / ax;
+        auto edgex = copysign(85.0f / (abs(slope) + 16.0f / 69.0f), ax);
+        auto edgey = copysign(std::min(abs(edgex * slope), 85.0f / (1.0f / abs(slope) + 16.0f / 69.0f)), ay);
+        edgex = edgey / slope;
+
+        auto scale = sqrt(edgex * edgex + edgey * edgey) / 85.0f;
+        ax *= scale;
+        ay *= scale;
+    }
+
+    if (isRightStick) {
+        getRightStickX(virtualSlot) = +ax;
+        getRightStickY(virtualSlot) = ay;
+    } else {
+        getLeftStickX(virtualSlot) = +ax;
+        getLeftStickY(virtualSlot) = ay;
+    }
+}
+
+void SwitchController::ReadFromSource(int32_t virtualSlot) {
+    auto profile = getProfile(virtualSlot);
+    PadState* state = &mController->state;
+    padUpdate(state);
+
+    const auto pressedBtns = padGetButtons(state);
+
+    getPressedButtons(virtualSlot) = 0;
+    getLeftStickX(virtualSlot) = 0;
+    getLeftStickY(virtualSlot) = 0;
+    getRightStickX(virtualSlot) = 0;
+    getRightStickY(virtualSlot) = 0;
+    getGyroX(virtualSlot) = 0;
+    getGyroY(virtualSlot) = 0;
+
+    int16_t stickX = 0;
+    int16_t stickY = 0;
+    int16_t camX = 0;
+    int16_t camY = 0;
+    for (uint32_t id = 0; id < 35; id++) {
+        uint32_t btn = BIT(id);
+        if (!profile->Mappings.contains(btn)) continue;
+
+        const auto pBtn = profile->Mappings[btn];
+
+        if (btn >= HidNpadButton_StickLLeft) {
+
+            HidAnalogStickState LStick = padGetStickPos(state, 0);
+            HidAnalogStickState RStick = padGetStickPos(state, 1);
+            float axisX = btn >= HidNpadButton_StickRLeft ? RStick.x : LStick.x;
+            float axisY = btn >= HidNpadButton_StickRLeft ? RStick.y : LStick.y;
+
+            if (pBtn == BTN_STICKRIGHT || pBtn == BTN_STICKLEFT) {
+                stickX = axisX;
+                continue;
+            } else if (pBtn == BTN_STICKDOWN || pBtn == BTN_STICKUP) {
+                stickY = axisY;
+                continue;
+            } else if (pBtn == BTN_VSTICKRIGHT || pBtn == BTN_VSTICKLEFT) {
+                camX = axisX;
+                continue;
+            } else if (pBtn == BTN_VSTICKDOWN || pBtn == BTN_VSTICKUP) {
+                camY = axisY;
+                continue;
+            }
+        }
+
+        if (pressedBtns & btn) {
+            getPressedButtons(virtualSlot) |= pBtn;
+        } else {
+            getPressedButtons(virtualSlot) &= ~pBtn;
+        }
+    }
+
+    if (stickX || stickY) {
+        NormalizeStickAxis(virtualSlot, stickX, stickY, profile->AxisDeadzones[0], false);
+    }
+
+    if (camX || camY) {
+        NormalizeStickAxis(virtualSlot, camX, camY, profile->AxisDeadzones[2], true);
+    }
+
+    if(profile->UseGyro){
+        HidSixAxisSensorState sixaxis = {0};
+        UpdateSixAxisSensor(sixaxis);
+
+        float gyroX = sixaxis.angular_velocity.x * -8.0f;
+        float gyroY = sixaxis.angular_velocity.y * -8.0f;
+
+        float gyro_drift_x = profile->GyroData[DRIFT_X] / 100.0f;
+        float gyro_drift_y = profile->GyroData[DRIFT_Y] / 100.0f;
+        const float gyro_sensitivity = profile->GyroData[GYRO_SENSITIVITY];
+
+        if (gyro_drift_x == 0) {
+            gyro_drift_x = gyroX;
+        }
+
+        if (gyro_drift_y == 0) {
+            gyro_drift_y = gyroY;
+        }
+
+        profile->GyroData[DRIFT_X] = gyro_drift_x * 100.0f;
+        profile->GyroData[DRIFT_Y] = gyro_drift_y * 100.0f;
+
+        getGyroX(virtualSlot) = gyroX - gyro_drift_x;
+        getGyroY(virtualSlot) = gyroY - gyro_drift_y;
+
+        getGyroX(virtualSlot) *= gyro_sensitivity;
+        getGyroY(virtualSlot) *= gyro_sensitivity;
+    }
+}
+
+void SwitchController::WriteToSource(int32_t virtualSlot, ControllerCallback* controller) {
+    if (getProfile(virtualSlot)->UseRumble) {
+        PadState* state = &mController->state;
+        float rumble_strength = getProfile(virtualSlot)->RumbleStrength;
+        HidVibrationValue VibrationValues[2];
+
+        for (int i = 0; i < 2; i++) {
+            float amp = controller->rumble > 0 ? 0xFFFF * rumble_strength : 0.0f;
+            VibrationValues[i].amp_low = amp;
+            VibrationValues[i].amp_high = amp;
+            VibrationValues[i].freq_low = 160.0f;
+            VibrationValues[i].freq_high = 320.0f;
+        }
+
+        hidSendVibrationValues(mController->handles[padIsHandheld(state) ? 0 : 1], VibrationValues, 2);
+        padUpdate(state);
+    }
+}
+
+int32_t SwitchController::ReadRawPress() {
+    PadState* state = &mController->state;
+    padUpdate(state);
+    u64 kDown = padGetButtonsDown(state);
+    HidAnalogStickState LStick = padGetStickPos(state, 0);
+    HidAnalogStickState RStick = padGetStickPos(state, 1);
+    for (uint32_t i = 0; i < 35; i++) {
+        if (kDown & BIT(i)) {
+            return BIT(i);
+        }
+    }
+
+    if (LStick.x > 0.7f) {
+        return HidNpadButton_StickLRight;
+    }
+    if (LStick.x < -0.7f) {
+        return HidNpadButton_StickLLeft;
+    }
+    if (LStick.y > 0.7f) {
+        return HidNpadButton_StickLUp;
+    }
+    if (LStick.y < -0.7f) {
+        return HidNpadButton_StickLDown;
+    }
+
+    if (RStick.x > 0.7f) {
+        return HidNpadButton_StickRRight;
+    }
+    if (RStick.x < -0.7f) {
+        return HidNpadButton_StickRLeft;
+    }
+    if (RStick.y > 0.7f) {
+        return HidNpadButton_StickRUp;
+    }
+    if (RStick.y < -0.7f) {
+        return HidNpadButton_StickRDown;
+    }
+
+    return -1;
+}
+
+const std::string SwitchController::GetButtonName(int32_t virtualSlot, int n64Button) {
+    std::map<int32_t, int32_t>& Mappings = getProfile(virtualSlot)->Mappings;
+    const auto find =
+        std::find_if(Mappings.begin(), Mappings.end(),
+                     [n64Button](const std::pair<int32_t, int32_t>& pair) { return pair.second == n64Button; });
+
+    if (find == Mappings.end())
+        return "Unknown";
+
+    uint32_t btn = find->first;
+
+    switch (btn) {
+        case HidNpadButton_A:
+            return "A";
+        case HidNpadButton_B:
+            return "B";
+        case HidNpadButton_X:
+            return "X";
+        case HidNpadButton_Y:
+            return "Y";
+        case HidNpadButton_Left:
+            return "D-pad Left";
+        case HidNpadButton_Right:
+            return "D-pad Right";
+        case HidNpadButton_Up:
+            return "D-pad Up";
+        case HidNpadButton_Down:
+            return "D-pad Down";
+        case HidNpadButton_ZL:
+            return "ZL";
+        case HidNpadButton_ZR:
+            return "ZR";
+        case HidNpadButton_L:
+            return "L";
+        case HidNpadButton_R:
+            return "R";
+        case HidNpadButton_Plus:
+            return "+ (START)";
+        case HidNpadButton_Minus:
+            return "- (SELECT)";
+        case HidNpadButton_StickR:
+            return "Stick Button R";
+        case HidNpadButton_StickL:
+            return "Stick Button L";
+        case HidNpadButton_StickRLeft:
+            return "Right Stick Left";
+        case HidNpadButton_StickRRight:
+            return "Right Stick Right";
+        case HidNpadButton_StickRUp:
+            return "Right Stick Up";
+        case HidNpadButton_StickRDown:
+            return "Right Stick Down";
+        case HidNpadButton_StickLLeft:
+            return "Left Stick Left";
+        case HidNpadButton_StickLRight:
+            return "Left Stick Right";
+        case HidNpadButton_StickLUp:
+            return "Left Stick Up";
+        case HidNpadButton_StickLDown:
+            return "Left Stick Down";
+    }
+
+    return "Unknown";
+}
+
+const std::string SwitchController::GetControllerName() {
+    return mControllerName;
+}
+
+void SwitchController::CreateDefaultBinding(int32_t virtualSlot) {
+    auto profile = getProfile(virtualSlot);
+    profile->Mappings.clear();
+    profile->AxisDeadzones.clear();
+    profile->AxisMinimumPress.clear();
+    profile->GyroData.clear();
+
+    profile->Version = DEVICE_PROFILE_CURRENT_VERSION;
+    profile->UseRumble = true;
+    profile->RumbleStrength = 1.0f;
+    profile->UseGyro = false;
+    profile->Mappings[HidNpadButton_StickRRight] = BTN_CRIGHT;
+    profile->Mappings[HidNpadButton_StickRLeft] = BTN_CLEFT;
+    profile->Mappings[HidNpadButton_StickRDown] = BTN_CDOWN;
+    profile->Mappings[HidNpadButton_StickRUp] = BTN_CUP;
+    profile->Mappings[HidNpadButton_ZR] = BTN_R;
+    profile->Mappings[HidNpadButton_L] = BTN_L;
+    profile->Mappings[HidNpadButton_Right] = BTN_DRIGHT;
+    profile->Mappings[HidNpadButton_Left] = BTN_DLEFT;
+    profile->Mappings[HidNpadButton_Down] = BTN_DDOWN;
+    profile->Mappings[HidNpadButton_Up] = BTN_DUP;
+    profile->Mappings[HidNpadButton_Plus] = BTN_START;
+    profile->Mappings[HidNpadButton_ZL] = BTN_Z;
+    profile->Mappings[HidNpadButton_B] = BTN_B;
+    profile->Mappings[HidNpadButton_A] = BTN_A;
+    profile->Mappings[HidNpadButton_StickLRight] = BTN_STICKRIGHT;
+    profile->Mappings[HidNpadButton_StickLLeft] = BTN_STICKLEFT;
+    profile->Mappings[HidNpadButton_StickLDown] = BTN_STICKDOWN;
+    profile->Mappings[HidNpadButton_StickLUp] = BTN_STICKUP;
+
+    for (int i = 0; i < 4; i++) {
+        profile->AxisDeadzones[i] = 16.0f;
+        profile->AxisMinimumPress[i] = 7680.0f;
+    }
+
+    profile->GyroData[DRIFT_X] = 0.0f;
+    profile->GyroData[DRIFT_Y] = 0.0f;
+    profile->GyroData[GYRO_SENSITIVITY] = 1.0f;
+}
+
+void SwitchController::UpdateSixAxisSensor(HidSixAxisSensorState& state) {
+    u64 style_set = padGetStyleSet(&mController->state);
+    if (style_set & HidNpadStyleTag_NpadHandheld)
+        hidGetSixAxisSensorStates(mController->sensors[0], &state, 1);
+    else if (style_set & HidNpadStyleTag_NpadFullKey)
+        hidGetSixAxisSensorStates(mController->sensors[1], &state, 1);
+    else if (style_set & HidNpadStyleTag_NpadJoyDual) {
+        u64 attrib = padGetAttributes(&mController->state);
+        if (attrib & HidNpadAttribute_IsLeftConnected)
+            hidGetSixAxisSensorStates(mController->sensors[2], &state, 1);
+        else if (attrib & HidNpadAttribute_IsRightConnected)
+            hidGetSixAxisSensorStates(mController->sensors[3], &state, 1);
+    }
+}
+
+std::string SwitchController::GetControllerExtensionName() {
+    u32 tagStyle = padGetStyleSet(&mController->state);
+
+    if (tagStyle & HidNpadStyleTag_NpadFullKey) {
+        return "Pro Controller";
+    }
+
+    if (tagStyle & HidNpadStyleTag_NpadHandheld) {
+        return "Nintendo Switch";
+    }
+
+    if (tagStyle & HidNpadStyleTag_NpadJoyLeft) {
+        return "Left Joy-Con";
+    }
+
+    if (tagStyle & HidNpadStyleTag_NpadJoyRight) {
+        return "Right Joy-Con";
+    }
+
+    return "Dual Joy-Con";
+}
+}

--- a/src/port/switch/SwitchController.h
+++ b/src/port/switch/SwitchController.h
@@ -1,4 +1,6 @@
+#ifdef __SWITCH__
 #pragma once
+
 #include "controller/Controller.h"
 #include <string>
 #include <switch.h>
@@ -6,9 +8,9 @@
 namespace Ship {
 
 struct NXControllerState {
-    PadState state;
-    HidVibrationDeviceHandle handles[2][2];
-    HidSixAxisSensorHandle sensors[4];
+    PadState State;
+    HidVibrationDeviceHandle Handles[2][2];
+    HidSixAxisSensorHandle Sensors[4];
 };
 
 class SwitchController : public Controller {
@@ -20,7 +22,7 @@ class SwitchController : public Controller {
     void ReadFromSource(int32_t virtualSlot) override;
     void WriteToSource(int32_t virtualSlot, ControllerCallback* controller) override;
     bool Connected() const override {
-        return connected;
+        return mConnected;
     };
     bool CanGyro() const override {
         return true;
@@ -37,7 +39,7 @@ class SwitchController : public Controller {
     const std::string GetControllerName() override;
 
   protected:
-    void NormalizeStickAxis(int32_t virtualSlot, float x, float y, int16_t threshold, bool isRightStick);
+    void NormalizeStickAxis(int32_t virtualSlot, float x, float y, int16_t axisThreshold, bool isRightStick);
     void CreateDefaultBinding(int32_t virtualSlot) override;
 
   private:
@@ -47,6 +49,7 @@ class SwitchController : public Controller {
     std::string mControllerName;
     int32_t mPhysicalSlot;
 
-    bool connected;
+    bool mConnected;
 };
 } // namespace Ship
+#endif

--- a/src/port/switch/SwitchController.h
+++ b/src/port/switch/SwitchController.h
@@ -22,7 +22,7 @@ class SwitchController : public Controller {
     void ReadFromSource(int32_t virtualSlot) override;
     void WriteToSource(int32_t virtualSlot, ControllerCallback* controller) override;
     bool Connected() const override {
-      return mConnected;
+        return mConnected;
     };
     bool CanGyro() const override {
         return true;

--- a/src/port/switch/SwitchController.h
+++ b/src/port/switch/SwitchController.h
@@ -46,7 +46,6 @@ class SwitchController : public Controller {
     NXControllerState* mController;
     std::string GetControllerExtensionName();
     void UpdateSixAxisSensor(HidSixAxisSensorState& state);
-    std::string mControllerName;
     int32_t mPhysicalSlot;
 
     bool mConnected;

--- a/src/port/switch/SwitchController.h
+++ b/src/port/switch/SwitchController.h
@@ -22,7 +22,7 @@ class SwitchController : public Controller {
     void ReadFromSource(int32_t virtualSlot) override;
     void WriteToSource(int32_t virtualSlot, ControllerCallback* controller) override;
     bool Connected() const override {
-        return mConnected;
+      return mConnected;
     };
     bool CanGyro() const override {
         return true;

--- a/src/port/switch/SwitchController.h
+++ b/src/port/switch/SwitchController.h
@@ -1,0 +1,51 @@
+#pragma once
+#include "controller/Controller.h"
+#include <string>
+#include <switch.h>
+
+namespace Ship {
+
+struct NXControllerState {
+  PadState state;
+  HidVibrationDeviceHandle handles[2][2];
+  HidSixAxisSensorHandle sensors[4];
+};
+
+class SwitchController : public Controller {
+  public:
+    SwitchController(int32_t physicalSlot);
+    bool Open();
+    void Close();
+
+    void ReadFromSource(int32_t virtualSlot) override;
+    void WriteToSource(int32_t virtualSlot, ControllerCallback* controller) override;
+    bool Connected() const override {
+      return connected;
+    };
+    bool CanGyro() const override {
+      return true;
+    }
+    bool CanRumble() const override {
+      return true;
+    };
+
+    void ClearRawPress() override {}
+    int32_t ReadRawPress() override;
+
+    const std::string GetButtonName(int32_t virtualSlot, int n64Button) override;
+    const std::string GetControllerName() override;
+
+  protected:
+    void NormalizeStickAxis(int32_t virtualSlot, float x, float y, int16_t threshold, bool isRightStick);
+    void CreateDefaultBinding(int32_t virtualSlot) override;
+
+  private:
+    NXControllerState* mController;
+    std::string GetControllerExtensionName();
+    void UpdateSixAxisSensor(HidSixAxisSensorState& state);
+    std::string mControllerName;
+    int32_t mPhysicalSlot;
+
+    bool connected;
+};
+} // namespace Ship

--- a/src/port/switch/SwitchController.h
+++ b/src/port/switch/SwitchController.h
@@ -6,9 +6,9 @@
 namespace Ship {
 
 struct NXControllerState {
-  PadState state;
-  HidVibrationDeviceHandle handles[2][2];
-  HidSixAxisSensorHandle sensors[4];
+    PadState state;
+    HidVibrationDeviceHandle handles[2][2];
+    HidSixAxisSensorHandle sensors[4];
 };
 
 class SwitchController : public Controller {
@@ -20,16 +20,17 @@ class SwitchController : public Controller {
     void ReadFromSource(int32_t virtualSlot) override;
     void WriteToSource(int32_t virtualSlot, ControllerCallback* controller) override;
     bool Connected() const override {
-      return connected;
+        return connected;
     };
     bool CanGyro() const override {
-      return true;
+        return true;
     }
     bool CanRumble() const override {
-      return true;
+        return true;
     };
 
-    void ClearRawPress() override {}
+    void ClearRawPress() override {
+    }
     int32_t ReadRawPress() override;
 
     const std::string GetButtonName(int32_t virtualSlot, int n64Button) override;

--- a/src/port/switch/SwitchImpl.cpp
+++ b/src/port/switch/SwitchImpl.cpp
@@ -37,6 +37,7 @@ void Ship::Switch::Init(SwitchPhase phase) {
             if (!hosversionBefore(8, 0, 0)) {
                 clkrstInitialize();
             }
+            padConfigureInput(8, HidNpadStyleSet_NpadStandard);
             break;
     }
 }

--- a/src/port/switch/SwitchImpl.h
+++ b/src/port/switch/SwitchImpl.h
@@ -21,5 +21,6 @@ class Switch {
     static void ApplyOverclock();
     static void ThrowMissingOTR(std::string OTRPath);
     static void PrintErrorMessageToScreen(const char* str, ...);
+    static char* GetControllerUUID(int controller);
 };
 }; // namespace Ship


### PR DESCRIPTION
This PR Includes a whole new backend for the nintendo switch controllers made for lus that supports gyro, rumble and fixes some ui bugs.

Shipwright PR: [#2270](https://github.com/HarbourMasters/Shipwright/pull/2270)