### PR TITLE
[Renderer] Fix graphics switching on macOS

### DIFF
--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -332,6 +332,7 @@ static void gfx_sdl_init(const char* game_name, const char* gfx_api_name, bool s
         SDL_GL_SetSwapInterval(1);
 
         window_impl.Opengl = { wnd, ctx };
+        window_impl.backend = SohImGui::Backend::SDL_OPENGL;
     } else {
         renderer = SDL_CreateRenderer(wnd, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
         if (renderer == NULL) {
@@ -341,9 +342,9 @@ static void gfx_sdl_init(const char* game_name, const char* gfx_api_name, bool s
 
         SDL_GetRendererOutputSize(renderer, &window_width, &window_height);
         window_impl.Metal = { wnd, renderer };
+        window_impl.backend = SohImGui::Backend::SDL_METAL;
     }
 
-    window_impl.backend = SohImGui::Backend::SDL;
     SohImGui::Init(window_impl);
 
     for (size_t i = 0; i < sizeof(windows_scancode_table) / sizeof(SDL_Scancode); i++) {

--- a/src/menu/ImGuiImpl.cpp
+++ b/src/menu/ImGuiImpl.cpp
@@ -35,7 +35,7 @@
 #include "graphic/Fast3D/gfx_gx2.h"
 #endif
 
-#if __APPLE__
+#ifdef __APPLE__
 #include <SDL_hints.h>
 #include <SDL_video.h>
 
@@ -202,15 +202,17 @@ void ImGuiWMInit() {
             ImGui_ImplWiiU_Init();
             break;
 #else
-        case Backend::SDL:
+        case Backend::SDL_OPENGL:
             SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "1");
-            if (impl.Metal.Window) {
-                ImGui_ImplSDL2_InitForMetal(static_cast<SDL_Window*>(impl.Metal.Window));
-                break;
-            }
-
             SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
             ImGui_ImplSDL2_InitForOpenGL(static_cast<SDL_Window*>(impl.Opengl.Window), impl.Opengl.Context);
+            break;
+#endif
+#if __APPLE__
+        case Backend::SDL_METAL:
+            SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "1");
+            SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+            ImGui_ImplSDL2_InitForMetal(static_cast<SDL_Window*>(impl.Metal.Window));
             break;
 #endif
 #if defined(ENABLE_DX11) || defined(ENABLE_DX12)
@@ -230,17 +232,18 @@ void ImGuiBackendInit() {
             ImGui_ImplGX2_Init();
             break;
 #else
-        case Backend::SDL:
+        case Backend::SDL_OPENGL:
 #ifdef __APPLE__
-            if (impl.Metal.Renderer) {
-                Metal_Init(impl.Metal.Renderer);
-                break;
-            }
-
             ImGui_ImplOpenGL3_Init("#version 410 core");
 #else
             ImGui_ImplOpenGL3_Init("#version 120");
 #endif
+            break;
+#endif
+
+#ifdef __APPLE__
+        case Backend::SDL_METAL:
+            Metal_Init(impl.Metal.Renderer);
             break;
 #endif
 
@@ -262,7 +265,8 @@ void ImGuiProcessEvent(EventImpl event) {
             if (!ImGui_ImplWiiU_ProcessInput((ImGui_ImplWiiU_ControllerInput*)event.Gx2.Input)) {}
             break;
 #else
-        case Backend::SDL:
+        case Backend::SDL_OPENGL:
+        case Backend::SDL_METAL:
             ImGui_ImplSDL2_ProcessEvent(static_cast<const SDL_Event*>(event.Sdl.Event));
 
 #ifdef __SWITCH__
@@ -287,7 +291,8 @@ void ImGuiWMNewFrame() {
         case Backend::GX2:
             break;
 #else
-        case Backend::SDL:
+        case Backend::SDL_OPENGL:
+        case Backend::SDL_METAL:
             ImGui_ImplSDL2_NewFrame();
             break;
 #endif
@@ -309,14 +314,13 @@ void ImGuiBackendNewFrame() {
             ImGui_ImplGX2_NewFrame();
             break;
 #else
-        case Backend::SDL:
-#ifdef __APPLE__
-            if (impl.Metal.Renderer) {
-                Metal_NewFrame(impl.Metal.Renderer);
-                break;
-            }
-#endif
+        case Backend::SDL_OPENGL:
             ImGui_ImplOpenGL3_NewFrame();
+            break;
+#endif
+#ifdef __APPLE__
+        case Backend::SDL_METAL:
+            Metal_NewFrame(impl.Metal.Renderer);
             break;
 #endif
 #if defined(ENABLE_DX11) || defined(ENABLE_DX12)
@@ -341,14 +345,13 @@ void ImGuiRenderDrawData(ImDrawData* data) {
             ImGui_ImplWiiU_DrawKeyboardOverlay();
             break;
 #else
-        case Backend::SDL:
-#ifdef __APPLE__
-            if (impl.Metal.Renderer) {
-                Metal_RenderDrawData(data);
-                break;
-            }
-#endif
+        case Backend::SDL_OPENGL:
             ImGui_ImplOpenGL3_RenderDrawData(data);
+            break;
+#endif
+#ifdef __APPLE__
+        case Backend::SDL_METAL:
+            Metal_RenderDrawData(data);
             break;
 #endif
 #if defined(ENABLE_DX11) || defined(ENABLE_DX12)
@@ -368,7 +371,8 @@ bool SupportsWindowedFullscreen() {
 
     // We don't yet support windowed fullscreen on DirectX
     switch (impl.backend) {
-        case Backend::SDL:
+        case Backend::SDL_OPENGL:
+        case Backend::SDL_METAL:
             return true;
         default:
             return false;
@@ -383,7 +387,8 @@ bool SupportsViewports() {
     switch (impl.backend) {
         case Backend::DX11:
             return true;
-        case Backend::SDL:
+        case Backend::SDL_OPENGL:
+        case Backend::SDL_METAL:
             return true;
         default:
             return false;
@@ -621,7 +626,7 @@ void DrawMainMenuAndCalculateGameSize(void) {
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, windowPadding);
         if (ImGui::BeginMenu("Shipwright")) {
             if (ImGui::MenuItem("Reset",
-#if __APPLE__
+#ifdef __APPLE__
                                 "Command-R"
 #else
                                 "Ctrl+R"
@@ -838,7 +843,8 @@ void Render() {
     ImGui::Render();
     ImGuiRenderDrawData(ImGui::GetDrawData());
     if (io->ConfigFlags & ImGuiConfigFlags_ViewportsEnable) {
-        if (impl.backend == Backend::SDL && impl.Opengl.Context != nullptr) {
+        if ((impl.backend == Backend::SDL_OPENGL || impl.backend == Backend::SDL_METAL) &&
+            impl.Opengl.Context != nullptr) {
             SDL_Window* backupCurrentWindow = SDL_GL_GetCurrentWindow();
             SDL_GLContext backupCurrentContext = SDL_GL_GetCurrentContext();
 
@@ -978,7 +984,7 @@ ImTextureID GetTextureByID(int id) {
     }
 #endif
 #ifdef __APPLE__
-    if (impl.Metal.Window) {
+    if (impl.backend == Backend::SDL_METAL) {
         return gfx_metal_get_texture_by_id(id);
     }
 #endif

--- a/src/menu/ImGuiImpl.h
+++ b/src/menu/ImGuiImpl.h
@@ -16,7 +16,8 @@ struct GameAsset {
 namespace SohImGui {
 enum class Backend {
     DX11,
-    SDL,
+    SDL_OPENGL,
+    SDL_METAL,
     GX2,
 };
 


### PR DESCRIPTION
Fixes a bug caused by the union of graphics option, now correctly splits the backends