### PR TITLE
gfx_pc: Removed clock_gettime-call for non-windows platforms

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -831,10 +831,10 @@ static void import_texture_ci8(int tile) {
         result_line_size *= metadata->h_byte_scale;
     }
 
-    uint32_t width = rdp.texture_tile[tile].line_size_bytes;
-    uint32_t height = size_bytes / rdp.texture_tile[tile].line_size_bytes;
+    uint32_t width = result_line_size;
+    uint32_t height = size_bytes / result_line_size;
 
-    gfx_rapi->upload_texture(rgba32_buf, width, height);
+    gfx_rapi->upload_texture(tex_upload_buffer, width, height);
     // DumpTexture(rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].otr_path, rgba32_buf, width, height);
 }
 
@@ -1424,10 +1424,6 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
         if (clip_parameters.z_is_from_0_to_1) {
             z = (z + w) / 2.0f;
         }
-
-        // if (markerOn) {
-        //     z = 10;
-        //}
 
         buf_vbo[buf_vbo_len++] = v_arr[i]->x;
         buf_vbo[buf_vbo_len++] = clip_parameters.invert_y ? -v_arr[i]->y : v_arr[i]->y;

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -212,18 +212,17 @@ static map<int, FBInfo> framebuffers;
 static set<pair<float, float>> get_pixel_depth_pending;
 static unordered_map<pair<float, float>, uint16_t, hash_pair_ff> get_pixel_depth_cached;
 
-#ifdef _WIN32
-// TODO: Properly implement for MSVC
-static unsigned long get_time(void) {
-    return 0;
-}
-#else
+#if defined(_DEBUG) && !defined(_WIN32) // TODO: Properly implement for MSVC
 #include <time.h>
 #include <string>
 static unsigned long get_time(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (unsigned long)ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
+}
+#else
+static unsigned long get_time(void) {
+    return 0;
 }
 #endif
 

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2284,14 +2284,8 @@ static void gfx_run_dl(Gfx* cmd) {
                     gfx_texture_cache_delete((const uint8_t*)texAddr);
                 }
             } break;
-            case G_NOOP: {
-                uint32_t index = C0(0, 16);
-                uint32_t type = C0(16, 8);
-                if (type == 2) {
-                    const char* str = (const char*)cmd->words.w1;
-                    // printf("%s, %u\n", str, index);
-                }
-            } break;
+            case G_NOOP:
+                break;
             case G_MTX: {
                 uintptr_t mtxAddr = cmd->words.w1;
 
@@ -2458,8 +2452,6 @@ static void gfx_run_dl(Gfx* cmd) {
                     }
                 } else {
                     cmd = (Gfx*)seg_addr(cmd->words.w1);
-                    cmd++;
-                    --cmd; // increase after break
                 }
                 break;
             case G_PUSHCD:
@@ -2865,16 +2857,6 @@ void gfx_init(struct GfxWindowManagerAPI* wapi, struct GfxRenderingAPI* rapi, co
         // We cap texture max to 8k, because why would you need more?
         int max_tex_size = min(8096, gfx_rapi->get_max_texture_size());
         tex_upload_buffer = (uint8_t*)malloc(max_tex_size * max_tex_size * 4);
-    }
-
-    // Used in the 120 star TAS
-    static uint32_t precomp_shaders[] = { 0x01200200, 0x00000045, 0x00000200, 0x01200a00, 0x00000a00, 0x01a00045,
-                                          0x00000551, 0x01045045, 0x05a00a00, 0x01200045, 0x05045045, 0x01045a00,
-                                          0x01a00a00, 0x0000038d, 0x01081081, 0x0120038d, 0x03200045, 0x03200a00,
-                                          0x01a00a6f, 0x01141045, 0x07a00a00, 0x05200200, 0x03200200, 0x09200200,
-                                          0x0920038d, 0x09200045 };
-    for (size_t i = 0; i < sizeof(precomp_shaders) / sizeof(uint32_t); i++) {
-        // gfx_lookup_or_create_shader_program(precomp_shaders[i]);
     }
 
     Ship::ExecuteHooks<Ship::GfxInit>();

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -1327,7 +1327,7 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
             z = (z + w) / 2.0f;
         }
 
-        //if (markerOn) {
+        // if (markerOn) {
         //     z = 10;
         //}
 

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -1755,6 +1755,10 @@ static void gfx_dp_set_tile(uint8_t fmt, uint32_t siz, uint32_t line, uint32_t t
     rdp.texture_tile[tile].shiftt = shiftt;
     rdp.texture_tile[tile].line_size_bytes = line * 8;
 
+    if (rdp.texture_tile[tile].line_size_bytes > 15000) {
+        int bp = 0;
+    }
+
     rdp.texture_tile[tile].tmem = tmem;
     // rdp.texture_tile[tile].tmem_index = tmem / 256; // tmem is the 64-bit word offset, so 256 words means 2 kB
     rdp.texture_tile[tile].tmem_index =


### PR DESCRIPTION
While checking the results of perf I found some instances of calls to `clock_gettime` within `gfx_flush` even with some high optimization settings (-O3, release). The code is old and propably unused, but in case somebody still uses that to debug/profile rendering code for now I just added the condition, that the debug flag is set. That change removes that call for Linux / Non-Windows platforms in release builds now.