### PR TITLE
add methods to get macos app bundle path

### DIFF
--- a/src/core/Window.cpp
+++ b/src/core/Window.cpp
@@ -145,6 +145,21 @@ void Window::Close() {
     mWindowManagerApi->close();
 }
 
+std::string Window::GetAppBundlePath() {
+#ifdef __APPLE__
+    FolderManager folderManager;
+    return folderManager.getMainBundlePath();
+#endif
+
+#ifdef __linux__
+    char* fpath = std::getenv("SHIP_HOME");
+    if (fpath != NULL)
+        return std::string(fpath);
+#endif
+
+    return ".";
+}
+
 std::string Window::GetAppDirectoryPath() {
 #ifdef __APPLE__
     FolderManager folderManager;
@@ -160,6 +175,10 @@ std::string Window::GetAppDirectoryPath() {
 #endif
 
     return ".";
+}
+
+std::string Window::GetPathRelativeToAppBundle(const char* path) {
+    return GetAppBundlePath() + "/" + path;
 }
 
 std::string Window::GetPathRelativeToAppDirectory(const char* path) {

--- a/src/core/Window.cpp
+++ b/src/core/Window.cpp
@@ -153,8 +153,9 @@ std::string Window::GetAppBundlePath() {
 
 #ifdef __linux__
     char* fpath = std::getenv("SHIP_HOME");
-    if (fpath != NULL)
+    if (fpath != NULL) {
         return std::string(fpath);
+    }
 #endif
 
     return ".";
@@ -170,8 +171,9 @@ std::string Window::GetAppDirectoryPath() {
 
 #ifdef __linux__
     char* fpath = std::getenv("SHIP_HOME");
-    if (fpath != NULL)
+    if (fpath != NULL) {
         return std::string(fpath);
+    }
 #endif
 
     return ".";

--- a/src/core/Window.h
+++ b/src/core/Window.h
@@ -23,8 +23,10 @@ class Window {
     static std::shared_ptr<Window> GetInstance();
     static std::shared_ptr<Window> CreateInstance(const std::string name, const std::vector<std::string>& otrFiles = {},
                                                   const std::unordered_set<uint32_t>& validHashes = {});
+    static std::string GetAppBundlePath();
     static std::string GetAppDirectoryPath();
     static std::string GetPathRelativeToAppDirectory(const char* path);
+    static std::string GetPathRelativeToAppBundle(const char* path);
 
     Window(std::string Name);
     ~Window();

--- a/src/misc/OSXFolderManager.h
+++ b/src/misc/OSXFolderManager.h
@@ -57,6 +57,7 @@ class FolderManager {
     FolderManager();
     ~FolderManager();
 
+    const char* getMainBundlePath();
     const char* pathForDirectory(SearchPathDirectory directory, SearchPathDomainMask domainMask);
     const char* pathForDirectoryAppropriateForItemAtPath(SearchPathDirectory directory, SearchPathDomainMask domainMask,
                                                          const char* itemPath, bool create = false);

--- a/src/misc/OSXFolderManager.mm
+++ b/src/misc/OSXFolderManager.mm
@@ -18,6 +18,11 @@ FolderManager::~FolderManager() {
     [(NSAutoreleasePool *)m_autoreleasePool release];
 }
 
+const char * FolderManager::getMainBundlePath() {
+    NSString *bundlePath = [[NSBundle mainBundle] resourcePath];
+    return [bundlePath UTF8String];
+}
+
 const char * FolderManager::pathForDirectory(SearchPathDirectory directory, SearchPathDomainMask domainMask) {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSArray *URLs = [fileManager URLsForDirectory:(NSSearchPathDirectory)directory inDomains:domainMask];


### PR DESCRIPTION
This adds methods to get the app bundle path on mac which will return the corresponding locations in the following scenarios:
* local development: `build-cmake/soh` (where the soh-macos and otr files are placed)
* release app: `xxx/soh.app/Contents/Resources`

Then files can be bundled into the resources folder within the app to be read later.