### PR TITLE
Fixes error in MatrixFactory that was causing deadlocks.

### DIFF
--- a/src/resource/factory/MatrixFactory.cpp
+++ b/src/resource/factory/MatrixFactory.cpp
@@ -9,7 +9,7 @@ std::shared_ptr<Resource> MatrixFactory::ReadResource(uint32_t version, std::sha
 
     switch (version) {
         case 0:
-            factory = std::shared_ptr<MatrixFactoryV0>();
+            factory = std::make_shared<MatrixFactoryV0>();
             break;
     }
 


### PR DESCRIPTION
`MatrixFactory.cpp` was creating a new empty shared pointer instead of constructing a new `MatrixFactoryV0` and returning a shared pointer to it. This resulted in a deadlock when equipping a Deku Shield to Link while he didn't already have a sword equipped.

This PR fixes the deadlock, but the fact that there was a deadlock here rather than a crash probably warrants some investigation. Crashing in this kind of scenario seems preferable to me, it would be much easier to debug a crash while attempting to load a resource than a deadlock in the ResourceLoader.