### PR TITLE
Set notch prox angle onto device profile instead of cvar

### DIFF
--- a/src/controller/ControlDeck.cpp
+++ b/src/controller/ControlDeck.cpp
@@ -140,7 +140,7 @@ void ControlDeck::LoadControllerSettings() {
 
             profile->Mappings.clear();
             profile->AxisDeadzones.clear();
-            profile->AxisDeadzones.clear();
+            profile->AxisMinimumPress.clear();
             profile->GyroData.clear();
 
             profile->Version = config->getInt(NESTED("Version", ""), DEVICE_PROFILE_VERSION_V0);
@@ -166,6 +166,7 @@ void ControlDeck::LoadControllerSettings() {
                     profile->UseRumble = config->getBool(NESTED("Rumble.Enabled", ""));
                     profile->RumbleStrength = config->getFloat(NESTED("Rumble.Strength", ""));
                     profile->UseGyro = config->getBool(NESTED("Gyro.Enabled", ""));
+                    profile->NotchProximityThreshold = config->getInt(NESTED("Notches.ProximityThreshold", ""));
 
                     for (auto const& val : rawProfile["AxisDeadzones"].items()) {
                         profile->AxisDeadzones[std::stoi(val.key())] = val.value();
@@ -219,6 +220,7 @@ void ControlDeck::SaveControllerSettings() {
             config->setBool(NESTED("Rumble.Enabled", ""), profile->UseRumble);
             config->setFloat(NESTED("Rumble.Strength", ""), profile->RumbleStrength);
             config->setBool(NESTED("Gyro.Enabled", ""), profile->UseGyro);
+            config->setInt(NESTED("Notches.ProximityThreshold", ""), profile->NotchProximityThreshold);
 
             for (auto const& val : rawProfile["Mappings"].items()) {
                 config->setInt(NESTED("Mappings.%s", val.key().c_str()), -1);

--- a/src/controller/Controller.cpp
+++ b/src/controller/Controller.cpp
@@ -88,7 +88,7 @@ int8_t Controller::ReadStick(int32_t virtualSlot, Stick stick, Axis axis) {
     return 0;
 }
 
-void Controller::ProcessStick(int8_t& x, int8_t& y, uint16_t deadzoneX, uint16_t deadzoneY) {
+void Controller::ProcessStick(int8_t& x, int8_t& y, float deadzoneX, float deadzoneY, int32_t notchProxmityThreshold) {
     auto ux = fabs(x);
     auto uy = fabs(y);
 
@@ -122,8 +122,7 @@ void Controller::ProcessStick(int8_t& x, int8_t& y, uint16_t deadzoneX, uint16_t
     }
 
     // map to virtual notches
-    double notchProximityVal = CVarGetInteger("gNotchProximityThreshold", 0);
-    const double notchProximityValRadians = notchProximityVal * M_TAU / 360;
+    const double notchProximityValRadians = notchProxmityThreshold * M_TAU / 360;
 
     const double distance = std::sqrt((ux * ux) + (uy * uy)) / MAX_AXIS_RANGE;
     if (distance >= MINIMUM_RADIUS_TO_MAP_NOTCH) {
@@ -158,8 +157,10 @@ void Controller::Read(OSContPad* pad, int32_t virtualSlot) {
     int8_t rightStickY = ReadStick(virtualSlot, RIGHT, Y);
 
     auto profile = getProfile(virtualSlot);
-    ProcessStick(leftStickX, leftStickY, profile->AxisDeadzones[0], profile->AxisDeadzones[1]);
-    ProcessStick(rightStickX, rightStickY, profile->AxisDeadzones[2], profile->AxisDeadzones[3]);
+    ProcessStick(leftStickX, leftStickY, profile->AxisDeadzones[0], profile->AxisDeadzones[1],
+                 profile->NotchProximityThreshold);
+    ProcessStick(rightStickX, rightStickY, profile->AxisDeadzones[2], profile->AxisDeadzones[3],
+                 profile->NotchProximityThreshold);
 
     if (pad == nullptr) {
         return;

--- a/src/controller/Controller.h
+++ b/src/controller/Controller.h
@@ -26,6 +26,7 @@ struct DeviceProfile {
     bool UseRumble = false;
     bool UseGyro = false;
     float RumbleStrength = 1.0f;
+    int32_t NotchProximityThreshold = 0;
     std::unordered_map<int32_t, float> AxisDeadzones;
     std::unordered_map<int32_t, float> AxisMinimumPress;
     std::unordered_map<int32_t, float> GyroData;
@@ -67,7 +68,7 @@ class Controller {
 
     void LoadBinding();
     int8_t ReadStick(int32_t virtualSlot, Stick stick, Axis axis);
-    void ProcessStick(int8_t& x, int8_t& y, uint16_t deadzoneX, uint16_t deadzoneY);
+    void ProcessStick(int8_t& x, int8_t& y, float deadzoneX, float deadzoneY, int32_t notchProxmityThreshold);
 
   private:
     struct Buttons {

--- a/src/menu/InputEditor.cpp
+++ b/src/menu/InputEditor.cpp
@@ -327,12 +327,8 @@ void InputEditor::DrawControllerSchema() {
     }
 
     if (!isKeyboard) {
-        const char* notchProximityCvar = "gNotchProximityThreshold";
-        int notchProximityVal = CVarGetInteger(notchProximityCvar, 0);
-        auto nda = notchProximityVal;
-
         ImGui::SetCursorPosX(cursorX);
-        ImGui::Text("Notch Snap Angle: %d", nda);
+        ImGui::Text("Notch Snap Angle: %d", profile->NotchProximityThreshold);
         ImGui::SetCursorPosX(cursorX);
 
 #ifdef __WIIU__
@@ -340,11 +336,8 @@ void InputEditor::DrawControllerSchema() {
 #else
         ImGui::PushItemWidth(135.0f);
 #endif
-        ImGui::SliderInt("##NotchProximityThreshold", &notchProximityVal, 0, 45, "", ImGuiSliderFlags_AlwaysClamp);
-        {
-            CVarSetInteger(notchProximityCvar, notchProximityVal);
-            SohImGui::RequestCvarSaveOnNextTick();
-        }
+        ImGui::SliderInt("##NotchProximityThreshold", &profile->NotchProximityThreshold, 0, 45, "",
+                         ImGuiSliderFlags_AlwaysClamp);
         ImGui::PopItemWidth();
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip(
@@ -368,10 +361,10 @@ void InputEditor::DrawHud() {
     ImVec2 maxSize = ImVec2(2200, 505);
 #elif defined(__WIIU__)
     ImVec2 minSize = ImVec2(641 * 2, 250 * 2);
-    ImVec2 maxSize = ImVec2(1200 * 2, 290 * 2);
+    ImVec2 maxSize = ImVec2(1200 * 2, 330 * 2);
 #else
     ImVec2 minSize = ImVec2(641, 250);
-    ImVec2 maxSize = ImVec2(1200, 290);
+    ImVec2 maxSize = ImVec2(1200, 330);
 #endif
 
     ImGui::SetNextWindowSizeConstraints(minSize, maxSize);


### PR DESCRIPTION
This moves the notch proximity value to be set on the device profile so that each device can have unique notch angles and matches the rest of controller settings.

This change also removes a broken if statement that was causing CVar save on next tick on every frame, cause performance issues when the controller window was open.

I increased the max window height to account for the notch angle slider without needing to scroll.