### PR TITLE
fix: load exact in imgui

### DIFF
--- a/src/menu/ImGuiImpl.cpp
+++ b/src/menu/ImGuiImpl.cpp
@@ -1013,7 +1013,8 @@ ImTextureID GetTextureByID(int id) {
 
 void LoadResource(const std::string& name, const std::string& path, const ImVec4& tint) {
     GfxRenderingAPI* api = gfx_get_current_rendering_api();
-    const auto res = static_cast<Ship::Texture*>(Window::GetInstance()->GetResourceManager()->LoadResource(path).get());
+    const auto res =
+        static_cast<Ship::Texture*>(Window::GetInstance()->GetResourceManager()->LoadResource(path, true).get());
 
     std::vector<uint8_t> texBuffer;
     texBuffer.reserve(res->Width * res->Height * 4);

--- a/src/resource/ResourceMgr.cpp
+++ b/src/resource/ResourceMgr.cpp
@@ -169,7 +169,7 @@ std::shared_future<std::shared_ptr<Resource>> ResourceMgr::LoadResourceAsync(con
     // Check for and remove the OTR signature
     if (OtrSignatureCheck(filePath.c_str())) {
         auto newFilePath = filePath.substr(7);
-        return LoadResourceAsync(newFilePath);
+        return LoadResourceAsync(newFilePath, loadExact);
     }
 
     // Check the cache before queueing the job.


### PR DESCRIPTION
in SoH, `LoadResource` in `ImGuiImpl.cpp` is used to load the textures for the item tracker and the save editor. this only happens once (on game load).

this is currently leading to corrupt song and greg icons when using alternate assets (I'm assuming this has something to do with how we're using ImGui to apply colors),  as well as an inability to toggle between alternate and authentic icons.

as a short term fix, i decided it would make sense to have `LoadResource` in `ImGuiImpl.cpp` load exact resources, and always load the authentic icons for the item tracker and the save editor.

while implementing this, i noticed it was not working. i found this was because `loadExact` was not being passed into the recursive `LoadResourceAsync` call after removing `__OTR__`

a proper medium/long term fix for this is to actually toggle resources loaded in ImGui, i [created an issue for it here](https://github.com/HarbourMasters/Shipwright/issues/2776)

verified working in SoH ([testing PR](https://github.com/HarbourMasters/Shipwright/pull/2777))