### PR TITLE
fix z-fighting on roads

### DIFF
--- a/src/graphic/Fast3D/gfx_direct3d11.cpp
+++ b/src/graphic/Fast3D/gfx_direct3d11.cpp
@@ -699,7 +699,11 @@ static void gfx_d3d11_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_t
         rasterizer_desc.CullMode = D3D11_CULL_NONE;
         rasterizer_desc.FrontCounterClockwise = true;
         rasterizer_desc.DepthBias = 0;
-        rasterizer_desc.SlopeScaledDepthBias = d3d.zmode_decal ? -2.0f : 0.0f;
+        // SSDB = SlopeScaledDepthBias (name in D3D) 120 leads to -2 at 240p which is the intended resolution (I was told)
+        static int SSDBfactor = 120; // could be changed to constant and moved to a header to share with OGL if the value is accepted
+        // get internal resolution and overwrite the Offset with scaled version
+        float SSDB = -1.0f * (float)d3d.render_target_height / SSDBfactor;
+        rasterizer_desc.SlopeScaledDepthBias = d3d.zmode_decal ? SSDB : 0.0f;
         rasterizer_desc.DepthBiasClamp = 0.0f;
         rasterizer_desc.DepthClipEnable = false;
         rasterizer_desc.ScissorEnable = true;

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -721,24 +721,27 @@ static void gfx_opengl_set_depth_test_and_mask(bool depth_test, bool z_upd) {
 
 static void gfx_opengl_set_zmode_decal(bool zmode_decal) {
     if (zmode_decal) {
-        
+
         // SSDB = SlopeScaledDepthBias 120 leads to -2 at 240p which is the same as N64 mode which has very little
         // fighting
         const int n64modeFactor = 120;
         const int noVanishFactor = 100;
         GLfloat SSDB = -2;
         switch (CVarGetInteger("gDirtPathFix", 0)) {
-            case 1: // scaled z-fighting (N64 mode like)
+            // scaled z-fighting (N64 mode like)
+            case 1:
                 if (framebuffers.size() > current_framebuffer) { // safety check for vector size can probably be removed
                     SSDB = -1.0f * (GLfloat)framebuffers[current_framebuffer].height / n64modeFactor;
                 }
                 break;
-            case 2: // no vanishing paths
+            // no vanishing paths
+            case 2:
                 if (framebuffers.size() > current_framebuffer) { // safety check for vector size can probably be removed
                     SSDB = -1.0f * (GLfloat)framebuffers[current_framebuffer].height / noVanishFactor;
                 }
                 break;
-            case 0: // disabled
+            // disabled
+            case 0:
             default:
                 SSDB = -2;
         }

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -720,7 +720,17 @@ static void gfx_opengl_set_depth_test_and_mask(bool depth_test, bool z_upd) {
 
 static void gfx_opengl_set_zmode_decal(bool zmode_decal) {
     if (zmode_decal) {
-        glPolygonOffset(-2, -2);
+        
+        GLfloat Offset1 = -2; // original value
+        // SSDB = SlopeScaledDepthBias (name in D3D) 120 leads to -2 at 240p which is the original resolution (I was told)
+        // could be changed to constant and moved to a header to share with OGL if the value is accepted
+        static int SSDBfactor = 120; 
+        // get internal resolution and overwrite the Offset with scaled version if calculation is successful 
+        const size_t fbsize = framebuffers.size();
+        if (framebuffers.size() > current_framebuffer) { //safety check for vector size can probably be removed
+            Offset1 = -1.0f * (float)framebuffers[current_framebuffer].height / SSDBfactor;
+        }
+        glPolygonOffset(Offset1, -2);
         glEnable(GL_POLYGON_OFFSET_FILL);
     } else {
         glPolygonOffset(0, 0);


### PR DESCRIPTION
uses a CVar for 3 different settings: 
same as before (default) (z-fighting swallows more of the paths in higher res)
like in N64 mode for all resolutions
no z-fighting for all resolutions