### PR TITLE
Fix opengl api not getting used correctly

### DIFF
--- a/src/core/Window.cpp
+++ b/src/core/Window.cpp
@@ -323,15 +323,14 @@ void Window::InitializeWindowManager(std::string_view gfxBackend, std::string_vi
 #endif
 #if defined(ENABLE_OPENGL) || defined(__APPLE__)
     if (gfxBackend == "sdl") {
-        if (gfxApi == "OpenGL") {
-            mRenderingApi = &gfx_opengl_api;
-        }
+        mRenderingApi = &gfx_opengl_api;
+        mWindowManagerApi = &gfx_sdl;
 #ifdef __APPLE__
-        else if (gfxApi == "Metal") {
+        else if (gfxApi == "Metal" && Metal_IsSupported()) {
             mRenderingApi = &gfx_metal_api;
         }
 #endif
-        mWindowManagerApi = &gfx_sdl;
+        return;
     }
 #if defined(__linux__) && defined(X11_SUPPORTED)
     if (gfxBackend == "glx") {

--- a/src/core/Window.cpp
+++ b/src/core/Window.cpp
@@ -326,7 +326,7 @@ void Window::InitializeWindowManager(std::string_view gfxBackend, std::string_vi
         mRenderingApi = &gfx_opengl_api;
         mWindowManagerApi = &gfx_sdl;
 #ifdef __APPLE__
-        else if (gfxApi == "Metal" && Metal_IsSupported()) {
+        if (gfxApi == "Metal" && Metal_IsSupported()) {
             mRenderingApi = &gfx_metal_api;
         }
 #endif

--- a/src/menu/ImGuiImpl.cpp
+++ b/src/menu/ImGuiImpl.cpp
@@ -111,7 +111,7 @@ const char* filters[3] = {
 
 std::vector<std::pair<const char*, const char*>> renderingBackends = {
 #ifdef _WIN32
-    { "Dx11", "DirectX" },
+    { "dx11", "DirectX" },
 #endif
 #ifndef __WIIU__
     { "sdl", "OpenGL" }


### PR DESCRIPTION
The early return was removed and prevented the open gl api from being used on windows. https://github.com/HarbourMasters/Shipwright/issues/2534

I also renamed the dx11 string back to lower case to maintain compatibility with existing json files.