### PR TITLE
gfx_opengl.cpp: OpenGL / GLSL optimizations

### DIFF
--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -254,8 +254,8 @@ static void append_rand_function(char* buf, size_t* len) {
     append_line(buf, len, "uniform float noise_scale;");
 
     append_line(buf, len, "float random(in vec3 value) {");
-    append_line(buf, len, "    float random = dot(sin(value), vec3(12.9898, 78.233, 37.719));");
-    append_line(buf, len, "    return fract(sin(random) * 143758.5453);");
+    append_line(buf, len, "float random = dot(sin(value), vec3(12.9898, 78.233, 37.719));");
+    append_line(buf, len, "return fract(sin(random) * 143758.5453);");
     append_line(buf, len, "}");
 }
 
@@ -481,7 +481,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
         }
     }
 
-    append_line(fs_buf, &fs_len, cc_features.opt_alpha ? "vec4 texel;" : "vec3 texel;");
+    append_str(fs_buf, &fs_len, cc_features.opt_alpha ? "vec4 " : "vec3 ");
     for (int c = 0; c < (cc_features.opt_2cyc ? 2 : 1); c++) {
         append_str(fs_buf, &fs_len, "texel = ");
         if (!cc_features.color_alpha_same[c] && cc_features.opt_alpha) {

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -430,7 +430,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
             append_line(fs_buf, &fs_len, "vec4 c1 = TEX_OFFSET(vec2(offset.x - sign(offset.x), offset.y));");
             append_line(fs_buf, &fs_len, "vec4 c2 = TEX_OFFSET(vec2(offset.x, offset.y - sign(offset.y)));");
             append_line(fs_buf, &fs_len, "return c0 + abs(offset.x)*(c1-c0) + abs(offset.y)*(c2-c0);");
-    } else {
+        } else {
             append_line(fs_buf, &fs_len, "vec4 hookTexture2D(in sampler2D tex, in vec2 texCoord, in vec2 texSize) {");
 #if __APPLE__
             append_line(fs_buf, &fs_len, "return texture(tex, texCoord);");
@@ -552,7 +552,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
     }
     append_line(fs_buf, &fs_len, "}");
 
-    if(!used_noise && used_rand) {
+    if (!used_noise && used_rand) {
         append_rand_function(fs_buf, &fs_len);
     }
 


### PR DESCRIPTION
With this PR I propose the following changes:

1. **reduction of `glUniform`-calls**: previously, once per frame every `ShaderProgram` received two `glUniform` calls. One to update the `frame_count` and one for `noise_scale`. For the OpenGL-renderer, both variables were only used for the GLSL function `random(vec3)` which isn't actually used in most shaders within SOH. To avoid this I introduced a variable `used_noise` into `ShaderProgram` which determines whether the `glUniform` calls are made or not. (Note: I apparently wasn't the first one with this idea, as the renderer `gfx_gx2.cpp` uses a similar approach)
2. **removal of unused GLSL functions**: both `random(vec3)` and `hookTexture2D(sampler2D, vec2, vec2)` were only used in specific situations and don't need to be included in every GLSL-shader. I simply introduced appropriate conditions to include them in the shader source.
3. **limitation of frame_count**: the renderers for dx11, dx12 and metal do this, too. I'm not actually sure if this is needed within SOH as this change seems to originate from the original SM64 renderer. Since I'm uncertain where this shader noise is used in SOH I couldn't test and compare this change but I thought it might make sense for the renderers to behave as similarily to each other as possible.