### PR TITLE
Add shader support for some CPU-modified textures in OpenGL and D3D11

### DIFF
--- a/src/core/bridge/resourcebridge.cpp
+++ b/src/core/bridge/resourcebridge.cpp
@@ -193,24 +193,4 @@ void UnloadResourceByCrc(uint64_t crc) {
 void UnloadResourceDirectory(const char* name) {
     Ship::Window::GetInstance()->GetResourceManager()->UnloadDirectory(name);
 }
-
-void WriteTextureDataInt16ByName(const char* name, size_t index, int16_t valueToWrite, bool now) {
-    const auto res = static_pointer_cast<Ship::Texture>(LoadResource(name, now));
-
-    if (res != nullptr) {
-        if ((index * sizeof(int16_t)) < res->ImageDataSize) {
-            ((int16_t*)res->ImageData)[index] = valueToWrite;
-        }
-    }
-}
-
-void WriteTextureDataInt16ByCrc(uint64_t crc, size_t index, int16_t valueToWrite, bool now) {
-    const auto res = static_pointer_cast<Ship::Texture>(LoadResource(crc, now));
-
-    if (res != nullptr) {
-        if ((index * sizeof(int16_t)) < res->ImageDataSize) {
-            ((int16_t*)res->ImageData)[index] = valueToWrite;
-        }
-    }
-}
 }

--- a/src/core/bridge/resourcebridge.h
+++ b/src/core/bridge/resourcebridge.h
@@ -40,8 +40,6 @@ void UnloadResourceByName(const char* name);
 void UnloadResourceByCrc(uint64_t crc);
 void UnloadResourceDirectory(const char* name);
 void ClearResourceCache(void);
-void WriteTextureDataInt16ByName(const char* name, size_t index, int16_t valueToWrite, bool now);
-void WriteTextureDataInt16ByCrc(uint64_t crc, size_t index, int16_t valueToWrite, bool now);
 
 #ifdef __cplusplus
 };

--- a/src/graphic/Fast3D/gfx_cc.cpp
+++ b/src/graphic/Fast3D/gfx_cc.cpp
@@ -25,6 +25,10 @@ void gfx_cc_get_features(uint64_t shader_id0, uint32_t shader_id1, struct CCFeat
 
     cc_features->used_textures[0] = false;
     cc_features->used_textures[1] = false;
+    cc_features->used_masks[0] = false;
+    cc_features->used_masks[1] = false;
+    cc_features->used_blend[0] = false;
+    cc_features->used_blend[1] = false;
     cc_features->num_inputs = 0;
 
     for (int c = 0; c < 2; c++) {
@@ -54,5 +58,19 @@ void gfx_cc_get_features(uint64_t shader_id0, uint32_t shader_id1, struct CCFeat
         cc_features->do_mix[c][1] = cc_features->c[c][1][1] == cc_features->c[c][1][3];
         cc_features->color_alpha_same[c] =
             ((shader_id0 >> c * 32) & 0xffff) == ((shader_id0 >> (c * 32 + 16)) & 0xffff);
+    }
+
+    if (cc_features->used_textures[0] && (shader_id1 & SHADER_OPT_TEXEL0_MASK)) {
+        cc_features->used_masks[0] = true;
+    }
+    if (cc_features->used_textures[1] && (shader_id1 & SHADER_OPT_TEXEL1_MASK)) {
+        cc_features->used_masks[1] = true;
+    }
+
+    if (cc_features->used_textures[0] && (shader_id1 & SHADER_OPT_TEXEL0_BLEND)) {
+        cc_features->used_blend[0] = true;
+    }
+    if (cc_features->used_textures[1] && (shader_id1 & SHADER_OPT_TEXEL1_BLEND)) {
+        cc_features->used_blend[1] = true;
     }
 }

--- a/src/graphic/Fast3D/gfx_cc.h
+++ b/src/graphic/Fast3D/gfx_cc.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <compare>
 
 /*enum {
     CC_0,
@@ -45,7 +46,22 @@ enum {
 #define SHADER_OPT_TEXEL0_CLAMP_T (1 << 9)
 #define SHADER_OPT_TEXEL1_CLAMP_S (1 << 10)
 #define SHADER_OPT_TEXEL1_CLAMP_T (1 << 11)
-#define CC_SHADER_OPT_POS 56
+#define SHADER_OPT_TEXEL0_MASK (1 << 12)
+#define SHADER_OPT_TEXEL1_MASK (1 << 13)
+#define SHADER_OPT_TEXEL0_BLEND (1 << 14)
+#define SHADER_OPT_TEXEL1_BLEND (1 << 15)
+
+struct ColorCombinerKey {
+    uint64_t combine_mode;
+    uint64_t options;
+
+    auto operator<=>(const ColorCombinerKey&) const = default;
+};
+
+#define SHADER_MAX_TEXURES 6
+#define SHADER_FIRST_TEXTURE 0
+#define SHADER_FIRST_MASK_TEXTURE 2
+#define SHADER_FIRST_REPLACEMENT_TEXTURE 4
 
 struct CCFeatures {
     uint8_t c[2][2][4];
@@ -58,6 +74,8 @@ struct CCFeatures {
     bool opt_invisible;
     bool opt_grayscale;
     bool used_textures[2];
+    bool used_masks[2];
+    bool used_blend[2];
     bool clamp[2][2];
     int num_inputs;
     bool do_single[2][2];

--- a/src/graphic/Fast3D/gfx_direct3d_common.cpp
+++ b/src/graphic/Fast3D/gfx_direct3d_common.cpp
@@ -326,7 +326,8 @@ void gfx_direct3d_common_build_shader(char buf[8192], size_t& len, size_t& num_f
                                    "float2(textures[%d].width, textures[%d].height));\r\n",
                                    i, i, i, i, i, i);
                     len += sprintf(buf + len, "        float2 maskSize%d;\r\n", i);
-                    len += sprintf(buf + len, "        g_textureMask%d.GetDimensions(maskSize%d.x, maskSize%d.y);\r\n", i, i, i);
+                    len += sprintf(buf + len, "        g_textureMask%d.GetDimensions(maskSize%d.x, maskSize%d.y);\r\n",
+                                   i, i, i);
                     len += sprintf(buf + len,
                                    "        float4 maskVal%d = tex2D3PointFilter(g_textureMask%d, g_sampler%d, tc%d, "
                                    "maskSize%d);\r\n",
@@ -339,8 +340,8 @@ void gfx_direct3d_common_build_shader(char buf[8192], size_t& len, size_t& num_f
                     } else {
                         len += sprintf(buf + len, "        float4 blendVal%d = float4(0, 0, 0, 0);\r\n", i);
                     }
-                    len +=
-                        sprintf(buf + len, "        texVal%d = lerp(texVal%d, blendVal%d, maskVal%d.a);\r\n", i, i, i, i);
+                    len += sprintf(buf + len, "        texVal%d = lerp(texVal%d, blendVal%d, maskVal%d.a);\r\n", i, i,
+                                   i, i);
                 } else {
                     len += sprintf(buf + len,
                                    "        texVal%d = tex2D3PointFilter(g_texture%d, g_sampler%d, tc%d, "
@@ -356,8 +357,8 @@ void gfx_direct3d_common_build_shader(char buf[8192], size_t& len, size_t& num_f
                 if (cc_features.used_masks[i]) {
                     if (cc_features.used_blend[i]) {
                         len += sprintf(buf + len,
-                                       "    float4 blendVal%d = g_textureBlend%d.Sample(g_sampler%d, tc%d);\r\n", i,
-                                i, i, i);
+                                       "    float4 blendVal%d = g_textureBlend%d.Sample(g_sampler%d, tc%d);\r\n", i, i,
+                                       i, i);
                     } else {
                         len += sprintf(buf + len, "    float4 blendVal%d = float4(0, 0, 0, 0);\r\n", i);
                     }

--- a/src/graphic/Fast3D/gfx_direct3d_common.h
+++ b/src/graphic/Fast3D/gfx_direct3d_common.h
@@ -7,7 +7,7 @@
 
 #include "gfx_cc.h"
 
-void gfx_direct3d_common_build_shader(char buf[4096], size_t& len, size_t& num_floats, const CCFeatures& cc_features,
+void gfx_direct3d_common_build_shader(char buf[8192], size_t& len, size_t& num_floats, const CCFeatures& cc_features,
                                       bool include_root_signature, bool three_point_filtering);
 
 #endif

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -462,14 +462,20 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
                 fs_len += sprintf(fs_buf + fs_len, "vec2 vTexCoordAdj%d = vTexCoord%d;\n", i, i);
             } else {
                 if (s && t) {
-                    fs_len += sprintf(fs_buf + fs_len, "vec2 vTexCoordAdj%d = clamp(vTexCoord%d, 0.5 / texSize%d, "
-                                      "vec2(vTexClampS%d, vTexClampT%d));\n", i, i, i, i, i);
+                    fs_len += sprintf(fs_buf + fs_len,
+                                      "vec2 vTexCoordAdj%d = clamp(vTexCoord%d, 0.5 / texSize%d, "
+                                      "vec2(vTexClampS%d, vTexClampT%d));\n",
+                                      i, i, i, i, i);
                 } else if (s) {
-                    fs_len += sprintf(fs_buf + fs_len, "vec2 vTexCoordAdj%d = vec2(clamp(vTexCoord%d.s, 0.5 / "
-                                      "texSize%d.s, vTexClampS%d), vTexCoord%d.t);\n", i, i, i, i, i);
+                    fs_len += sprintf(fs_buf + fs_len,
+                                      "vec2 vTexCoordAdj%d = vec2(clamp(vTexCoord%d.s, 0.5 / "
+                                      "texSize%d.s, vTexClampS%d), vTexCoord%d.t);\n",
+                                      i, i, i, i, i);
                 } else {
-                    fs_len += sprintf(fs_buf + fs_len, "vec2 vTexCoordAdj%d = vec2(vTexCoord%d.s, clamp(vTexCoord%d.t, "
-                                      "0.5 / texSize%d.t, vTexClampT%d));\n", i, i, i, i, i);
+                    fs_len += sprintf(fs_buf + fs_len,
+                                      "vec2 vTexCoordAdj%d = vec2(vTexCoord%d.s, clamp(vTexCoord%d.t, "
+                                      "0.5 / texSize%d.t, vTexClampT%d));\n",
+                                      i, i, i, i, i);
                 }
             }
 
@@ -478,8 +484,9 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
             if (cc_features.used_masks[i]) {
                 fs_len += sprintf(fs_buf + fs_len, "vec2 maskSize%d = textureSize(uTexMask%d, 0);\n", i, i);
 
-                fs_len += sprintf(fs_buf + fs_len,
-                                  "vec4 maskVal%d = hookTexture2D(uTexMask%d, vTexCoordAdj%d, maskSize%d);\n", i, i, i, i);
+                fs_len +=
+                    sprintf(fs_buf + fs_len,
+                            "vec4 maskVal%d = hookTexture2D(uTexMask%d, vTexCoordAdj%d, maskSize%d);\n", i, i, i, i);
                 if (cc_features.used_blend[i]) {
                     fs_len += sprintf(fs_buf + fs_len,
                                       "vec4 blendVal%d = hookTexture2D(uTexBlend%d, vTexCoordAdj%d, texSize%d);\n", i,

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -53,7 +53,7 @@ using namespace std;
 struct ShaderProgram {
     GLuint opengl_program_id;
     uint8_t num_inputs;
-    bool used_textures[2];
+    bool used_textures[SHADER_MAX_TEXURES];
     uint8_t num_floats;
     GLint attrib_locations[16];
     uint8_t attrib_sizes[16];
@@ -249,7 +249,7 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
     gfx_cc_get_features(shader_id0, shader_id1, &cc_features);
 
     char vs_buf[1024];
-    char fs_buf[3000];
+    char fs_buf[6000];
     size_t vs_len = 0;
     size_t fs_len = 0;
     size_t num_floats = 4;
@@ -394,6 +394,18 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
     if (cc_features.used_textures[1]) {
         append_line(fs_buf, &fs_len, "uniform sampler2D uTex1;");
     }
+    if (cc_features.used_masks[0]) {
+        append_line(fs_buf, &fs_len, "uniform sampler2D uTexMask0;");
+    }
+    if (cc_features.used_masks[1]) {
+        append_line(fs_buf, &fs_len, "uniform sampler2D uTexMask1;");
+    }
+    if (cc_features.used_blend[0]) {
+        append_line(fs_buf, &fs_len, "uniform sampler2D uTexBlend0;");
+    }
+    if (cc_features.used_blend[1]) {
+        append_line(fs_buf, &fs_len, "uniform sampler2D uTexBlend1;");
+    }
 
     append_line(fs_buf, &fs_len, "uniform int frame_count;");
     append_line(fs_buf, &fs_len, "uniform float noise_scale;");
@@ -447,25 +459,36 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
             fs_len += sprintf(fs_buf + fs_len, "vec2 texSize%d = textureSize(uTex%d, 0);\n", i, i);
 
             if (!s && !t) {
-                fs_len += sprintf(fs_buf + fs_len, "vec4 texVal%d = hookTexture2D(uTex%d, vTexCoord%d, texSize%d);\n",
-                                  i, i, i, i);
+                fs_len += sprintf(fs_buf + fs_len, "vec2 vTexCoordAdj%d = vTexCoord%d;\n", i, i);
             } else {
                 if (s && t) {
-                    fs_len += sprintf(fs_buf + fs_len,
-                                      "vec4 texVal%d = hookTexture2D(uTex%d, clamp(vTexCoord%d, 0.5 / texSize%d, "
-                                      "vec2(vTexClampS%d, vTexClampT%d)), texSize%d);\n",
-                                      i, i, i, i, i, i, i);
+                    fs_len += sprintf(fs_buf + fs_len, "vec2 vTexCoordAdj%d = clamp(vTexCoord%d, 0.5 / texSize%d, "
+                                      "vec2(vTexClampS%d, vTexClampT%d));\n", i, i, i, i, i);
                 } else if (s) {
-                    fs_len += sprintf(fs_buf + fs_len,
-                                      "vec4 texVal%d = hookTexture2D(uTex%d, vec2(clamp(vTexCoord%d.s, 0.5 / "
-                                      "texSize%d.s, vTexClampS%d), vTexCoord%d.t), texSize%d);\n",
-                                      i, i, i, i, i, i, i);
+                    fs_len += sprintf(fs_buf + fs_len, "vec2 vTexCoordAdj%d = vec2(clamp(vTexCoord%d.s, 0.5 / "
+                                      "texSize%d.s, vTexClampS%d), vTexCoord%d.t);\n", i, i, i, i, i);
                 } else {
-                    fs_len += sprintf(fs_buf + fs_len,
-                                      "vec4 texVal%d = hookTexture2D(uTex%d, vec2(vTexCoord%d.s, clamp(vTexCoord%d.t, "
-                                      "0.5 / texSize%d.t, vTexClampT%d)), texSize%d);\n",
-                                      i, i, i, i, i, i, i);
+                    fs_len += sprintf(fs_buf + fs_len, "vec2 vTexCoordAdj%d = vec2(vTexCoord%d.s, clamp(vTexCoord%d.t, "
+                                      "0.5 / texSize%d.t, vTexClampT%d));\n", i, i, i, i, i);
                 }
+            }
+
+            fs_len += sprintf(fs_buf + fs_len, "vec4 texVal%d = hookTexture2D(uTex%d, vTexCoordAdj%d, texSize%d);\n", i,
+                              i, i, i);
+            if (cc_features.used_masks[i]) {
+                fs_len += sprintf(fs_buf + fs_len, "vec2 maskSize%d = textureSize(uTexMask%d, 0);\n", i, i);
+
+                fs_len += sprintf(fs_buf + fs_len,
+                                  "vec4 maskVal%d = hookTexture2D(uTexMask%d, vTexCoordAdj%d, maskSize%d);\n", i, i, i, i);
+                if (cc_features.used_blend[i]) {
+                    fs_len += sprintf(fs_buf + fs_len,
+                                      "vec4 blendVal%d = hookTexture2D(uTexBlend%d, vTexCoordAdj%d, texSize%d);\n", i,
+                                      i, i, i);
+                } else {
+                    fs_len += sprintf(fs_buf + fs_len, "vec4 blendVal%d = vec4(0, 0, 0, 0);\n", i);
+                }
+
+                fs_len += sprintf(fs_buf + fs_len, "texVal%d = mix(texVal%d, blendVal%d, maskVal%d.a);\n", i, i, i, i);
             }
         }
     }
@@ -637,6 +660,10 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
     prg->num_inputs = cc_features.num_inputs;
     prg->used_textures[0] = cc_features.used_textures[0];
     prg->used_textures[1] = cc_features.used_textures[1];
+    prg->used_textures[2] = cc_features.used_masks[0];
+    prg->used_textures[3] = cc_features.used_masks[1];
+    prg->used_textures[4] = cc_features.used_blend[0];
+    prg->used_textures[5] = cc_features.used_blend[1];
     prg->num_floats = num_floats;
     prg->num_attribs = cnt;
 
@@ -649,6 +676,22 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
     if (cc_features.used_textures[1]) {
         GLint sampler_location = glGetUniformLocation(shader_program, "uTex1");
         glUniform1i(sampler_location, 1);
+    }
+    if (cc_features.used_masks[0]) {
+        GLint sampler_location = glGetUniformLocation(shader_program, "uTexMask0");
+        glUniform1i(sampler_location, 2);
+    }
+    if (cc_features.used_masks[1]) {
+        GLint sampler_location = glGetUniformLocation(shader_program, "uTexMask1");
+        glUniform1i(sampler_location, 3);
+    }
+    if (cc_features.used_blend[0]) {
+        GLint sampler_location = glGetUniformLocation(shader_program, "uTexBlend0");
+        glUniform1i(sampler_location, 4);
+    }
+    if (cc_features.used_blend[1]) {
+        GLint sampler_location = glGetUniformLocation(shader_program, "uTexBlend1");
+        glUniform1i(sampler_location, 5);
     }
 
     prg->frame_count_location = glGetUniformLocation(shader_program, "frame_count");

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -1437,7 +1437,7 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
                 gfx_flush();
                 import_texture(i, tile, false);
                 if (rdp.loaded_texture[i].masked) {
-                    import_texture_mask(SHADER_FIRST_MASK_TEXTURE+ i, tile);
+                    import_texture_mask(SHADER_FIRST_MASK_TEXTURE + i, tile);
                 }
                 if (rdp.loaded_texture[i].blended) {
                     import_texture(SHADER_FIRST_REPLACEMENT_TEXTURE + i, tile, true);

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -130,7 +130,6 @@ struct RawTexMetadata {
     uint16_t width, height;
     float h_byte_scale = 1, v_pixel_scale = 1;
     std::shared_ptr<Ship::Texture> resource;
-    std::string name;
     Ship::TextureType type;
 };
 
@@ -583,8 +582,9 @@ static void gfx_texture_cache_delete(const uint8_t* orig_addr) {
 
 static void import_texture_rgba16(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
-                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement && (metadata->resource != nullptr)
+                              ? masked_textures.find(metadata->resource->InitData->Path)->second.replacementData
+                              : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -612,8 +612,9 @@ static void import_texture_rgba16(int tile, bool importReplacement) {
 
 static void import_texture_rgba32(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
-                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement && (metadata->resource != nullptr)
+                              ? masked_textures.find(metadata->resource->InitData->Path)->second.replacementData
+                              : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -628,8 +629,9 @@ static void import_texture_rgba32(int tile, bool importReplacement) {
 
 static void import_texture_ia4(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
-                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement && (metadata->resource != nullptr)
+                              ? masked_textures.find(metadata->resource->InitData->Path)->second.replacementData
+                              : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -659,8 +661,9 @@ static void import_texture_ia4(int tile, bool importReplacement) {
 
 static void import_texture_ia8(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
-                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement && (metadata->resource != nullptr)
+                              ? masked_textures.find(metadata->resource->InitData->Path)->second.replacementData
+                              : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -688,8 +691,9 @@ static void import_texture_ia8(int tile, bool importReplacement) {
 
 static void import_texture_ia16(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
-                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement && (metadata->resource != nullptr)
+                              ? masked_textures.find(metadata->resource->InitData->Path)->second.replacementData
+                              : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -717,8 +721,9 @@ static void import_texture_ia16(int tile, bool importReplacement) {
 
 static void import_texture_i4(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
-                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement && (metadata->resource != nullptr)
+                              ? masked_textures.find(metadata->resource->InitData->Path)->second.replacementData
+                              : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -748,8 +753,9 @@ static void import_texture_i4(int tile, bool importReplacement) {
 
 static void import_texture_i8(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
-                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement && (metadata->resource != nullptr)
+                              ? masked_textures.find(metadata->resource->InitData->Path)->second.replacementData
+                              : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -777,8 +783,9 @@ static void import_texture_i8(int tile, bool importReplacement) {
 
 static void import_texture_ci4(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
-                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement && (metadata->resource != nullptr)
+                              ? masked_textures.find(metadata->resource->InitData->Path)->second.replacementData
+                              : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -814,8 +821,9 @@ static void import_texture_ci4(int tile, bool importReplacement) {
 
 static void import_texture_ci8(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
-                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement && (metadata->resource != nullptr)
+                              ? masked_textures.find(metadata->resource->InitData->Path)->second.replacementData
+                              : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -851,8 +859,9 @@ static void import_texture_ci8(int tile, bool importReplacement) {
 
 static void import_texture_raw(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
-                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement && (metadata->resource != nullptr)
+                              ? masked_textures.find(metadata->resource->InitData->Path)->second.replacementData
+                              : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
 
     uint16_t width = metadata->width;
     uint16_t height = metadata->height;
@@ -908,8 +917,9 @@ static void import_texture(int i, int tile, bool importReplacement) {
     uint8_t palette_index = rdp.texture_tile[tile].palette;
 
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* orig_addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
-                                                 : rdp.loaded_texture[tmem_index].addr;
+    const uint8_t* orig_addr = importReplacement && (metadata->resource != nullptr)
+                                   ? masked_textures.find(metadata->resource->InitData->Path)->second.replacementData
+                                   : rdp.loaded_texture[tmem_index].addr;
 
     TextureCacheKey key;
     if (fmt == G_IM_FMT_CI) {
@@ -972,7 +982,11 @@ static void import_texture_mask(int i, int tile) {
     uint32_t tmem_index = rdp.texture_tile[tile].tmem_index;
     RawTexMetadata metadata = rdp.loaded_texture[tmem_index].raw_tex_metadata;
 
-    auto maskIter = masked_textures.find(metadata.name);
+    if (metadata.resource == nullptr) {
+        return;
+    }
+
+    auto maskIter = masked_textures.find(metadata.resource->InitData->Path);
     if (maskIter == masked_textures.end()) {
         return;
     }
@@ -1933,7 +1947,10 @@ static void gfx_dp_load_block(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t
     rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata = rdp.texture_to_load.raw_tex_metadata;
     rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr = rdp.texture_to_load.addr;
 
-    auto maskedTextureIter = masked_textures.find(rdp.texture_to_load.raw_tex_metadata.name);
+    const std::string& texPath = rdp.texture_to_load.raw_tex_metadata.resource != nullptr
+                                     ? rdp.texture_to_load.raw_tex_metadata.resource->InitData->Path
+                                     : "";
+    auto maskedTextureIter = masked_textures.find(texPath);
     if (maskedTextureIter != masked_textures.end()) {
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].masked = true;
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].blended =
@@ -1999,7 +2016,10 @@ static void gfx_dp_load_tile(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t 
     rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata = rdp.texture_to_load.raw_tex_metadata;
     rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr = rdp.texture_to_load.addr + start_offset_bytes;
 
-    auto maskedTextureIter = masked_textures.find(rdp.texture_to_load.raw_tex_metadata.name);
+    const std::string& texPath = rdp.texture_to_load.raw_tex_metadata.resource != nullptr
+                                     ? rdp.texture_to_load.raw_tex_metadata.resource->InitData->Path
+                                     : "";
+    auto maskedTextureIter = masked_textures.find(texPath);
     if (maskedTextureIter != masked_textures.end()) {
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].masked = true;
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].blended =
@@ -2325,7 +2345,6 @@ static void gfx_s2dex_bg_copy(uObjBg* bg) {
         rawTexMetadata.v_pixel_scale = tex->VPixelScale;
         rawTexMetadata.type = tex->Type;
         rawTexMetadata.resource = tex;
-        rawTexMetadata.name = std::string((char*)data);
         data = (uintptr_t) reinterpret_cast<char*>(tex->ImageData);
     }
 
@@ -2719,7 +2738,6 @@ static void gfx_run_dl(Gfx* cmd) {
                     rawTexMetadata.v_pixel_scale = texture->VPixelScale;
                     rawTexMetadata.type = texture->Type;
                     rawTexMetadata.resource = texture;
-                    rawTexMetadata.name = std::string(fileName);
 
 #if _DEBUG && 0
                     tex = reinterpret_cast<char*>(texture->imageData);
@@ -2779,7 +2797,6 @@ static void gfx_run_dl(Gfx* cmd) {
                     rawTexMetadata.v_pixel_scale = texture->VPixelScale;
                     rawTexMetadata.type = texture->Type;
                     rawTexMetadata.resource = texture;
-                    rawTexMetadata.name = std::string(fileName);
 
                     uint32_t fmt = C0(21, 3);
                     uint32_t size = C0(19, 2);

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -96,8 +96,8 @@ struct ColorCombiner {
     uint8_t shader_input_mapping[2][7];
 };
 
-static map<uint64_t, struct ColorCombiner> color_combiner_pool;
-static map<uint64_t, struct ColorCombiner>::iterator prev_combiner = color_combiner_pool.end();
+static map<ColorCombinerKey, struct ColorCombiner> color_combiner_pool;
+static map<ColorCombinerKey, struct ColorCombiner>::iterator prev_combiner = color_combiner_pool.end();
 
 static uint8_t* tex_upload_buffer = nullptr;
 
@@ -130,6 +130,7 @@ struct RawTexMetadata {
     uint16_t width, height;
     float h_byte_scale = 1, v_pixel_scale = 1;
     std::shared_ptr<Ship::Texture> resource;
+    std::string name;
     Ship::TextureType type;
 };
 
@@ -150,6 +151,8 @@ static struct RDP {
         uint32_t line_size_bytes;
         uint32_t tex_flags;
         struct RawTexMetadata raw_tex_metadata;
+        bool masked;
+        bool blended;
     } loaded_texture[2];
     struct {
         uint8_t fmt;
@@ -184,7 +187,7 @@ static struct RenderingState {
     bool alpha_blend;
     struct XYWidthHeight viewport, scissor;
     struct ShaderProgram* shader_program;
-    TextureCacheNode* textures[2];
+    TextureCacheNode* textures[SHADER_MAX_TEXURES];
 } rendering_state;
 
 struct GfxDimensions gfx_current_window_dimensions;
@@ -225,6 +228,13 @@ static map<int, FBInfo> framebuffers;
 
 static set<pair<float, float>> get_pixel_depth_pending;
 static unordered_map<pair<float, float>, uint16_t, hash_pair_ff> get_pixel_depth_cached;
+
+struct MaskedTextureEntry {
+    uint8_t* mask;
+    uint8_t* replacementData;
+};
+
+static map<string, MaskedTextureEntry> masked_textures;
 
 static std::string GetPathWithoutFileName(char* filePath) {
     int len = strlen(filePath);
@@ -306,23 +316,23 @@ static const char* acmux_to_string(uint32_t acmux) {
     return tbl[acmux];
 }
 
-static void gfx_generate_cc(struct ColorCombiner* comb, uint64_t cc_id) {
-    bool is_2cyc = (cc_id & (uint64_t)SHADER_OPT_2CYC << CC_SHADER_OPT_POS) != 0;
+static void gfx_generate_cc(struct ColorCombiner* comb, const ColorCombinerKey& key) {
+    bool is_2cyc = (key.options & (uint64_t)SHADER_OPT_2CYC) != 0;
 
     uint8_t c[2][2][4];
     uint64_t shader_id0 = 0;
-    uint32_t shader_id1 = (cc_id >> CC_SHADER_OPT_POS);
+    uint32_t shader_id1 = key.options;
     uint8_t shader_input_mapping[2][7] = { { 0 } };
     bool used_textures[2] = { false, false };
     for (int i = 0; i < 2 && (i == 0 || is_2cyc); i++) {
-        uint32_t rgb_a = (cc_id >> (i * 28)) & 0xf;
-        uint32_t rgb_b = (cc_id >> (i * 28 + 4)) & 0xf;
-        uint32_t rgb_c = (cc_id >> (i * 28 + 8)) & 0x1f;
-        uint32_t rgb_d = (cc_id >> (i * 28 + 13)) & 7;
-        uint32_t alpha_a = (cc_id >> (i * 28 + 16)) & 7;
-        uint32_t alpha_b = (cc_id >> (i * 28 + 16 + 3)) & 7;
-        uint32_t alpha_c = (cc_id >> (i * 28 + 16 + 6)) & 7;
-        uint32_t alpha_d = (cc_id >> (i * 28 + 16 + 9)) & 7;
+        uint32_t rgb_a = (key.combine_mode >> (i * 28)) & 0xf;
+        uint32_t rgb_b = (key.combine_mode >> (i * 28 + 4)) & 0xf;
+        uint32_t rgb_c = (key.combine_mode >> (i * 28 + 8)) & 0x1f;
+        uint32_t rgb_d = (key.combine_mode >> (i * 28 + 13)) & 7;
+        uint32_t alpha_a = (key.combine_mode >> (i * 28 + 16)) & 7;
+        uint32_t alpha_b = (key.combine_mode >> (i * 28 + 16 + 3)) & 7;
+        uint32_t alpha_c = (key.combine_mode >> (i * 28 + 16 + 6)) & 7;
+        uint32_t alpha_d = (key.combine_mode >> (i * 28 + 16 + 9)) & 7;
 
         if (rgb_a >= 8) {
             rgb_a = G_CCMUX_0;
@@ -489,18 +499,18 @@ static void gfx_generate_cc(struct ColorCombiner* comb, uint64_t cc_id) {
     memcpy(comb->shader_input_mapping, shader_input_mapping, sizeof(shader_input_mapping));
 }
 
-static struct ColorCombiner* gfx_lookup_or_create_color_combiner(uint64_t cc_id) {
-    if (prev_combiner != color_combiner_pool.end() && prev_combiner->first == cc_id) {
+static struct ColorCombiner* gfx_lookup_or_create_color_combiner(const ColorCombinerKey& key) {
+    if (prev_combiner != color_combiner_pool.end() && prev_combiner->first == key) {
         return &prev_combiner->second;
     }
 
-    prev_combiner = color_combiner_pool.find(cc_id);
+    prev_combiner = color_combiner_pool.find(key);
     if (prev_combiner != color_combiner_pool.end()) {
         return &prev_combiner->second;
     }
     gfx_flush();
-    prev_combiner = color_combiner_pool.insert(make_pair(cc_id, ColorCombiner())).first;
-    gfx_generate_cc(&prev_combiner->second, cc_id);
+    prev_combiner = color_combiner_pool.insert(make_pair(key, ColorCombiner())).first;
+    gfx_generate_cc(&prev_combiner->second, key);
     return &prev_combiner->second;
 }
 
@@ -512,24 +522,9 @@ void gfx_texture_cache_clear() {
     gfx_texture_cache.lru.clear();
 }
 
-static bool gfx_texture_cache_lookup(int i, int tile) {
-    uint8_t fmt = rdp.texture_tile[tile].fmt;
-    uint8_t siz = rdp.texture_tile[tile].siz;
-    uint32_t tmem_index = rdp.texture_tile[tile].tmem_index;
-
-    TextureCacheNode** n = &rendering_state.textures[i];
-    const uint8_t* orig_addr = rdp.loaded_texture[tmem_index].addr;
-    uint8_t palette_index = rdp.texture_tile[tile].palette;
-
-    TextureCacheKey key;
-    if (fmt == G_IM_FMT_CI) {
-        key = { orig_addr, { rdp.palettes[0], rdp.palettes[1] }, fmt, siz, palette_index };
-    } else {
-        key = { orig_addr, {}, fmt, siz, palette_index };
-    }
-
+static bool gfx_texture_cache_lookup(int i, const TextureCacheKey& key) {
     TextureCacheMap::iterator it = gfx_texture_cache.map.find(key);
-    RawTexMetadata metadata = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
+    TextureCacheNode** n = &rendering_state.textures[i];
 
     if (it != gfx_texture_cache.map.end()) {
         gfx_rapi->select_texture(i, it->second.texture_id);
@@ -586,8 +581,10 @@ static void gfx_texture_cache_delete(const uint8_t* orig_addr) {
     }
 }
 
-static void import_texture_rgba16(int tile) {
-    const uint8_t* addr = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+static void import_texture_rgba16(int tile, bool importReplacement) {
+    const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
+    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
+                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -613,8 +610,10 @@ static void import_texture_rgba16(int tile) {
     // DumpTexture(rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].otr_path, rgba32_buf, width, height);
 }
 
-static void import_texture_rgba32(int tile) {
-    const uint8_t* addr = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+static void import_texture_rgba32(int tile, bool importReplacement) {
+    const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
+    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
+                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -627,8 +626,10 @@ static void import_texture_rgba32(int tile) {
     // DumpTexture(rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].otr_path, addr, width, height);
 }
 
-static void import_texture_ia4(int tile) {
-    const uint8_t* addr = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+static void import_texture_ia4(int tile, bool importReplacement) {
+    const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
+    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
+                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -656,8 +657,10 @@ static void import_texture_ia4(int tile) {
     // DumpTexture(rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].otr_path, rgba32_buf, width, height);
 }
 
-static void import_texture_ia8(int tile) {
-    const uint8_t* addr = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+static void import_texture_ia8(int tile, bool importReplacement) {
+    const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
+    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
+                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -683,8 +686,10 @@ static void import_texture_ia8(int tile) {
     // DumpTexture(rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].otr_path, rgba32_buf, width, height);
 }
 
-static void import_texture_ia16(int tile) {
-    const uint8_t* addr = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+static void import_texture_ia16(int tile, bool importReplacement) {
+    const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
+    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
+                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -710,8 +715,10 @@ static void import_texture_ia16(int tile) {
     // DumpTexture(rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].otr_path, rgba32_buf, width, height);
 }
 
-static void import_texture_i4(int tile) {
-    const uint8_t* addr = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+static void import_texture_i4(int tile, bool importReplacement) {
+    const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
+    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
+                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -739,8 +746,10 @@ static void import_texture_i4(int tile) {
     // DumpTexture(rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].otr_path, rgba32_buf, width, height);
 }
 
-static void import_texture_i8(int tile) {
-    const uint8_t* addr = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+static void import_texture_i8(int tile, bool importReplacement) {
+    const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
+    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
+                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -766,9 +775,10 @@ static void import_texture_i8(int tile) {
     // DumpTexture(rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].otr_path, rgba32_buf, width, height);
 }
 
-static void import_texture_ci4(int tile) {
+static void import_texture_ci4(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
+                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -802,9 +812,10 @@ static void import_texture_ci4(int tile) {
     gfx_rapi->upload_texture(tex_upload_buffer, width, height);
 }
 
-static void import_texture_ci8(int tile) {
+static void import_texture_ci8(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
+                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
     uint32_t size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].size_bytes;
     uint32_t full_image_line_size_bytes =
         rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
@@ -838,9 +849,10 @@ static void import_texture_ci8(int tile) {
     // DumpTexture(rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].otr_path, rgba32_buf, width, height);
 }
 
-static void import_texture_raw(int tile) {
+static void import_texture_raw(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* addr = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
+    const uint8_t* addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
+                                            : rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr;
 
     uint16_t width = metadata->width;
     uint16_t height = metadata->height;
@@ -849,10 +861,10 @@ static void import_texture_raw(int tile) {
     // if texture type is CI4 or CI8 we need to apply tlut to it
     switch (type) {
         case Ship::TextureType::Palette4bpp:
-            import_texture_ci4(tile);
+            import_texture_ci4(tile, false);
             return;
         case Ship::TextureType::Palette8bpp:
-            import_texture_ci8(tile);
+            import_texture_ci8(tile, false);
             return;
         default:
             break;
@@ -888,60 +900,129 @@ static void import_texture_raw(int tile) {
     gfx_rapi->upload_texture(tex_upload_buffer, result_new_line_size / 4, result_new_height);
 }
 
-static void import_texture(int i, int tile) {
+static void import_texture(int i, int tile, bool importReplacement) {
     uint8_t fmt = rdp.texture_tile[tile].fmt;
     uint8_t siz = rdp.texture_tile[tile].siz;
     uint32_t texFlags = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].tex_flags;
     uint32_t tmem_index = rdp.texture_tile[tile].tmem_index;
+    uint8_t palette_index = rdp.texture_tile[tile].palette;
 
-    if (gfx_texture_cache_lookup(i, tile)) {
+    const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
+    const uint8_t* orig_addr = importReplacement ? masked_textures.find(metadata->name)->second.replacementData
+                                                 : rdp.loaded_texture[tmem_index].addr;
+
+    TextureCacheKey key;
+    if (fmt == G_IM_FMT_CI) {
+        key = { orig_addr, { rdp.palettes[0], rdp.palettes[1] }, fmt, siz, palette_index };
+    } else {
+        key = { orig_addr, {}, fmt, siz, palette_index };
+    }
+
+    if (gfx_texture_cache_lookup(i, key)) {
         return;
     }
 
     // if load as raw is set then we load_raw();
     if ((texFlags & TEX_FLAG_LOAD_AS_RAW) != 0) {
-        import_texture_raw(tile);
+        import_texture_raw(tile, importReplacement);
         return;
     }
 
     if (fmt == G_IM_FMT_RGBA) {
         if (siz == G_IM_SIZ_16b) {
-            import_texture_rgba16(tile);
+            import_texture_rgba16(tile, importReplacement);
         } else if (siz == G_IM_SIZ_32b) {
-            import_texture_rgba32(tile);
+            import_texture_rgba32(tile, importReplacement);
         } else {
             // abort(); // OTRTODO: Sometimes, seemingly randomly, we end up here. Could be a bad dlist, could be
             // something F3D does not have supported. Further investigation is needed.
         }
     } else if (fmt == G_IM_FMT_IA) {
         if (siz == G_IM_SIZ_4b) {
-            import_texture_ia4(tile);
+            import_texture_ia4(tile, importReplacement);
         } else if (siz == G_IM_SIZ_8b) {
-            import_texture_ia8(tile);
+            import_texture_ia8(tile, importReplacement);
         } else if (siz == G_IM_SIZ_16b) {
-            import_texture_ia16(tile);
+            import_texture_ia16(tile, importReplacement);
         } else {
             abort();
         }
     } else if (fmt == G_IM_FMT_CI) {
         if (siz == G_IM_SIZ_4b) {
-            import_texture_ci4(tile);
+            import_texture_ci4(tile, importReplacement);
         } else if (siz == G_IM_SIZ_8b) {
-            import_texture_ci8(tile);
+            import_texture_ci8(tile, importReplacement);
         } else {
             abort();
         }
     } else if (fmt == G_IM_FMT_I) {
         if (siz == G_IM_SIZ_4b) {
-            import_texture_i4(tile);
+            import_texture_i4(tile, importReplacement);
         } else if (siz == G_IM_SIZ_8b) {
-            import_texture_i8(tile);
+            import_texture_i8(tile, importReplacement);
         } else {
             abort();
         }
     } else {
         abort();
     }
+}
+
+static void import_texture_mask(int i, int tile) {
+    uint32_t tmem_index = rdp.texture_tile[tile].tmem_index;
+    RawTexMetadata metadata = rdp.loaded_texture[tmem_index].raw_tex_metadata;
+
+    auto maskIter = masked_textures.find(metadata.name);
+    if (maskIter == masked_textures.end()) {
+        return;
+    }
+
+    const uint8_t* orig_addr = maskIter->second.mask;
+
+    if (orig_addr == nullptr) {
+        return;
+    }
+
+    TextureCacheKey key = { orig_addr, {}, 0, 0, 0 };
+
+    if (gfx_texture_cache_lookup(i, key)) {
+        return;
+    }
+
+    uint32_t width = rdp.texture_tile[tile].line_size_bytes;
+    uint32_t height =
+        rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].orig_size_bytes / rdp.texture_tile[tile].line_size_bytes;
+    switch (rdp.texture_tile[tile].siz) {
+        case G_IM_SIZ_4b:
+            width *= 2;
+            break;
+        case G_IM_SIZ_8b:
+        default:
+            break;
+        case G_IM_SIZ_16b:
+            width /= 2;
+            break;
+        case G_IM_SIZ_32b:
+            width /= 4;
+            break;
+    }
+
+    for (uint32_t texIndex = 0; texIndex < width * height; texIndex++) {
+        uint8_t masked = orig_addr[texIndex];
+        if (masked) {
+            tex_upload_buffer[4 * texIndex + 0] = 0;
+            tex_upload_buffer[4 * texIndex + 1] = 0;
+            tex_upload_buffer[4 * texIndex + 2] = 0;
+            tex_upload_buffer[4 * texIndex + 3] = 0xFF;
+        } else {
+            tex_upload_buffer[4 * texIndex + 0] = 0;
+            tex_upload_buffer[4 * texIndex + 1] = 0;
+            tex_upload_buffer[4 * texIndex + 2] = 0;
+            tex_upload_buffer[4 * texIndex + 3] = 0;
+        }
+    }
+
+    gfx_rapi->upload_texture(tex_upload_buffer, width, height);
 }
 
 static void gfx_normalize_vector(float v[3]) {
@@ -1282,6 +1363,7 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
     }
 
     uint64_t cc_id = rdp.combine_mode;
+    uint64_t cc_options = 0;
     bool use_alpha =
         (rdp.other_mode_l & (3 << 20)) == (G_BL_CLR_MEM << 20) && (rdp.other_mode_l & (3 << 16)) == (G_BL_1MA << 16);
     bool use_fog = (rdp.other_mode_l >> 30) == G_BL_CLR_FOG;
@@ -1298,35 +1380,52 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
     }
 
     if (use_alpha) {
-        cc_id |= (uint64_t)SHADER_OPT_ALPHA << CC_SHADER_OPT_POS;
+        cc_options |= (uint64_t)SHADER_OPT_ALPHA;
     }
     if (use_fog) {
-        cc_id |= (uint64_t)SHADER_OPT_FOG << CC_SHADER_OPT_POS;
+        cc_options |= (uint64_t)SHADER_OPT_FOG;
     }
     if (texture_edge) {
-        cc_id |= (uint64_t)SHADER_OPT_TEXTURE_EDGE << CC_SHADER_OPT_POS;
+        cc_options |= (uint64_t)SHADER_OPT_TEXTURE_EDGE;
     }
     if (use_noise) {
-        cc_id |= (uint64_t)SHADER_OPT_NOISE << CC_SHADER_OPT_POS;
+        cc_options |= (uint64_t)SHADER_OPT_NOISE;
     }
     if (use_2cyc) {
-        cc_id |= (uint64_t)SHADER_OPT_2CYC << CC_SHADER_OPT_POS;
+        cc_options |= (uint64_t)SHADER_OPT_2CYC;
     }
     if (alpha_threshold) {
-        cc_id |= (uint64_t)SHADER_OPT_ALPHA_THRESHOLD << CC_SHADER_OPT_POS;
+        cc_options |= (uint64_t)SHADER_OPT_ALPHA_THRESHOLD;
     }
     if (invisible) {
-        cc_id |= (uint64_t)SHADER_OPT_INVISIBLE << CC_SHADER_OPT_POS;
+        cc_options |= (uint64_t)SHADER_OPT_INVISIBLE;
     }
     if (use_grayscale) {
-        cc_id |= (uint64_t)SHADER_OPT_GRAYSCALE << CC_SHADER_OPT_POS;
+        cc_options |= (uint64_t)SHADER_OPT_GRAYSCALE;
+    }
+    if (rdp.loaded_texture[0].masked) {
+        cc_options |= (uint64_t)SHADER_OPT_TEXEL0_MASK;
+    }
+    if (rdp.loaded_texture[1].masked) {
+        cc_options |= (uint64_t)SHADER_OPT_TEXEL1_MASK;
+    }
+    if (rdp.loaded_texture[0].blended) {
+        cc_options |= (uint64_t)SHADER_OPT_TEXEL0_BLEND;
+    }
+    if (rdp.loaded_texture[1].blended) {
+        cc_options |= (uint64_t)SHADER_OPT_TEXEL1_BLEND;
     }
 
+    // If we are not using alpha, clear the alpha components of the combiner as they have no effect
     if (!use_alpha) {
-        cc_id &= ~((0xfff << 16) | ((uint64_t)0xfff << 44));
+        cc_options &= ~((0xfff << 16) | ((uint64_t)0xfff << 44));
     }
 
-    ColorCombiner* comb = gfx_lookup_or_create_color_combiner(cc_id);
+    ColorCombinerKey key;
+    key.combine_mode = rdp.combine_mode;
+    key.options = cc_options;
+
+    ColorCombiner* comb = gfx_lookup_or_create_color_combiner(key);
 
     uint32_t tm = 0;
     uint32_t tex_width[2], tex_height[2], tex_width2[2], tex_height2[2];
@@ -1336,7 +1435,13 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
         if (comb->used_textures[i]) {
             if (rdp.textures_changed[i]) {
                 gfx_flush();
-                import_texture(i, tile);
+                import_texture(i, tile, false);
+                if (rdp.loaded_texture[i].masked) {
+                    import_texture_mask(SHADER_FIRST_MASK_TEXTURE+ i, tile);
+                }
+                if (rdp.loaded_texture[i].blended) {
+                    import_texture(SHADER_FIRST_REPLACEMENT_TEXTURE + i, tile, true);
+                }
                 rdp.textures_changed[i] = false;
             }
 
@@ -1827,6 +1932,17 @@ static void gfx_dp_load_block(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t
     rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].tex_flags = rdp.texture_to_load.tex_flags;
     rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata = rdp.texture_to_load.raw_tex_metadata;
     rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr = rdp.texture_to_load.addr;
+
+    auto maskedTextureIter = masked_textures.find(rdp.texture_to_load.raw_tex_metadata.name);
+    if (maskedTextureIter != masked_textures.end()) {
+        rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].masked = true;
+        rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].blended =
+            maskedTextureIter->second.replacementData != nullptr;
+    } else {
+        rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].masked = false;
+        rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].blended = false;
+    }
+
     rdp.textures_changed[rdp.texture_tile[tile].tmem_index] = true;
 }
 
@@ -1882,6 +1998,17 @@ static void gfx_dp_load_tile(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t 
     rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].tex_flags = rdp.texture_to_load.tex_flags;
     rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata = rdp.texture_to_load.raw_tex_metadata;
     rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].addr = rdp.texture_to_load.addr + start_offset_bytes;
+
+    auto maskedTextureIter = masked_textures.find(rdp.texture_to_load.raw_tex_metadata.name);
+    if (maskedTextureIter != masked_textures.end()) {
+        rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].masked = true;
+        rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].blended =
+            maskedTextureIter->second.replacementData != nullptr;
+    } else {
+        rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].masked = false;
+        rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].blended = false;
+    }
+
     rdp.texture_tile[tile].uls = uls;
     rdp.texture_tile[tile].ult = ult;
     rdp.texture_tile[tile].lrs = lrs;
@@ -2198,6 +2325,7 @@ static void gfx_s2dex_bg_copy(uObjBg* bg) {
         rawTexMetadata.v_pixel_scale = tex->VPixelScale;
         rawTexMetadata.type = tex->Type;
         rawTexMetadata.resource = tex;
+        rawTexMetadata.name = std::string((char*)data);
         data = (uintptr_t) reinterpret_cast<char*>(tex->ImageData);
     }
 
@@ -2579,18 +2707,19 @@ static void gfx_run_dl(Gfx* cmd) {
 
                 fileName = GetResourceNameByCrc(hash);
                 uint32_t texFlags = 0;
-                RawTexMetadata rawTexMetdata = {};
+                RawTexMetadata rawTexMetadata = {};
 
                 std::shared_ptr<Ship::Texture> texture =
                     std::static_pointer_cast<Ship::Texture>(LoadResource(hash, true));
                 if (texture != nullptr) {
                     texFlags = texture->Flags;
-                    rawTexMetdata.width = texture->Width;
-                    rawTexMetdata.height = texture->Height;
-                    rawTexMetdata.h_byte_scale = texture->HByteScale;
-                    rawTexMetdata.v_pixel_scale = texture->VPixelScale;
-                    rawTexMetdata.type = texture->Type;
-                    rawTexMetdata.resource = texture;
+                    rawTexMetadata.width = texture->Width;
+                    rawTexMetadata.height = texture->Height;
+                    rawTexMetadata.h_byte_scale = texture->HByteScale;
+                    rawTexMetadata.v_pixel_scale = texture->VPixelScale;
+                    rawTexMetadata.type = texture->Type;
+                    rawTexMetadata.resource = texture;
+                    rawTexMetadata.name = std::string(fileName);
 
 #if _DEBUG && 0
                     tex = reinterpret_cast<char*>(texture->imageData);
@@ -2625,7 +2754,7 @@ static void gfx_run_dl(Gfx* cmd) {
                     uint32_t width = C0(0, 10);
 
                     if (tex != NULL) {
-                        gfx_dp_set_texture_image(fmt, size, width, fileName, texFlags, rawTexMetdata, tex);
+                        gfx_dp_set_texture_image(fmt, size, width, fileName, texFlags, rawTexMetadata, tex);
                     }
                 } else {
                     SPDLOG_ERROR("G_SETTIMG_OTR_HASH: Texture is null");
@@ -2650,6 +2779,7 @@ static void gfx_run_dl(Gfx* cmd) {
                     rawTexMetadata.v_pixel_scale = texture->VPixelScale;
                     rawTexMetadata.type = texture->Type;
                     rawTexMetadata.resource = texture;
+                    rawTexMetadata.name = std::string(fileName);
 
                     uint32_t fmt = C0(21, 3);
                     uint32_t size = C0(19, 2);
@@ -3064,6 +3194,7 @@ void gfx_push_current_dir(char* path) {
 
     currentDir.push(GetPathWithoutFileName(path));
 }
+
 int32_t gfx_check_image_signature(const char* imgData) {
     uintptr_t i = (uintptr_t)(imgData);
 
@@ -3076,4 +3207,19 @@ int32_t gfx_check_image_signature(const char* imgData) {
     }
 
     return 0;
+}
+
+void gfx_register_blended_texture(const char* name, uint8_t* mask, uint8_t* replacement) {
+    if (gfx_check_image_signature(name)) {
+        name += 7;
+    }
+
+    if (gfx_check_image_signature(reinterpret_cast<char*>(replacement))) {
+        Ship::Texture* tex =
+            std::static_pointer_cast<Ship::Texture>(LoadResource(reinterpret_cast<char*>(replacement), true)).get();
+
+        replacement = tex->ImageData;
+    }
+
+    masked_textures[name] = MaskedTextureEntry{ mask, replacement };
 }

--- a/src/graphic/Fast3D/gfx_pc.h
+++ b/src/graphic/Fast3D/gfx_pc.h
@@ -86,5 +86,6 @@ void gfx_get_pixel_depth_prepare(float x, float y);
 uint16_t gfx_get_pixel_depth(float x, float y);
 void gfx_push_current_dir(char* path);
 int32_t gfx_check_image_signature(const char* imgData);
+void gfx_register_blended_texture(const char* name, uint8_t* mask, uint8_t* replacement = nullptr);
 
 #endif

--- a/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
+++ b/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <spdlog/fmt/fmt.h>
 
-static ISpVoice* mVoice = NULL;
+ISpVoice* mVoice = NULL;
 
 namespace Ship {
 SAPISpeechSynthesizer::SAPISpeechSynthesizer() {

--- a/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
+++ b/src/speechsynthesizer/SAPISpeechSynthesizer.cpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <spdlog/fmt/fmt.h>
 
-ISpVoice* mVoice = NULL;
+static ISpVoice* mVoice = NULL;
 
 namespace Ship {
 SAPISpeechSynthesizer::SAPISpeechSynthesizer() {


### PR DESCRIPTION
This introduces shader features in order to support some CPU-modified textures in OOT.

In OOT, several effects are implemented by gradually clearing textures. Additionally, there is an effect that gradually replaces one texture with another. I have implemented this by adding a mechanism to indicate that a texture is masked by another, and when it is, it is replaced by another texture. When another texture is not specified, it is replaced by transparent black, which is what OOT uses in all cases.

I considered two options for this. Firstly, adding a custom DL command. Secondly, by specifying what texture would be replaced by file path so that the information could be referenced when loaded. I opted for the latter because it was the more general-purpose solution. I was not sure of the scope patching all the DLs in OOT would be if I added a custom command for this, or what it would be in other games. Having a hook for the game to say "mask this texture," with no worry about any other data, seemed ideal. This approach does not exclude adding a command, if desired.

To facilitate this, I needed additional bits for the color combiner settings. Accordingly, I have done some work to expand the bits for the keys for the them. For speed, instead of splitting them all into bools, they are 2 `uint64_t`s, but when more space is needed, a third, fourth, etc. can easily be added. For now, there is plenty of free space for additional flags.

This PR is limited to DX11 and OpenGL, as I do not have a way of testing other APIs. There is a risk of crashing with other APIs until they are changed to support them, as with these changes Fast3D assumes that they support 6 textures, up from 2.