### PR TITLE
update mac to use SHIP_HOME for app dir

### DIFF
--- a/src/core/Window.cpp
+++ b/src/core/Window.cpp
@@ -164,14 +164,7 @@ std::string Window::GetAppBundlePath() {
 }
 
 std::string Window::GetAppDirectoryPath() {
-#ifdef __APPLE__
-    FolderManager folderManager;
-    std::string fpath = std::string(folderManager.pathForDirectory(NSApplicationSupportDirectory, NSUserDomainMask));
-    fpath.append("/com.libultraship." + Window::GetInstance()->GetShortName());
-    return fpath;
-#endif
-
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     char* fpath = std::getenv("SHIP_HOME");
     if (fpath != NULL) {
         return std::string(fpath);


### PR DESCRIPTION
have mac use `SHIP_HOME` which will be set from the launch script similar to linux