### PR TITLE
Resource Load Logging Changes

### DIFF
--- a/src/resource/Archive.cpp
+++ b/src/resource/Archive.cpp
@@ -91,7 +91,7 @@ std::shared_ptr<File> Archive::LoadFileFromHandle(const std::string& filePath, b
         bool attempt = SFileOpenFileEx(mpqHandle, filePath.c_str(), 0, &fileHandle);
 
         if (!attempt) {
-            SPDLOG_ERROR("({}) Failed to open file {} from mpq archive  {}.", GetLastError(), filePath, mMainPath);
+            SPDLOG_TRACE("({}) Failed to open file {} from mpq archive  {}.", GetLastError(), filePath, mMainPath);
             return nullptr;
         }
 

--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -64,7 +64,7 @@ std::shared_ptr<File> ResourceManager::LoadFileProcess(const std::string& filePa
     if (file != nullptr) {
         SPDLOG_TRACE("Loaded File {} on ResourceManager", file->Path);
     } else {
-        SPDLOG_WARN("Could not load File {} in ResourceManager", filePath);
+        SPDLOG_TRACE("Could not load File {} in ResourceManager", filePath);
     }
     return file;
 }
@@ -114,7 +114,7 @@ std::shared_ptr<Resource> ResourceManager::LoadResourceProcess(const std::string
     // Get the file from the OTR
     auto file = LoadFileProcess(filePath);
     if (file == nullptr) {
-        SPDLOG_ERROR("Failed to load resource file at path {}", filePath);
+        SPDLOG_TRACE("Failed to load resource file at path {}", filePath);
     }
 
     // Transform the raw data into a resource
@@ -143,7 +143,7 @@ std::shared_ptr<Resource> ResourceManager::LoadResourceProcess(const std::string
     if (resource != nullptr) {
         SPDLOG_TRACE("Loaded Resource {} on ResourceManager", filePath);
     } else {
-        SPDLOG_WARN("Resource load FAILED {} on ResourceManager", filePath);
+        SPDLOG_TRACE("Resource load FAILED {} on ResourceManager", filePath);
     }
 
     return resource;

--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -179,7 +179,11 @@ std::shared_future<std::shared_ptr<Resource>> ResourceManager::LoadResourceAsync
 }
 
 std::shared_ptr<Resource> ResourceManager::LoadResource(const std::string& filePath, bool loadExact) {
-    return LoadResourceAsync(filePath, loadExact).get();
+    auto resource = LoadResourceAsync(filePath, loadExact).get();
+    if (resource == nullptr) {
+        SPDLOG_ERROR("Failed to load resource file at path {}", filePath);
+    }
+    return resource;
 }
 
 std::variant<ResourceManager::ResourceLoadError, std::shared_ptr<Resource>>


### PR DESCRIPTION
Change logging for resource loading to TRACE to prevent unnecessary log spam for missing alternate assets in releases.