### PR TITLE
[Speech] Allow Setting Language + Allow Uninitialization 

### DIFF
--- a/src/core/bridge/speechsynthesizerbridge.cpp
+++ b/src/core/bridge/speechsynthesizerbridge.cpp
@@ -23,12 +23,16 @@ bool SpeechSynthesizerInit(void) {
     return false;
 }
 
-void SpeechSynthesizerSpeak(const char* text) {
+void SpeechSynthesizerSpeakEnglish(const char* text) {
+    SpeechSynthesizerSpeak(text, "en-US");
+}
+
+void SpeechSynthesizerSpeak(const char* text, const char* language) {
     auto speechSynthesizer = Ship::Window::GetInstance()->GetSpeechSynthesizer();
     if (speechSynthesizer == nullptr) {
         return;
     }
 
-    speechSynthesizer->Speak(text);
+    speechSynthesizer->Speak(text, language);
 }
 }

--- a/src/core/bridge/speechsynthesizerbridge.cpp
+++ b/src/core/bridge/speechsynthesizerbridge.cpp
@@ -23,6 +23,15 @@ bool SpeechSynthesizerInit(void) {
     return false;
 }
 
+void SpeechSynthesizerUninitialize(void) {
+    auto speechSynthesizer = Ship::Window::GetInstance()->GetSpeechSynthesizer();
+    if (speechSynthesizer == nullptr) {
+        return;
+    }
+
+    speechSynthesizer->Uninitialize();
+}
+
 void SpeechSynthesizerSpeakEnglish(const char* text) {
     SpeechSynthesizerSpeak(text, "en-US");
 }

--- a/src/core/bridge/speechsynthesizerbridge.cpp
+++ b/src/core/bridge/speechsynthesizerbridge.cpp
@@ -32,10 +32,6 @@ void SpeechSynthesizerUninitialize(void) {
     speechSynthesizer->Uninitialize();
 }
 
-void SpeechSynthesizerSpeakEnglish(const char* text) {
-    SpeechSynthesizerSpeak(text, "en-US");
-}
-
 void SpeechSynthesizerSpeak(const char* text, const char* language) {
     auto speechSynthesizer = Ship::Window::GetInstance()->GetSpeechSynthesizer();
     if (speechSynthesizer == nullptr) {

--- a/src/core/bridge/speechsynthesizerbridge.h
+++ b/src/core/bridge/speechsynthesizerbridge.h
@@ -17,7 +17,6 @@ extern "C" {
 bool SpeechSynthesizerInit(void);
 void SpeechSynthesizerUninitialize(void);
 
-void SpeechSynthesizerSpeakEnglish(const char* text);
 void SpeechSynthesizerSpeak(const char* text, const char* language);
 
 #ifdef __cplusplus

--- a/src/core/bridge/speechsynthesizerbridge.h
+++ b/src/core/bridge/speechsynthesizerbridge.h
@@ -15,6 +15,7 @@ extern "C" {
 #endif
 
 bool SpeechSynthesizerInit(void);
+void SpeechSynthesizerUninitialize(void);
 
 void SpeechSynthesizerSpeakEnglish(const char* text);
 void SpeechSynthesizerSpeak(const char* text, const char* language);

--- a/src/core/bridge/speechsynthesizerbridge.h
+++ b/src/core/bridge/speechsynthesizerbridge.h
@@ -15,7 +15,9 @@ extern "C" {
 #endif
 
 bool SpeechSynthesizerInit(void);
-void SpeechSynthesizerSpeak(const char* text);
+
+void SpeechSynthesizerSpeakEnglish(const char* text);
+void SpeechSynthesizerSpeak(const char* text, const char* language);
 
 #ifdef __cplusplus
 };

--- a/src/speechsynthesizer/DarwinSpeechSynthesizer.h
+++ b/src/speechsynthesizer/DarwinSpeechSynthesizer.h
@@ -16,7 +16,7 @@ class DarwinSpeechSynthesizer : public SpeechSynthesizer {
   public:
     DarwinSpeechSynthesizer();
 
-    void Speak(const char* text);
+    void Speak(const char* text, const char* language);
 
   protected:
     bool DoInit(void);

--- a/src/speechsynthesizer/DarwinSpeechSynthesizer.h
+++ b/src/speechsynthesizer/DarwinSpeechSynthesizer.h
@@ -9,7 +9,6 @@
 #define DarwinSpeechSynthesizer_h
 
 #include "SpeechSynthesizer.h"
-#include <stdio.h>
 
 namespace Ship {
 class DarwinSpeechSynthesizer : public SpeechSynthesizer {
@@ -20,6 +19,7 @@ class DarwinSpeechSynthesizer : public SpeechSynthesizer {
 
   protected:
     bool DoInit(void);
+    void DoUninitialize(void);
 
   private:
     void* mSynthesizer;

--- a/src/speechsynthesizer/DarwinSpeechSynthesizer.mm
+++ b/src/speechsynthesizer/DarwinSpeechSynthesizer.mm
@@ -16,9 +16,9 @@ bool DarwinSpeechSynthesizer::DoInit() {
     return true;
 }
 
-void DarwinSpeechSynthesizer::Speak(const char* text) {
+void DarwinSpeechSynthesizer::Speak(const char* text, const char* language) {
     AVSpeechUtterance *utterance = [AVSpeechUtterance speechUtteranceWithString:@(text)];
-    [utterance setVoice:[AVSpeechSynthesisVoice voiceWithIdentifier:@"com.apple.voice.compact.en-US.Samantha"]];
+    [utterance setVoice:[AVSpeechSynthesisVoice voiceWithLanguage:@(language)]];
 
     if (@available(macOS 11.0, *)) {
         [utterance setPrefersAssistiveTechnologySettings:YES];

--- a/src/speechsynthesizer/DarwinSpeechSynthesizer.mm
+++ b/src/speechsynthesizer/DarwinSpeechSynthesizer.mm
@@ -16,6 +16,11 @@ bool DarwinSpeechSynthesizer::DoInit() {
     return true;
 }
 
+void DarwinSpeechSynthesizer::DoUninitialize() {
+    [(AVSpeechSynthesizer *)mSynthesizer stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
+    mSynthesizer = nil;
+}
+
 void DarwinSpeechSynthesizer::Speak(const char* text, const char* language) {
     AVSpeechUtterance *utterance = [AVSpeechUtterance speechUtteranceWithString:@(text)];
     [utterance setVoice:[AVSpeechSynthesisVoice voiceWithLanguage:@(language)]];

--- a/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
+++ b/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
@@ -8,6 +8,8 @@
 #include "SAPISpeechSynthesizer.h"
 #include <sapi.h>
 #include <thread>
+#include <string>
+#include <spdlog/fmt/fmt.h>
 
 ISpVoice* mVoice = NULL;
 
@@ -23,11 +25,14 @@ bool SAPISpeechSynthesizer::DoInit() {
 }
 
 void SpeakThreadTask(const char* text, const char* language) {
-    std::wstring wtext = L"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='";
-    wtext += std::wstring(language, language + strlen(language));
-    wtext += L"'>";
-    wtext += std::wstring(text, text + strlen(text));
-    wtext += L"</speak>";
+    std::string speak = fmt::format("<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{}'>{}</speak>", language, text);
+
+    const int w = 512;
+    int* wp = const_cast<int*>(&w);
+    *wp = strlen(speak.c_str());
+
+    wchar_t wtext[w];
+    mbstowcs(wtext, speak.c_str(), strlen(speak.c_str()) + 1);
 
     mVoice->Speak(wtext, SPF_IS_XML | SPF_ASYNC | SPF_PURGEBEFORESPEAK, NULL);
 }

--- a/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
+++ b/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
@@ -24,6 +24,12 @@ bool SAPISpeechSynthesizer::DoInit() {
     return true;
 }
 
+void SAPISpeechSynthesizer::DoUninitialize() {
+    mVoice->Release();
+    mVoice = NULL;
+    CoUninitialize();
+}
+
 void SpeakThreadTask(const char* text, const char* language) {
     std::string speak = fmt::format(
         "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{}'>{}</speak>", language, text);

--- a/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
+++ b/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
@@ -31,15 +31,17 @@ void SAPISpeechSynthesizer::DoUninitialize() {
 }
 
 void SpeakThreadTask(const char* text, const char* language) {
-    std::string speak = fmt::format(
-        "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{}'>{}</speak>", language, text);
+    auto speak =
+        fmt::format("<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{}'>{}</speak>",
+                    language, text)
+            .c_str();
 
     const int w = 512;
     int* wp = const_cast<int*>(&w);
-    *wp = strlen(speak.c_str());
+    *wp = strlen(speak));
 
     wchar_t wtext[w];
-    mbstowcs(wtext, speak.c_str(), strlen(speak.c_str()) + 1);
+    mbstowcs(wtext, speak), strlen(speak)) + 1);
 
     mVoice->Speak(wtext, SPF_IS_XML | SPF_ASYNC | SPF_PURGEBEFORESPEAK, NULL);
 }

--- a/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
+++ b/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
@@ -22,19 +22,18 @@ bool SAPISpeechSynthesizer::DoInit() {
     return true;
 }
 
-void SpeakThreadTask(const char* text) {
-    const int w = 512;
-    int* wp = const_cast<int*>(&w);
-    *wp = strlen(text);
-
-    wchar_t wtext[w];
-    mbstowcs(wtext, text, strlen(text) + 1);
+void SpeakThreadTask(const char* text, const char* language) {
+    std::wstring wtext = L"<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='";
+    wtext += std::wstring(language, language + strlen(language));
+    wtext += L"'>";
+    wtext += std::wstring(text, text + strlen(text));
+    wtext += L"</speak>";
 
     mVoice->Speak(wtext, SPF_IS_XML | SPF_ASYNC | SPF_PURGEBEFORESPEAK, NULL);
 }
 
-void SAPISpeechSynthesizer::Speak(const char* text) {
-    std::thread t1(SpeakThreadTask, text);
+void SAPISpeechSynthesizer::Speak(const char* text, const char* language) {
+    std::thread t1(SpeakThreadTask, text, language);
     t1.detach();
 }
 } // namespace Ship

--- a/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
+++ b/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
@@ -25,7 +25,8 @@ bool SAPISpeechSynthesizer::DoInit() {
 }
 
 void SpeakThreadTask(const char* text, const char* language) {
-    std::string speak = fmt::format("<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{}'>{}</speak>", language, text);
+    std::string speak = fmt::format(
+        "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='{}'>{}</speak>", language, text);
 
     const int w = 512;
     int* wp = const_cast<int*>(&w);

--- a/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
+++ b/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
@@ -38,10 +38,10 @@ void SpeakThreadTask(const char* text, const char* language) {
 
     const int w = 512;
     int* wp = const_cast<int*>(&w);
-    *wp = strlen(speak));
+    *wp = strlen(speak);
 
     wchar_t wtext[w];
-    mbstowcs(wtext, speak), strlen(speak)) + 1);
+    mbstowcs(wtext, speak, strlen(speak) + 1);
 
     mVoice->Speak(wtext, SPF_IS_XML | SPF_ASYNC | SPF_PURGEBEFORESPEAK, NULL);
 }

--- a/src/speechsynthesizer/SAPISpeechSynthesizer.h
+++ b/src/speechsynthesizer/SAPISpeechSynthesizer.h
@@ -16,7 +16,7 @@ class SAPISpeechSynthesizer : public SpeechSynthesizer {
   public:
     SAPISpeechSynthesizer();
 
-    void Speak(const char* text);
+    void Speak(const char* text, const char* language);
 
   protected:
     bool DoInit(void);

--- a/src/speechsynthesizer/SAPISpeechSynthesizer.h
+++ b/src/speechsynthesizer/SAPISpeechSynthesizer.h
@@ -20,6 +20,7 @@ class SAPISpeechSynthesizer : public SpeechSynthesizer {
 
   protected:
     bool DoInit(void);
+    void DoUninitialize(void);
 };
 } // namespace Ship
 

--- a/src/speechsynthesizer/SpeechSynthesizer.cpp
+++ b/src/speechsynthesizer/SpeechSynthesizer.cpp
@@ -11,8 +11,21 @@ namespace Ship {
 SpeechSynthesizer::SpeechSynthesizer() : mInitialized(false){};
 
 bool SpeechSynthesizer::Init(void) {
+    if (mInitialized) {
+        return true;
+    }
+
     mInitialized = DoInit();
-    return IsInitialized();
+    return mInitialized;
+}
+
+void SpeechSynthesizer::Uninitialize(void) {
+    if (!mInitialized) {
+        return;
+    }
+
+    DoUninitialize();
+    mInitialized = false;
 }
 
 bool SpeechSynthesizer::IsInitialized(void) {

--- a/src/speechsynthesizer/SpeechSynthesizer.h
+++ b/src/speechsynthesizer/SpeechSynthesizer.h
@@ -16,7 +16,7 @@ class SpeechSynthesizer {
     SpeechSynthesizer();
 
     bool Init(void);
-    virtual void Speak(const char* text) = 0;
+    virtual void Speak(const char* text, const char* language) = 0;
 
     bool IsInitialized(void);
 

--- a/src/speechsynthesizer/SpeechSynthesizer.h
+++ b/src/speechsynthesizer/SpeechSynthesizer.h
@@ -16,12 +16,14 @@ class SpeechSynthesizer {
     SpeechSynthesizer();
 
     bool Init(void);
+    void Uninitialize(void);
     virtual void Speak(const char* text, const char* language) = 0;
 
     bool IsInitialized(void);
 
   protected:
     virtual bool DoInit(void) = 0;
+    virtual void DoUninitialize(void) = 0;
 
   private:
     bool mInitialized;


### PR DESCRIPTION
Allows specifying the language to use for the given text in the format: `en-US`.
Also creates a basically `SpeechSynthesizerSpeakEnglish()` method in case you don't want to specify language.