### PR TITLE
fix: don't crash trying to load textures before we finish gfx_init

### DIFF
--- a/src/window/Window.cpp
+++ b/src/window/Window.cpp
@@ -89,6 +89,7 @@ void Window::Init() {
 
     gfx_init(mWindowManagerApi, mRenderingApi, LUS::Context::GetInstance()->GetName().c_str(), mIsFullscreen, mWidth,
              mHeight);
+    GetGui()->LoadDefaultGuiTextures();
     mWindowManagerApi->set_fullscreen_changed_callback(OnFullscreenChanged);
     mWindowManagerApi->set_keyboard_callbacks(KeyDown, KeyUp, AllKeysUp);
     SetTextureFilter((FilteringMode)CVarGetInteger("gTextureFilter", FILTER_THREE_POINT));

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -144,18 +144,6 @@ void Gui::Init(GuiWindowInitData windowImpl) {
         Context::GetInstance()->GetWindow()->SetCursorVisibility(GetMenuBar() && GetMenuBar()->IsVisible());
     }
 
-    LoadTexture("Game_Icon", "textures/icons/gIcon.png");
-    LoadTexture("A-Btn", "textures/buttons/ABtn.png");
-    LoadTexture("B-Btn", "textures/buttons/BBtn.png");
-    LoadTexture("L-Btn", "textures/buttons/LBtn.png");
-    LoadTexture("R-Btn", "textures/buttons/RBtn.png");
-    LoadTexture("Z-Btn", "textures/buttons/ZBtn.png");
-    LoadTexture("Start-Btn", "textures/buttons/StartBtn.png");
-    LoadTexture("C-Left", "textures/buttons/CLeft.png");
-    LoadTexture("C-Right", "textures/buttons/CRight.png");
-    LoadTexture("C-Up", "textures/buttons/CUp.png");
-    LoadTexture("C-Down", "textures/buttons/CDown.png");
-
     CVarClear("gNewFileDropped");
     CVarClear("gDroppedFile");
 
@@ -225,6 +213,21 @@ void Gui::ImGuiBackendInit() {
         default:
             break;
     }
+}
+
+// otrtodo: not sure if i like this name
+void Gui::LoadDefaultGuiTextures() {
+    LoadTexture("Game_Icon", "textures/icons/gIcon.png");
+    LoadTexture("A-Btn", "textures/buttons/ABtn.png");
+    LoadTexture("B-Btn", "textures/buttons/BBtn.png");
+    LoadTexture("L-Btn", "textures/buttons/LBtn.png");
+    LoadTexture("R-Btn", "textures/buttons/RBtn.png");
+    LoadTexture("Z-Btn", "textures/buttons/ZBtn.png");
+    LoadTexture("Start-Btn", "textures/buttons/StartBtn.png");
+    LoadTexture("C-Left", "textures/buttons/CLeft.png");
+    LoadTexture("C-Right", "textures/buttons/CRight.png");
+    LoadTexture("C-Up", "textures/buttons/CUp.png");
+    LoadTexture("C-Down", "textures/buttons/CDown.png");
 }
 
 void Gui::LoadTexture(const std::string& name, const std::string& path) {

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -81,6 +81,7 @@ class Gui {
     std::shared_ptr<GameOverlay> GetGameOverlay();
     void SetMenuBar(std::shared_ptr<GuiMenuBar> menuBar);
     std::shared_ptr<GuiMenuBar> GetMenuBar();
+    void LoadDefaultGuiTextures();
 
   protected:
     void ImGuiWMInit();


### PR DESCRIPTION
in `gfx_init` we are calling `gfx_wapi->init(game_name, rapi->get_name(), start_in_fullscreen, width, height)` which calls `gfx_sdl_init` which calls `LUS::Context::GetInstance()->GetWindow()->GetGui()->Init(window_impl)` which was trying to load textures before we finished the `gfx_init` stuff (i'm assuming it's the `tex_upload_buffer` part that needs to happen first)

this just splits up the texture loading and calls it after gfx init, which fixes the crash

there might be a better way to handle this but nothing is coming to mind