### PR TITLE
Declutter logs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -418,7 +418,8 @@ if (NOT CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
         ENABLE_OPENGL
         $<$<CONFIG:Debug>:_DEBUG>
         $<$<NOT:$<CONFIG:Debug>>:NDEBUG>
-        SPDLOG_ACTIVE_LEVEL=1
+        $<$<CONFIG:Debug>:SPDLOG_ACTIVE_LEVEL=0>
+        $<$<NOT:$<CONFIG:Debug>>:SPDLOG_ACTIVE_LEVEL=1>
     )
 else ()
     target_compile_definitions(libultraship PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -418,7 +418,7 @@ if (NOT CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
         ENABLE_OPENGL
         $<$<CONFIG:Debug>:_DEBUG>
         $<$<NOT:$<CONFIG:Debug>>:NDEBUG>
-        SPDLOG_ACTIVE_LEVEL=0
+        SPDLOG_ACTIVE_LEVEL=1
     )
 else ()
     target_compile_definitions(libultraship PRIVATE

--- a/src/core/Window.cpp
+++ b/src/core/Window.cpp
@@ -454,13 +454,21 @@ void Window::InitializeLogging() {
 #ifndef __WIIU__
         auto logPath = GetPathRelativeToAppDirectory(("logs/" + GetName() + ".log").c_str());
         auto fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logPath, 1024 * 1024 * 10, 10);
+#ifdef _DEBUG
+        fileSink->set_level(spdlog::level::trace);
+#else
         fileSink->set_level(spdlog::level::debug);
+#endif
         sinks.push_back(fileSink);
 #endif
 
         mLogger = std::make_shared<spdlog::async_logger>(GetName(), sinks.begin(), sinks.end(), spdlog::thread_pool(),
                                                          spdlog::async_overflow_policy::block);
+#ifdef _DEBUG
         GetLogger()->set_level(spdlog::level::debug);
+#else
+        GetLogger()->set_level(spdlog::level::trace);
+#endif
 
 #if defined(_DEBUG)
         GetLogger()->flush_on(spdlog::level::trace);

--- a/src/core/Window.cpp
+++ b/src/core/Window.cpp
@@ -454,13 +454,13 @@ void Window::InitializeLogging() {
 #ifndef __WIIU__
         auto logPath = GetPathRelativeToAppDirectory(("logs/" + GetName() + ".log").c_str());
         auto fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logPath, 1024 * 1024 * 10, 10);
-        fileSink->set_level(spdlog::level::trace);
+        fileSink->set_level(spdlog::level::debug);
         sinks.push_back(fileSink);
 #endif
 
         mLogger = std::make_shared<spdlog::async_logger>(GetName(), sinks.begin(), sinks.end(), spdlog::thread_pool(),
                                                          spdlog::async_overflow_policy::block);
-        GetLogger()->set_level(spdlog::level::trace);
+        GetLogger()->set_level(spdlog::level::debug);
 
 #if defined(_DEBUG)
         GetLogger()->flush_on(spdlog::level::trace);


### PR DESCRIPTION
Changes the default for release builds to `debug` rather than `trace` through `spdlog`. This should drastically reduce the size of files and allow for easier client-side debugging.