### PR TITLE
vsync on for opengl

### DIFF
--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -50,7 +50,7 @@ static SDL_Window* wnd;
 static SDL_GLContext ctx;
 static SDL_Renderer* renderer;
 static int sdl_to_lus_table[512];
-static bool vsync_enabled = false;
+static bool vsync_enabled = true;
 // OTRTODO: These are redundant. Info can be queried from SDL.
 static int window_width = DESIRED_SCREEN_WIDTH;
 static int window_height = DESIRED_SCREEN_HEIGHT;


### PR DESCRIPTION
looks like an oversight in https://github.com/Kenix3/libultraship/pull/172 that was reported here https://github.com/HarbourMasters/Shipwright/issues/2895#issuecomment-1560122331

we have
https://github.com/Kenix3/libultraship/blob/ce43d0b83dbbe49357f23e1279b9b8dc4cf5ef34/src/graphic/Fast3D/gfx_sdl2.cpp#L565-L567

we could probably go the route of testing vsync off on opengl but that feels bigger than just making sure when we can't disable vsync we actually enable it 