### PR TITLE
ZAPDUtils vec struct rework for save thread support courtesy of rozelette

### DIFF
--- a/extern/ZAPDUtils/Vec2f.h
+++ b/extern/ZAPDUtils/Vec2f.h
@@ -2,18 +2,18 @@
 
 #include <cstdint>
 
-struct Vec2f
-{
-	float x, y;
+namespace ZAPDUtils {
 
-	Vec2f()
-	{
-		x = 0;
-		y = 0;
-	};
-	Vec2f(float nX, float nY)
-	{
-		x = nX;
-		y = nY;
-	};
+struct Vec2f {
+    float x, y;
+
+    Vec2f() {
+        x = 0;
+        y = 0;
+    };
+    Vec2f(float nX, float nY) {
+        x = nX;
+        y = nY;
+    };
 };
+} // namespace ZAPDUtils

--- a/extern/ZAPDUtils/Vec3f.h
+++ b/extern/ZAPDUtils/Vec3f.h
@@ -1,19 +1,19 @@
 #pragma once
 
-struct Vec3f
-{
-	float x, y, z;
+namespace ZAPDUtils {
 
-	Vec3f()
-	{
-		x = 0;
-		y = 0;
-		z = 0;
-	};
-	Vec3f(float nX, float nY, float nZ)
-	{
-		x = nX;
-		y = nY;
-		z = nZ;
-	};
+struct Vec3f {
+    float x, y, z;
+
+    Vec3f() {
+        x = 0;
+        y = 0;
+        z = 0;
+    };
+    Vec3f(float nX, float nY, float nZ) {
+        x = nX;
+        y = nY;
+        z = nZ;
+    };
 };
+} // namespace ZAPDUtils

--- a/extern/ZAPDUtils/Vec3s.h
+++ b/extern/ZAPDUtils/Vec3s.h
@@ -2,20 +2,20 @@
 
 #include <cstdint>
 
-struct Vec3s
-{
-	int16_t x, y, z;
+namespace ZAPDUtils {
 
-	Vec3s()
-	{
-		x = 0;
-		y = 0;
-		z = 0;
-	};
-	Vec3s(int16_t nX, int16_t nY, int16_t nZ)
-	{
-		x = nX;
-		y = nY;
-		z = nZ;
-	};
+struct Vec3s {
+    int16_t x, y, z;
+
+    Vec3s() {
+        x = 0;
+        y = 0;
+        z = 0;
+    };
+    Vec3s(int16_t nX, int16_t nY, int16_t nZ) {
+        x = nX;
+        y = nY;
+        z = nZ;
+    };
 };
+} // namespace ZAPDUtils

--- a/src/binarytools/BinaryReader.cpp
+++ b/src/binarytools/BinaryReader.cpp
@@ -163,20 +163,20 @@ double Ship::BinaryReader::ReadDouble() {
     return result;
 }
 
-Vec3f Ship::BinaryReader::ReadVec3f() {
-    return Vec3f();
+ZAPDUtils::Vec3f Ship::BinaryReader::ReadVec3f() {
+    return ZAPDUtils::Vec3f();
 }
 
-Vec3s Ship::BinaryReader::ReadVec3s() {
-    return Vec3s(0, 0, 0);
+ZAPDUtils::Vec3s Ship::BinaryReader::ReadVec3s() {
+    return ZAPDUtils::Vec3s(0, 0, 0);
 }
 
-Vec3s Ship::BinaryReader::ReadVec3b() {
-    return Vec3s(0, 0, 0);
+ZAPDUtils::Vec3s Ship::BinaryReader::ReadVec3b() {
+    return ZAPDUtils::Vec3s(0, 0, 0);
 }
 
-Vec2f Ship::BinaryReader::ReadVec2f() {
-    return Vec2f();
+ZAPDUtils::Vec2f Ship::BinaryReader::ReadVec2f() {
+    return ZAPDUtils::Vec2f();
 }
 
 Color3b Ship::BinaryReader::ReadColor3b() {

--- a/src/binarytools/BinaryReader.h
+++ b/src/binarytools/BinaryReader.h
@@ -40,10 +40,10 @@ class BinaryReader {
     uint64_t ReadUInt64();
     float ReadFloat();
     double ReadDouble();
-    Vec3f ReadVec3f();
-    Vec3s ReadVec3s();
-    Vec3s ReadVec3b();
-    Vec2f ReadVec2f();
+    ZAPDUtils::Vec3f ReadVec3f();
+    ZAPDUtils::Vec3s ReadVec3s();
+    ZAPDUtils::Vec3s ReadVec3b();
+    ZAPDUtils::Vec2f ReadVec2f();
     Color3b ReadColor3b();
     std::string ReadString();
     std::string ReadCString();


### PR DESCRIPTION
Encapsulates `Vec2f`, `Vec3f`, and `Vec3s` structs into `ZAPDUtils` namespace to isolate from structures that could exist in other codebases (like `z64math` in SoH).