### PR TITLE
GCC 13 support

### DIFF
--- a/extern/ZAPDUtils/Utils/StringHelper.h
+++ b/extern/ZAPDUtils/Utils/StringHelper.h
@@ -6,6 +6,7 @@
 #include <numeric>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class StringHelper
 {

--- a/src/controller/ControlDeck.cpp
+++ b/src/controller/ControlDeck.cpp
@@ -111,7 +111,7 @@ void ControlDeck::LoadControllerSettings() {
 
         for (size_t dev = 0; dev < mPhysicalDevices.size(); dev++) {
             std::string guid = mPhysicalDevices[dev]->GetGuid();
-            if (guid != val.value()) {
+            if (guid != val.value().get<std::string>()) {
                 continue;
             }
 

--- a/src/misc/stox.h
+++ b/src/misc/stox.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <cstdint>
 
 namespace Ship {
 bool stob(const std::string& s, bool defaultVal = false);


### PR DESCRIPTION
This fixes builds with GCC 13 due to the changes mentioned in [Porting to GCC 13](https://gcc.gnu.org/gcc-13/porting_to.html).
The main issue being `<cstdint>` no longer being widely used in libstdc++ and is now needed to be included explicitly.
