### PR TITLE
[WIP] cvar changes (DO NOT MERGE)

### DIFF
--- a/include/libultraship/color.h
+++ b/include/libultraship/color.h
@@ -7,12 +7,34 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct Color_RGB8_t {
     uint8_t r, g, b;
+
+#ifdef __cplusplus
+    bool operator==(struct Color_RGB8_t const& other) const {
+        return (r == other.r) && (g == other.g) && (b == other.b);
+    }
+
+    bool operator!=(struct Color_RGB8_t const& other) const {
+        return !(*this == other);
+    }
+#endif
+
 } Color_RGB8;
 
-typedef struct {
+typedef struct Color_RGBA8_t {
     uint8_t r, g, b, a;
+
+#ifdef __cplusplus
+    bool operator==(Color_RGBA8_t const& other) const {
+        return (r == other.r) && (g == other.g) && (b == other.b) && (a == other.a);
+    }
+
+    bool operator!=(Color_RGBA8_t const& other) const {
+        return !(*this == other);
+    }
+#endif
+
 } Color_RGBA8;
 
 // only use when necessary for alignment purposes

--- a/src/core/ConsoleVariable.cpp
+++ b/src/core/ConsoleVariable.cpp
@@ -11,45 +11,62 @@ namespace Ship {
 ConsoleVariable::ConsoleVariable() {
 }
 
-std::shared_ptr<CVar> ConsoleVariable::Get(const char* name) {
+std::shared_ptr<CVar> ConsoleVariable::Get(const std::string& name) {
     auto it = mVariables.find(name);
     return it != mVariables.end() ? it->second : nullptr;
 }
 
-int32_t ConsoleVariable::GetInteger(const char* name, int32_t defaultValue) {
+int32_t ConsoleVariable::GetInteger(const std::string& name, int32_t defaultValue) {
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Integer) {
+        assert(Get<int32_t>(name) == variable->Integer);
+
         return variable->Integer;
     }
 
+    RegisterEmbedded(name, defaultValue);
+    assert(Get<int32_t>(name) == defaultValue);
+
     return defaultValue;
 }
 
-float ConsoleVariable::GetFloat(const char* name, float defaultValue) {
+float ConsoleVariable::GetFloat(const std::string& name, float defaultValue) {
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Float) {
+        assert(Get<float>(name) == variable->Float);
+
         return variable->Float;
     }
 
+    RegisterEmbedded(name, defaultValue);
+    assert(Get<float>(name) == defaultValue);
+
     return defaultValue;
 }
 
-const char* ConsoleVariable::GetString(const char* name, const char* defaultValue) {
+const char* ConsoleVariable::GetString(const std::string& name, const char* defaultValue) {
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::String) {
+        assert(Get<std::string>(name) == variable->String);
+
         return variable->String.c_str();
     }
+
+    RegisterEmbedded(name, std::string(defaultValue));
+    assert(Get<std::string>(name) == defaultValue);
 
     return defaultValue;
 }
 
-Color_RGBA8 ConsoleVariable::GetColor(const char* name, Color_RGBA8 defaultValue) {
+Color_RGBA8 ConsoleVariable::GetColor(const std::string& name, Color_RGBA8 defaultValue) {
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Color) {
+        assert(Get<Color_RGBA8>(name) == variable->Color);
+
         return variable->Color;
     } else if (variable != nullptr && variable->Type == ConsoleVariableType::Color24) {
         Color_RGBA8 temp;
@@ -60,13 +77,18 @@ Color_RGBA8 ConsoleVariable::GetColor(const char* name, Color_RGBA8 defaultValue
         return temp;
     }
 
+    RegisterEmbedded(name, defaultValue);
+    assert(Get<Color_RGBA8>(name) == defaultValue);
+
     return defaultValue;
 }
 
-Color_RGB8 ConsoleVariable::GetColor24(const char* name, Color_RGB8 defaultValue) {
+Color_RGB8 ConsoleVariable::GetColor24(const std::string& name, Color_RGB8 defaultValue) {
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Color24) {
+        assert(Get<Color_RGB8>(name) == variable->Color24);
+
         return variable->Color24;
     } else if (variable != nullptr && variable->Type == ConsoleVariableType::Color) {
         Color_RGB8 temp;
@@ -76,93 +98,118 @@ Color_RGB8 ConsoleVariable::GetColor24(const char* name, Color_RGB8 defaultValue
         return temp;
     }
 
+    RegisterEmbedded(name, defaultValue);
+    assert(Get<Color_RGB8>(name) == defaultValue);
+
     return defaultValue;
 }
 
-void ConsoleVariable::SetInteger(const char* name, int32_t value) {
+void ConsoleVariable::SetInteger(const std::string& name, int32_t value) {
     auto& variable = mVariables[name];
     if (variable == nullptr) {
         variable = std::make_shared<CVar>();
+
+        RegisterEmbedded(name, value);
     }
 
     variable->Type = ConsoleVariableType::Integer;
     variable->Integer = value;
+
+    Set<int32_t>(name, value);
 }
 
-void ConsoleVariable::SetFloat(const char* name, float value) {
+void ConsoleVariable::SetFloat(const std::string& name, float value) {
     auto& variable = mVariables[name];
     if (variable == nullptr) {
         variable = std::make_shared<CVar>();
+
+        RegisterEmbedded(name, value);
     }
 
     variable->Type = ConsoleVariableType::Float;
     variable->Float = value;
+
+    Set<float>(name, value);
 }
 
-void ConsoleVariable::SetString(const char* name, const char* value) {
+void ConsoleVariable::SetString(const std::string& name, const char* value) {
     auto& variable = mVariables[name];
     if (variable == nullptr) {
         variable = std::make_shared<CVar>();
+
+        RegisterEmbedded(name, std::string(value));
     }
 
     variable->Type = ConsoleVariableType::String;
     variable->String = std::string(value);
+
+    Set<std::string>(name, value);
 }
 
-void ConsoleVariable::SetColor(const char* name, Color_RGBA8 value) {
+void ConsoleVariable::SetColor(const std::string& name, Color_RGBA8 value) {
     auto& variable = mVariables[name];
     if (!variable) {
         variable = std::make_shared<CVar>();
+
+        RegisterEmbedded(name, value);
     }
 
     variable->Type = ConsoleVariableType::Color;
     variable->Color = value;
+
+    Set<Color_RGBA8>(name, value);
 }
 
-void ConsoleVariable::SetColor24(const char* name, Color_RGB8 value) {
+void ConsoleVariable::SetColor24(const std::string& name, Color_RGB8 value) {
     auto& variable = mVariables[name];
     if (!variable) {
         variable = std::make_shared<CVar>();
+
+        RegisterEmbedded(name, value);
     }
 
     variable->Type = ConsoleVariableType::Color24;
     variable->Color24 = value;
+
+    Set<Color_RGB8>(name, value);
 }
 
-void ConsoleVariable::RegisterInteger(const char* name, int32_t defaultValue) {
+void ConsoleVariable::RegisterInteger(const std::string& name, int32_t defaultValue) {
     if (Get(name) == nullptr) {
         SetInteger(name, defaultValue);
     }
 }
 
-void ConsoleVariable::RegisterFloat(const char* name, float defaultValue) {
+void ConsoleVariable::RegisterFloat(const std::string& name, float defaultValue) {
     if (Get(name) == nullptr) {
         SetFloat(name, defaultValue);
     }
 }
 
-void ConsoleVariable::RegisterString(const char* name, const char* defaultValue) {
+void ConsoleVariable::RegisterString(const std::string& name, const char* defaultValue) {
     if (Get(name) == nullptr) {
         SetString(name, defaultValue);
     }
 }
 
-void ConsoleVariable::RegisterColor(const char* name, Color_RGBA8 defaultValue) {
+void ConsoleVariable::RegisterColor(const std::string& name, Color_RGBA8 defaultValue) {
     if (Get(name) == nullptr) {
         SetColor(name, defaultValue);
     }
 }
 
-void ConsoleVariable::RegisterColor24(const char* name, Color_RGB8 defaultValue) {
+void ConsoleVariable::RegisterColor24(const std::string& name, Color_RGB8 defaultValue) {
     if (Get(name) == nullptr) {
         SetColor24(name, defaultValue);
     }
 }
 
-void ConsoleVariable::ClearVariable(const char* name) {
+void ConsoleVariable::ClearVariable(const std::string& name) {
     std::shared_ptr<Mercury> conf = Ship::Window::GetInstance()->GetConfig();
     mVariables.erase(name);
-    conf->erase(StringHelper::Sprintf("CVars.%s", name));
+    conf->erase(StringHelper::Sprintf("CVars.%s", name.c_str()));
+    mVariables_New.erase(name);
+    conf->erase(StringHelper::Sprintf("CVars2.%s", name.c_str()));
 }
 
 void ConsoleVariable::Save() {
@@ -194,6 +241,35 @@ void ConsoleVariable::Save() {
         }
     }
 
+    for (const auto& variable : mVariables_New) {
+        if (variable.second->ShouldSave()) {
+            const std::string key = StringHelper::Sprintf("CVars2.%s", variable.first.c_str());
+            CVarInterface::VauleType cvarValue = variable.second->Get();
+            if (int32_t* data = std::get_if<int32_t>(&cvarValue)) {
+                conf->setInt(key, *data);
+            } else if (float* data = std::get_if<float>(&cvarValue)) {
+                conf->setFloat(key, *data);
+            } else if (std::string* data = std::get_if<std::string>(&cvarValue)) {
+                if (data->length() > 0) {
+                    conf->setString(key, *data);
+                }
+            } else if (Color_RGBA8* data = std::get_if<Color_RGBA8>(&cvarValue)) {
+                const char* keyStr = key.c_str();
+                conf->setUInt(StringHelper::Sprintf("%s.R", keyStr), data->r);
+                conf->setUInt(StringHelper::Sprintf("%s.G", keyStr), data->g);
+                conf->setUInt(StringHelper::Sprintf("%s.B", keyStr), data->b);
+                conf->setUInt(StringHelper::Sprintf("%s.A", keyStr), data->a);
+                conf->setString(StringHelper::Sprintf("%s.Type", keyStr), mercuryRGBAObjectType);
+            } else if (Color_RGB8* data = std::get_if<Color_RGB8>(&cvarValue)) {
+                const char* keyStr = key.c_str();
+                conf->setUInt(StringHelper::Sprintf("%s.R", keyStr), data->r);
+                conf->setUInt(StringHelper::Sprintf("%s.G", keyStr), data->g);
+                conf->setUInt(StringHelper::Sprintf("%s.B", keyStr), data->b);
+                conf->setString(StringHelper::Sprintf("%s.Type", keyStr), mercuryRGBObjectType);
+            }
+        }
+    }
+
     conf->save();
 }
 
@@ -202,6 +278,7 @@ void ConsoleVariable::Load() {
     conf->reload();
 
     LoadFromPath("", conf->rjson["CVars"].items());
+    LoadFromPath("", conf->rjson["CVars2"].items());
 
     LoadLegacy();
 }
@@ -225,35 +302,36 @@ void ConsoleVariable::LoadFromPath(
                     clr.g = value["G"].get<uint8_t>();
                     clr.b = value["B"].get<uint8_t>();
                     clr.a = value["A"].get<uint8_t>();
-                    SetColor(itemPath.c_str(), clr);
+                    SetColor(itemPath, clr);
                 } else if (value.contains("Type") && value["Type"].get<std::string>() == mercuryRGBObjectType) {
                     Color_RGB8 clr;
                     clr.r = value["R"].get<uint8_t>();
                     clr.g = value["G"].get<uint8_t>();
                     clr.b = value["B"].get<uint8_t>();
-                    SetColor24(itemPath.c_str(), clr);
+                    SetColor24(itemPath, clr);
                 } else {
                     LoadFromPath(itemPath, value.items());
                 }
 
                 break;
             case nlohmann::detail::value_t::string:
-                SetString(itemPath.c_str(), value.get<std::string>().c_str());
+                SetString(itemPath, value.get<std::string>().c_str());
                 break;
             case nlohmann::detail::value_t::boolean:
-                SetInteger(itemPath.c_str(), value.get<bool>());
+                SetInteger(itemPath, value.get<bool>());
                 break;
             case nlohmann::detail::value_t::number_unsigned:
             case nlohmann::detail::value_t::number_integer:
-                SetInteger(itemPath.c_str(), value.get<int>());
+                SetInteger(itemPath, value.get<int>());
                 break;
             case nlohmann::detail::value_t::number_float:
-                SetFloat(itemPath.c_str(), value.get<float>());
+                SetFloat(itemPath, value.get<float>());
                 break;
             default:;
         }
     }
 }
+
 void ConsoleVariable::LoadLegacy() {
     auto conf = Ship::Window::GetPathRelativeToAppDirectory("cvars.cfg");
     if (File::Exists(conf)) {
@@ -302,4 +380,5 @@ void ConsoleVariable::LoadLegacy() {
         fs::remove(conf);
     }
 }
+
 } // namespace Ship

--- a/src/core/ConsoleVariable.h
+++ b/src/core/ConsoleVariable.h
@@ -4,14 +4,72 @@
 #include <nlohmann/json.hpp>
 #include <stdint.h>
 #include <memory>
-#include <map>
 #include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <variant>
 
 namespace Ship {
 typedef enum class ConsoleVariableType { Integer, Float, String, Color, Color24 } ConsoleVariableType;
 typedef union CVarValue {
 
 } CVarValue;
+
+class CVarInterface {
+  public:
+    using VauleType = std::variant<int32_t, float, std::string, Color_RGBA8, Color_RGB8>;
+
+    CVarInterface() = default;
+    virtual ~CVarInterface() = default;
+
+    virtual VauleType Get() const = 0;
+
+    virtual void Set(const VauleType&) = 0;
+
+    virtual bool ShouldSave() = 0;
+};
+
+template<class StorageType>
+class CVarDefaulted : public CVarInterface {
+
+    using DefualtType = std::remove_reference<StorageType>::type;
+
+  public:
+    CVarDefaulted(StorageType& initialValue, const DefualtType& defaultValue) :
+        mValue(initialValue),
+        mDefault(defaultValue)
+    {
+    };
+
+    virtual ~CVarDefaulted() = default;
+
+    VauleType Get() const override {
+        return VauleType{ mValue };
+    }
+
+    void Set(const VauleType& newValue) override {
+        // TODO assert type
+        if (const DefualtType* value = std::get_if<DefualtType>(&newValue)) {
+            mValue = *value;
+        }
+    }
+
+    bool ShouldSave() override {
+        return mValue != mDefault;
+    }
+
+  private:
+    StorageType mValue;
+    const DefualtType mDefault;
+};
+
+// Represents a CVar with embedded storage i.e. the lifetime of the value matches the lifetime of the CVar
+template<typename T>
+using CVarEmbedded = CVarDefaulted<T>;
+
+// Represents a CVar with embedded storage i.e. the lifetime of the value is independent of that of the CVar's
+template<typename T>
+using CVarManaged = CVarDefaulted<T&>;
 
 typedef struct CVar {
     const char* Name;
@@ -27,37 +85,86 @@ class ConsoleVariable {
   public:
     ConsoleVariable();
 
-    std::shared_ptr<CVar> Get(const char* name);
+    std::shared_ptr<CVar> Get(const std::string& name);
 
-    int32_t GetInteger(const char* name, int32_t defaultValue);
-    float GetFloat(const char* name, float defaultValue);
-    const char* GetString(const char* name, const char* defaultValue);
-    Color_RGBA8 GetColor(const char* name, Color_RGBA8 defaultValue);
-    Color_RGB8 GetColor24(const char* name, Color_RGB8 defaultValue);
+    int32_t GetInteger(const std::string& name, int32_t defaultValue);
+    float GetFloat(const std::string& name, float defaultValue);
+    const char* GetString(const std::string& name, const char* defaultValue);
+    Color_RGBA8 GetColor(const std::string& name, Color_RGBA8 defaultValue);
+    Color_RGB8 GetColor24(const std::string& name, Color_RGB8 defaultValue);
 
-    void SetInteger(const char* name, int32_t value);
-    void SetFloat(const char* name, float value);
-    void SetString(const char* name, const char* value);
-    void SetColor(const char* name, Color_RGBA8 value);
-    void SetColor24(const char* name, Color_RGB8 value);
+    void SetInteger(const std::string& name, int32_t value);
+    void SetFloat(const std::string& name, float value);
+    void SetString(const std::string& name, const char* value);
+    void SetColor(const std::string& name, Color_RGBA8 value);
+    void SetColor24(const std::string& name, Color_RGB8 value);
 
-    void RegisterInteger(const char* name, int32_t defaultValue);
-    void RegisterFloat(const char* name, float defaultValue);
-    void RegisterString(const char* name, const char* defaultValue);
-    void RegisterColor(const char* name, Color_RGBA8 defaultValue);
-    void RegisterColor24(const char* name, Color_RGB8 defaultValue);
+    void RegisterInteger(const std::string& name, int32_t defaultValue);
+    void RegisterFloat(const std::string& name, float defaultValue);
+    void RegisterString(const std::string& name, const char* defaultValue);
+    void RegisterColor(const std::string& name, Color_RGBA8 defaultValue);
+    void RegisterColor24(const std::string& name, Color_RGB8 defaultValue);
 
-    void ClearVariable(const char* name);
+    void ClearVariable(const std::string& name);
+
+    template<typename T>
+    T Get(const std::string& name) {
+        auto cvarIter = mVariables_New.find(name);
+        if (cvarIter == mVariables_New.end()) {
+            // TODO assert? CVar was not registered/created
+            return T{};
+        }
+
+        auto cvarValue = cvarIter->second->Get();
+        if (const T* ret = std::get_if<T>(&cvarValue)) {
+            return *ret;
+        }
+
+        // TODO assert? Incorrect type is probably a mistake
+
+        return T{};
+    }
+    
+    template<typename T>
+    void Set(const std::string& name, const T& value) {
+        auto cvarIter = mVariables_New.find(name);
+        if (cvarIter == mVariables_New.end()) {
+            // TODO assert? CVar was not registered/created
+            return;
+        }
+
+        cvarIter->second->Set(value);
+    }
+
+    // Creates a CVar that manages the value
+    template <typename T>
+    void RegisterEmbedded(const std::string& name, T value) {
+        if (mVariables_New.find(name) != mVariables_New.end()) {
+            return;
+        }
+
+        mVariables_New[name] = std::make_unique<CVarEmbedded<T>>(value, value);
+    }
+
+    // Creates a CVar that tracks the value
+    template <typename T>
+    void RegisterManaged(const std::string& name, T& value) {
+        if (mVariables_New.find(name) != mVariables_New.end()) {
+            return;
+        }
+
+        mVariables_New[name] = std::make_unique<CVarManaged<T>>(value, value);
+    }
 
     void Save();
     void Load();
 
-  protected:
+  private:
     void LoadFromPath(std::string path,
                       nlohmann::detail::iteration_proxy<nlohmann::detail::iter_impl<nlohmann::json>> items);
     void LoadLegacy();
 
-  private:
-    std::map<std::string, std::shared_ptr<CVar>, std::less<>> mVariables;
+    std::unordered_map<std::string, std::shared_ptr<CVar>> mVariables;
+    std::unordered_map<std::string, std::unique_ptr<CVarInterface>> mVariables_New;
 };
 } // namespace Ship

--- a/src/core/Window.cpp
+++ b/src/core/Window.cpp
@@ -99,6 +99,8 @@ void Window::Initialize(const std::vector<std::string>& otrFiles, const std::uno
     InitializeControlDeck();
     InitializeCrashHandler();
 
+    CVarLoad();
+
     bool steamDeckGameMode = false;
 
 #ifdef __linux__
@@ -364,6 +366,8 @@ void Window::InitializeControlDeck() {
 
 void Window::InitializeConsoleVariables() {
     mConsoleVariables = std::make_shared<ConsoleVariable>();
+
+    Ship::ExecuteHooks<Ship::CVarInit>();
 }
 
 void Window::InitializeCrashHandler() {

--- a/src/menu/ImGuiImpl.cpp
+++ b/src/menu/ImGuiImpl.cpp
@@ -377,7 +377,6 @@ void LoadTexture(const std::string& name, const std::string& path) {
 // MARK: - Public API
 
 void Init(WindowImpl window_impl) {
-    CVarLoad();
     impl = window_impl;
     ImGuiContext* ctx = ImGui::CreateContext();
     ImGui::SetCurrentContext(ctx);

--- a/src/misc/Hooks.h
+++ b/src/misc/Hooks.h
@@ -30,4 +30,5 @@ DEFINE_HOOK(GfxInit, void());
 DEFINE_HOOK(ExitGame, void());
 DEFINE_HOOK(LoadFile, void(uint32_t fileNum));
 DEFINE_HOOK(DeleteFile, void(uint32_t fileNum));
+DEFINE_HOOK(CVarInit, void());
 } // namespace Ship


### PR DESCRIPTION
This is a WIP example of reworking CVars to solve several issues with them. This is the LUS side of things, for the SoH PR, see https://github.com/HarbourMasters/Shipwright/pull/2552.

The issues I am trying to fix:

- CVar lookup is expensive since it involves a map lookup. It is one of the most expensive things that occurs in the game update loop (so outside of graphics/rendering)
- CVar usage is error-prone. Since they are identified with strings, and defaulted if they don't exist (a common occurrence since they don't exist until they are changed), there is potential for misspellings to result in bugs that go undetected.

To remedy this, I have introduced a new interface for CVars. The core idea is to disassociate CVars and their storage of data. That is, there are CVars and store the value they name, and also ones that just associate that name to a value stored elsewhere. This enables CVars to just be used as a name for a regular C variable, allowing clients of CVars to safely use that data without any additional overhead, whether that overhead be in access time or bug potential.

This PR adds this new interface alongside the old so I could used and test it, so it is a bit awkward. The intent is to entirely replace the old one, so in judging it, I would ask you to consider only the new additions, and not the modifications to the existing interface. I will try to note points of interest.