### PR TITLE
Add toggle fullscreen and quit buttons to main menu

### DIFF
--- a/src/menu/ImGuiImpl.cpp
+++ b/src/menu/ImGuiImpl.cpp
@@ -563,6 +563,10 @@ void DrawMainMenuAndCalculateGameSize(void) {
 
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, windowPadding);
         if (ImGui::BeginMenu("Shipwright")) {
+            const char* keyboardShortcut = SohImGui::GetCurrentRenderingBackend().first == "sdl" ? "F10" : "ALT+Enter";
+            if (ImGui::MenuItem("Toggle Fullscreen", keyboardShortcut)) {
+                Window::GetInstance()->ToggleFullscreen();
+            }
             if (ImGui::MenuItem("Reset",
 #if __APPLE__
                                 "Command-R"
@@ -571,6 +575,15 @@ void DrawMainMenuAndCalculateGameSize(void) {
 #endif
                                 )) {
                 console->Dispatch("reset");
+            }
+            if (ImGui::MenuItem("Quit",
+#if __APPLE__
+                                "Command-Q"
+#else
+                                "Ctrl+Q"
+#endif
+                                )) {
+                console->Dispatch("quit");
             }
             ImGui::EndMenu();
         }


### PR DESCRIPTION
Currently SoH doesn't implement the `quit` command properly, causing a crash prompt to show when this is triggered, but this is an issue to be resolved on SoH side.