### PR TITLE
Change log size to ~7MB

### DIFF
--- a/src/core/Window.cpp
+++ b/src/core/Window.cpp
@@ -453,7 +453,7 @@ void Window::InitializeLogging() {
 
 #ifndef __WIIU__
         auto logPath = GetPathRelativeToAppDirectory(("logs/" + GetName() + ".log").c_str());
-        auto fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logPath, 1024 * 1024 * 10, 10);
+        auto fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logPath, 1024 * 1024 * 7, 10);
         fileSink->set_level(spdlog::level::trace);
         sinks.push_back(fileSink);
 #endif


### PR DESCRIPTION
To accomodate for users uploading logs to Discord without Nitro.

![image](https://user-images.githubusercontent.com/4244591/232041763-967b667b-f3e5-43c7-bfb9-af65aea71c4b.png)

If we want to reduce the number of logs to keep around, we can change that here too, but I wasn't sure if that's still something we want to do.