### PR TITLE
fix: lowercase package names for vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows" AND USE_AUTO_VCPKG)
     set(VCPKG_TARGET_TRIPLET x64-windows-static)
 
     vcpkg_bootstrap()
-    vcpkg_install_packages(zlib bzip2 SDL2 GLEW)
+    vcpkg_install_packages(zlib bzip2 sdl2 glew)
 endif()
 
 add_subdirectory("extern")

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(OpenGL QUIET)
 
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
-    find_package(SDL2 CONFIG REQUIRED)
+    find_package(sdl2 CONFIG REQUIRED)
 else()
     find_package(SDL2 REQUIRED)
 endif()

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(OpenGL QUIET)
 
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
-    find_package(sdl2 CONFIG REQUIRED)
+    find_package(SDL2 CONFIG REQUIRED)
 else()
     find_package(SDL2 REQUIRED)
 endif()


### PR DESCRIPTION
vcpkg was throwing an error `error: invalid character in package name (must be lowercase, digits, '-')`
when looking on https://vcpkg.io/en/packages.html, both `glew` and `sdl2` are listed using lowercase
this updates our call to `vcpkg_install_packages` to use lowercase package names instead of uppercase