### PR TITLE
Remove skip over ports 2 and 4

### DIFF
--- a/src/controller/ControlDeck.cpp
+++ b/src/controller/ControlDeck.cpp
@@ -293,7 +293,6 @@ void ControlDeck::SaveSettings() {
                 config->SetFloat(NESTED("GyroData.%d", key), val);
             }
 
-            virtualSlot++;
         }
     }
 

--- a/src/controller/ControlDeck.cpp
+++ b/src/controller/ControlDeck.cpp
@@ -292,7 +292,6 @@ void ControlDeck::SaveSettings() {
             for (auto const& [key, val] : profile->GyroData) {
                 config->SetFloat(NESTED("GyroData.%d", key), val);
             }
-
         }
     }
 


### PR DESCRIPTION
Not quite sure if there was any reason why the slots were increased again here but it resulted in the input configs for the 2nd and 4th ports to not be saved