### PR TITLE
Fixes audio initialization for Windows.

### DIFF
--- a/src/core/Context.cpp
+++ b/src/core/Context.cpp
@@ -74,9 +74,9 @@ void Context::Init(const std::vector<std::string>& otrFiles, const std::unordere
     CreateDefaultSettings();
     InitControlDeck();
     InitCrashHandler();
-    InitAudio();
     InitConsole();
     InitWindow();
+    InitAudio();
 
     LUS::RegisterHook<ExitGame>([this]() { mControlDeck->SaveSettings(); });
 }


### PR DESCRIPTION
Wasapi audio context needs to be initialized before the Window.