### PR TITLE
fix out of bounds raw texture loading cases from authentic bugs

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -898,14 +898,15 @@ static void import_texture_raw(int tile) {
     }
 
     // Safely only copy the amount of bytes the resource can allow
-    for (uint32_t i = 0, j = 0; i < safe_loaded_bytes; i += safe_line_size_bytes, j += safe_full_image_line_size_bytes) {
+    for (uint32_t i = 0, j = 0; i < safe_loaded_bytes;
+         i += safe_line_size_bytes, j += safe_full_image_line_size_bytes) {
         memcpy(tex_upload_buffer + i, addr + j, safe_line_size_bytes);
     }
 
     // Set the remaining bytes to load as 0
     if (num_loaded_bytes > resource_image_size_bytes) {
         memset(tex_upload_buffer + resource_image_size_bytes, 0, num_loaded_bytes - resource_image_size_bytes);
-    } 
+    }
 
     gfx_rapi->upload_texture(tex_upload_buffer, result_new_line_size / 4, result_new_height);
 }


### PR DESCRIPTION
There are some rare instances where the game will incorrectly load textures as the wrong size. In the event that a texture is loaded as a size greater than its actual size, the underlying `memcpy` would go out of bounds. On some platforms this would crash.

To account for this, I've adjusted the `memcpy` byte logic to safely bound to the raw resource image size if the expect copy bytes is larger. Then afterwards `memset` the remaining expected bytes to 0. The extra data being set as 0 results in the texture being black or transparent.

This crash/fix was noticed for Freezards and Iron Knuckles.

The downsides to this approach, is that the garbage data cannot be replicated from authentic behavior (presumably the overflow on hardware is just reading rom data).