### PR TITLE
Fix a couple of problems indicated by compiler warnings

### DIFF
--- a/include/libultraship/libultra.h
+++ b/include/libultraship/libultra.h
@@ -8,7 +8,6 @@
 #include "libultra/gbi.h"
 #include "libultra/gs2dex.h"
 #include "libultra/gu.h"
-#include "libultra/hardware.h"
 #include "libultra/internal.h"
 #include "libultra/interrupt.h"
 #include "libultra/mbi.h"

--- a/include/libultraship/libultra/hardware.h
+++ b/include/libultraship/libultra/hardware.h
@@ -1,90 +1,9 @@
 #ifndef ULTRA64_HARDWARE_H
 #define ULTRA64_HARDWARE_H
 
-#define HW_REG(reg, type) *(volatile type*)((reg) | 0xa0000000)
+/* TODO: This file isn't a part of the original SDK headers, so either remove
+it completely or have it used to include a useful subset of headers */
 
-#define AI_DRAM_ADDR_REG 0x04500000
-#define AI_LEN_REG 0x04500004
-#define AI_CONTROL_REG 0x04500008
-#define AI_STATUS_REG 0x0450000C
-#define AI_STATUS_AI_FULL (1 << 31)
-#define AI_STATUS_AI_BUSY (1 << 30)
-#define AI_DACRATE_REG 0x04500010
-#define AI_BITRATE_REG 0x04500014
-
-#define VI_STATUS_REG 0x04400000
-#define VI_CONTROL_REG 0x04400000
-#define VI_ORIGIN_REG 0x04400004
-#define VI_DRAM_ADDR_REG 0x04400004
-#define VI_WIDTH_REG 0x04400008
-#define VI_H_WIDTH_REG 0x04400008
-#define VI_INTR_REG 0x0440000C
-#define VI_V_INTER_REG 0x0440000C
-#define VI_CURRENT_REG 0x04400010
-#define VI_V_CURRENT_LINE_REG 0x04400010
-#define VI_BURST_REG 0x04400014
-#define VI_TIMING_REG 0x04400014
-#define VI_V_SYNC_REG 0x04400018 // VI vertical sync
-#define VI_H_SYNC_REG 0x0440001C // VI horizontal sync
-#define VI_LEAP_REG 0x04400020   // VI horizontal sync leap
-#define VI_H_SYNC_LEAP_REG 0x04400020
-#define VI_H_START_REG 0x04400024 // VI horizontal video
-#define VI_H_VIDEO_REG 0x04400024
-#define VI_V_START_REG 0x04400028 // VI vertical video
-#define VI_V_VIDEO_REG 0x04400028
-#define VI_V_BURST_REG 0x0440002C // VI vertical burst
-#define VI_X_SCALE_REG 0x04400030 // VI x-scale
-#define VI_Y_SCALE_REG 0x04400034 // VI y-scale
-
-#define SP_IMEM_START 0x04001000
-#define SP_DMEM_START 0x04000000
-
-#define SP_MEM_ADDR_REG 0x04040000
-#define SP_DRAM_ADDR_REG 0x04040004
-#define SP_RD_LEN_REG 0x04040008
-#define SP_WR_LEN_REG 0x0404000C
-#define SP_STATUS_REG 0x04040010
-#define SP_PC_REG 0x04080000
-
-#define PI_DRAM_ADDR_REG 0x04600000    // PI DRAM address
-#define PI_CART_ADDR_REG 0x04600004    // PI pbus (cartridge) address
-#define PI_RD_LEN_REG 0x04600008       // PI read length
-#define PI_WR_LEN_REG 0x0460000C       // PI write length
-#define PI_STATUS_REG 0x04600010       // PI status
-#define PI_BSD_DOM1_LAT_REG 0x04600014 // PI dom1 latency
-#define PI_DOMAIN1_REG 0x04600014
-#define PI_BSD_DOM1_PWD_REG 0x04600018 // PI dom1 pulse width
-#define PI_BSD_DOM1_PGS_REG 0x0460001C // PI dom1 page size
-#define PI_BSD_DOM1_RLS_REG 0x04600020 // PI dom1 release
-#define PI_BSD_DOM2_LAT_REG 0x04600024 // PI dom2 latency
-#define PI_DOMAIN2_REG 0x04600024
-#define PI_BSD_DOM2_PWD_REG 0x04600028 // PI dom2 pulse width
-#define PI_BSD_DOM2_PGS_REG 0x0460002C // PI dom2 page size
-#define PI_BSD_DOM2_RLS_REG 0x04600030 // PI dom2 release
-
-#define PI_STATUS_BUSY 0x1
-#define PI_STATUS_IOBUSY 0x2
-#define PI_STATUS_ERROR 0x3
-
-#define PI_STATUS_RESET_CONTROLLER 0x1
-#define PI_STATUS_CLEAR_INTR 0x2
-
-#define SI_DRAM_ADDR_REG 0x04800000
-#define SI_PIF_ADDR_RD64B_REG 0x04800004
-#define SI_PIF_ADDR_WR64B_REG 0x04800010
-#define SI_STATUS_REG 0x04800018
-
-#define SI_STATUS_DMA_BUSY 0x1
-#define SI_STATUS_IO_READ_BUSY 0x2
-#define SI_STATUS_DMA_ERROR 0x8
-#define SI_STATUS_INTERRUPT (1 << 12)
-
-#define PIF_RAM_START 0x1FC007C0
-
-#define MI_INIT_MODE_REG 0x04300000
-#define MI_MODE_REG MI_INIT_MODE_REG
-#define MI_VERSION_REG 0x04300004
-#define MI_INTR_REG 0x04300008
-#define MI_INTR_MASK_REG 0x0430000C
+#include "rcp.h"
 
 #endif

--- a/include/libultraship/libultra/hardware.h
+++ b/include/libultraship/libultra/hardware.h
@@ -1,9 +1,0 @@
-#ifndef ULTRA64_HARDWARE_H
-#define ULTRA64_HARDWARE_H
-
-/* TODO: This file isn't a part of the original SDK headers, so either remove
-it completely or have it used to include a useful subset of headers */
-
-#include "rcp.h"
-
-#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -443,6 +443,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang")
 		-Wno-parentheses
 		-Wno-narrowing
 		-Wno-missing-field-initializers
-        -Wno-int-conversion
+        $<$<COMPILE_LANGUAGE:C,OBJC>:-Wno-int-conversion>
 	)
 endif()

--- a/src/controller/ControlDeck.cpp
+++ b/src/controller/ControlDeck.cpp
@@ -54,7 +54,7 @@ void ControlDeck::ScanPhysicalDevices() {
 
     mPhysicalDevices.push_back(std::make_shared<DummyController>("Disconnected", "None", false));
 
-    for (const auto device : mPhysicalDevices) {
+    for (const auto &device : mPhysicalDevices) {
         for (int32_t i = 0; i < MAXCONTROLLERS; i++) {
             device->CreateDefaultBinding(i);
         }
@@ -124,8 +124,7 @@ void ControlDeck::LoadControllerSettings() {
         config->setString(StringHelper::Sprintf("Controllers.Deck.Slot_%d", (int)i), backend->GetGuid());
     }
 
-    for (const auto device : mPhysicalDevices) {
-
+    for (const auto &device : mPhysicalDevices) {
         std::string guid = device->GetGuid();
 
         for (int32_t virtualSlot = 0; virtualSlot < MAXCONTROLLERS; virtualSlot++) {

--- a/src/controller/ControlDeck.cpp
+++ b/src/controller/ControlDeck.cpp
@@ -54,7 +54,7 @@ void ControlDeck::ScanPhysicalDevices() {
 
     mPhysicalDevices.push_back(std::make_shared<DummyController>("Disconnected", "None", false));
 
-    for (const auto &device : mPhysicalDevices) {
+    for (const auto& device : mPhysicalDevices) {
         for (int32_t i = 0; i < MAXCONTROLLERS; i++) {
             device->CreateDefaultBinding(i);
         }
@@ -124,7 +124,7 @@ void ControlDeck::LoadControllerSettings() {
         config->setString(StringHelper::Sprintf("Controllers.Deck.Slot_%d", (int)i), backend->GetGuid());
     }
 
-    for (const auto &device : mPhysicalDevices) {
+    for (const auto& device : mPhysicalDevices) {
         std::string guid = device->GetGuid();
 
         for (int32_t virtualSlot = 0; virtualSlot < MAXCONTROLLERS; virtualSlot++) {

--- a/src/core/Window.cpp
+++ b/src/core/Window.cpp
@@ -54,8 +54,8 @@ std::shared_ptr<Window> Window::CreateInstance(const std::string name, const std
 }
 
 Window::Window(std::string Name)
-    : mName(std::move(Name)), mAudioPlayer(nullptr), mControlDeck(nullptr), mResourceManager(nullptr), mLogger(nullptr),
-      mConfig(nullptr) {
+    : mLogger(nullptr), mConfig(nullptr), mResourceManager(nullptr),
+      mAudioPlayer(nullptr), mControlDeck(nullptr), mName(std::move(Name)) {
     mWindowManagerApi = nullptr;
     mRenderingApi = nullptr;
     mIsFullscreen = false;

--- a/src/core/Window.cpp
+++ b/src/core/Window.cpp
@@ -54,8 +54,8 @@ std::shared_ptr<Window> Window::CreateInstance(const std::string name, const std
 }
 
 Window::Window(std::string Name)
-    : mLogger(nullptr), mConfig(nullptr), mResourceManager(nullptr),
-      mAudioPlayer(nullptr), mControlDeck(nullptr), mName(std::move(Name)) {
+    : mLogger(nullptr), mConfig(nullptr), mResourceManager(nullptr), mAudioPlayer(nullptr), mControlDeck(nullptr),
+      mName(std::move(Name)) {
     mWindowManagerApi = nullptr;
     mRenderingApi = nullptr;
     mIsFullscreen = false;

--- a/src/menu/GameOverlay.cpp
+++ b/src/menu/GameOverlay.cpp
@@ -215,12 +215,12 @@ void GameOverlay::Draw() {
                     this->TextDraw(30, textY, true, color, "%s %s", text, var->String.c_str());
                     break;
                 case ConsoleVariableType::Color:
-                    this->TextDraw(30, textY, true, color, "%s (%u, %u, %u, %u)", text,
-                        var->Color.r, var->Color.g, var->Color.b, var->Color.a);
+                    this->TextDraw(30, textY, true, color, "%s (%u, %u, %u, %u)", text, var->Color.r, var->Color.g,
+                                   var->Color.b, var->Color.a);
                     break;
                 case ConsoleVariableType::Color24:
-                    this->TextDraw(30, textY, true, color, "%s (%u, %u, %u)", text,
-                        var->Color24.r, var->Color24.g, var->Color24.b);
+                    this->TextDraw(30, textY, true, color, "%s (%u, %u, %u)", text, var->Color24.r, var->Color24.g,
+                                   var->Color24.b);
                     break;
             }
 

--- a/src/menu/GameOverlay.cpp
+++ b/src/menu/GameOverlay.cpp
@@ -215,7 +215,12 @@ void GameOverlay::Draw() {
                     this->TextDraw(30, textY, true, color, "%s %s", text, var->String.c_str());
                     break;
                 case ConsoleVariableType::Color:
-                    this->TextDraw(30, textY, true, color, "#%08X", text, var->Color);
+                    this->TextDraw(30, textY, true, color, "%s (%u, %u, %u, %u)", text,
+                        var->Color.r, var->Color.g, var->Color.b, var->Color.a);
+                    break;
+                case ConsoleVariableType::Color24:
+                    this->TextDraw(30, textY, true, color, "%s (%u, %u, %u)", text,
+                        var->Color24.r, var->Color24.g, var->Color24.b);
                     break;
             }
 

--- a/src/menu/ImGuiImpl.cpp
+++ b/src/menu/ImGuiImpl.cpp
@@ -583,7 +583,8 @@ void DrawMainMenuAndCalculateGameSize(void) {
                 console->Dispatch("reset");
             }
 #if !defined(__SWITCH__) && !defined(__WIIU__)
-            const char* keyboardShortcut = strcmp(SohImGui::GetCurrentRenderingBackend().first, "sdl") == 0 ? "F10" : "ALT+Enter";
+            const char* keyboardShortcut =
+                strcmp(SohImGui::GetCurrentRenderingBackend().first, "sdl") == 0 ? "F10" : "ALT+Enter";
             if (ImGui::MenuItem("Toggle Fullscreen", keyboardShortcut)) {
                 Window::GetInstance()->ToggleFullscreen();
             }

--- a/src/menu/ImGuiImpl.cpp
+++ b/src/menu/ImGuiImpl.cpp
@@ -2,6 +2,7 @@
 
 #include "ImGuiImpl.h"
 
+#include <cstring>
 #include <iostream>
 #include <map>
 #include <utility>
@@ -582,7 +583,7 @@ void DrawMainMenuAndCalculateGameSize(void) {
                 console->Dispatch("reset");
             }
 #if !defined(__SWITCH__) && !defined(__WIIU__)
-            const char* keyboardShortcut = SohImGui::GetCurrentRenderingBackend().first == "sdl" ? "F10" : "ALT+Enter";
+            const char* keyboardShortcut = strcmp(SohImGui::GetCurrentRenderingBackend().first, "sdl") == 0 ? "F10" : "ALT+Enter";
             if (ImGui::MenuItem("Toggle Fullscreen", keyboardShortcut)) {
                 Window::GetInstance()->ToggleFullscreen();
             }

--- a/src/resource/Archive.cpp
+++ b/src/resource/Archive.cpp
@@ -345,7 +345,7 @@ bool Archive::LoadMainMPQ(bool enableWriting, bool generateCrcMap) {
         }
     }
     bool baseLoaded = false;
-    int i = 0;
+    size_t i = 0;
     while (!baseLoaded && i < mOtrArchives.size()) {
 #if defined(__SWITCH__) || defined(__WIIU__)
         std::string fullPath = mOtrArchives[i];
@@ -376,7 +376,7 @@ bool Archive::LoadMainMPQ(bool enableWriting, bool generateCrcMap) {
         SPDLOG_ERROR("No valid OTR file was provided.");
         return false;
     }
-    for (int j = i; j < mOtrArchives.size(); j++) {
+    for (size_t j = i; j < mOtrArchives.size(); j++) {
 #if defined(__SWITCH__) || defined(__WIIU__)
         std::string fullPath = mOtrArchives[j];
 #else


### PR DESCRIPTION
This PR dramatically reduces the number of warnings introduced by `libultraship` while building `shipwright` for Ubuntu 22.04/amd64. By 'dramatically' I mean that the error log is down from 13MB to 3MB, with most warnings due to conflicting definitions in `libultra/hardware.h`, a file that wasn't even in the original SDK. While I was at it, I also fixed at least four extremely minor bugs. Cheers!