### PR TITLE
fix: restore switch specific changes to imgui

### DIFF
--- a/extern/ImGui/backends/imgui_impl_sdl2.cpp
+++ b/extern/ImGui/backends/imgui_impl_sdl2.cpp
@@ -73,6 +73,7 @@
 
 #include "imgui.h"
 #include "imgui_impl_sdl2.h"
+#include "imgui_internal.h"
 
 // SDL
 // (the multi-viewports feature requires SDL features supported from SDL 2.0.4+. SDL 2.0.5+ is highly recommended)

--- a/extern/ImGui/backends/imgui_impl_sdl2.cpp
+++ b/extern/ImGui/backends/imgui_impl_sdl2.cpp
@@ -634,8 +634,10 @@ static void ImGui_ImplSDL2_UpdateMouseCursor()
 static void ImGui_ImplSDL2_UpdateGamepads()
 {
     ImGuiIO& io = ImGui::GetIO();
+    #ifndef __SWITCH__ //todo - Figure out if this is also an issue on steam deck
     if ((io.ConfigFlags & ImGuiConfigFlags_NavEnableGamepad) == 0) // FIXME: Technically feeding gamepad shouldn't depend on this now that they are regular inputs.
         return;
+    #endif
 
     // Get gamepad
     io.BackendFlags &= ~ImGuiBackendFlags_HasGamepad;

--- a/extern/ImGui/backends/imgui_impl_sdl2.cpp
+++ b/extern/ImGui/backends/imgui_impl_sdl2.cpp
@@ -113,6 +113,10 @@ struct ImGui_ImplSDL2_Data
     bool            MouseCanReportHoveredViewport;  // This is hard to use/unreliable on SDL so we'll set ImGuiBackendFlags_HasMouseHoveredViewport dynamically based on state.
     bool            UseVulkan;
 
+    #ifdef __SWITCH__
+    bool            ShowingVirtualKeyboard;
+    #endif
+
     ImGui_ImplSDL2_Data()   { memset((void*)this, 0, sizeof(*this)); }
 };
 


### PR DESCRIPTION
When testing out the latest LUS https://github.com/Kenix3/libultraship/commit/8a3222900242c9700d348628cf01d63f8c4a87ca on switch, I noticed I could not open the menu by pressing `-`

When investigating this, I noticed pretty much all the switch specific changes to imgui were removed by https://github.com/Kenix3/libultraship/pull/97

This PR restores those changes

Tested opening the menu with https://github.com/HarbourMasters/Shipwright/pull/2445, verified it's working as of https://github.com/HarbourMasters/Shipwright/pull/2445/commits/980f27d0ca1635cf622aea3e5b0add60cba68c6a