### PR TITLE
Changed calculation for `threadCount` to prevent unsigned underflow.

### DIFF
--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -15,14 +15,14 @@ extern bool SFileCheckWildCard(const char* szString, const char* szWildCard);
 namespace LUS {
 
 ResourceManager::ResourceManager(const std::string& mainPath, const std::string& patchesPath,
-                                 const std::unordered_set<uint32_t>& validHashes, uint32_t reservedThreadCount) {
+                                 const std::unordered_set<uint32_t>& validHashes, int32_t reservedThreadCount) {
     mResourceLoader = std::make_shared<ResourceLoader>();
     mArchive = std::make_shared<Archive>(mainPath, patchesPath, validHashes, false);
 #if defined(__SWITCH__) || defined(__WIIU__)
     size_t threadCount = 1;
 #else
     // the extra `- 1` is because we reserve an extra thread for spdlog
-    size_t threadCount = std::max(1, (int)(std::thread::hardware_concurrency() - reservedThreadCount - 1));
+    size_t threadCount = std::max(1, (int32_t)(std::thread::hardware_concurrency() - reservedThreadCount - 1));
 #endif
     mThreadPool = std::make_shared<BS::thread_pool>(threadCount);
 
@@ -33,14 +33,14 @@ ResourceManager::ResourceManager(const std::string& mainPath, const std::string&
 }
 
 ResourceManager::ResourceManager(const std::vector<std::string>& otrFiles,
-                                 const std::unordered_set<uint32_t>& validHashes, uint32_t reservedThreadCount) {
+                                 const std::unordered_set<uint32_t>& validHashes, int32_t reservedThreadCount) {
     mResourceLoader = std::make_shared<ResourceLoader>();
     mArchive = std::make_shared<Archive>(otrFiles, validHashes, false);
 #if defined(__SWITCH__) || defined(__WIIU__)
     size_t threadCount = 1;
 #else
     // the extra `- 1` is because we reserve an extra thread for spdlog
-    size_t threadCount = std::max(1, (int)(std::thread::hardware_concurrency() - reservedThreadCount - 1));
+    size_t threadCount = std::max(1, (int32_t)(std::thread::hardware_concurrency() - reservedThreadCount - 1));
 #endif
     mThreadPool = std::make_shared<BS::thread_pool>(threadCount);
 

--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -22,7 +22,7 @@ ResourceManager::ResourceManager(const std::string& mainPath, const std::string&
     size_t threadCount = 1;
 #else
     // the extra `- 1` is because we reserve an extra thread for spdlog
-    size_t threadCount = std::max(1U, (std::thread::hardware_concurrency() - reservedThreadCount - 1));
+    size_t threadCount = std::max(1, (int)(std::thread::hardware_concurrency() - reservedThreadCount - 1));
 #endif
     mThreadPool = std::make_shared<BS::thread_pool>(threadCount);
 
@@ -40,7 +40,7 @@ ResourceManager::ResourceManager(const std::vector<std::string>& otrFiles,
     size_t threadCount = 1;
 #else
     // the extra `- 1` is because we reserve an extra thread for spdlog
-    size_t threadCount = std::max(1U, (std::thread::hardware_concurrency() - reservedThreadCount - 1));
+    size_t threadCount = std::max(1, (int)(std::thread::hardware_concurrency() - reservedThreadCount - 1));
 #endif
     mThreadPool = std::make_shared<BS::thread_pool>(threadCount);
 

--- a/src/resource/ResourceManager.h
+++ b/src/resource/ResourceManager.h
@@ -22,9 +22,9 @@ class ResourceManager {
 
   public:
     ResourceManager(const std::string& mainPath, const std::string& patchesPath,
-                    const std::unordered_set<uint32_t>& validHashes, uint32_t reservedThreadCount = 1);
+                    const std::unordered_set<uint32_t>& validHashes, int32_t reservedThreadCount = 1);
     ResourceManager(const std::vector<std::string>& otrFiles, const std::unordered_set<uint32_t>& validHashes,
-                    uint32_t reservedThreadCount = 1);
+                    int32_t reservedThreadCount = 1);
     ~ResourceManager();
 
     bool DidLoadSuccessfully();


### PR DESCRIPTION
If the `reservedThreadCount` in `ResourceManager` was bigger than `hardware_concurrency`, the comparison for `std::max` would underflow to max positive value when calculating `hardware_concurrency() - reservedThreadCount - 1`, thus trying to create a thread pool with a max uint32_t value, causing an instant crash. This will prevent that underflow in max calculation. Machines with fewer threads available will still have issues, but are generally still mostly playable even in that state with this change.