### PR TITLE
Implement horizontal flipping support for gSPBgRectCopy

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2404,6 +2404,14 @@ static void gfx_s2dex_bg_copy(uObjBg* bg) {
         data = (uintptr_t) reinterpret_cast<char*>(tex->ImageData);
     }
 
+    s16 dsdx = 4 << 10;
+    s16 uls = bg->b.imageX << 3;
+    // Flip flag only flips horizontally
+    if (bg->b.imageFlip == G_BG_FLAG_FLIPS) {
+        dsdx = -dsdx;
+        uls = (bg->b.imageW - bg->b.imageX) << 3;
+    }
+
     SUPPORT_CHECK(bg->b.imageSiz == G_IM_SIZ_16b);
     gfx_dp_set_texture_image(G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, nullptr, texFlags, rawTexMetadata, (void*)data);
     gfx_dp_set_tile(G_IM_FMT_RGBA, G_IM_SIZ_16b, 0, 0, G_TX_LOADTILE, 0, 0, 0, 0, 0, 0, 0);
@@ -2412,8 +2420,8 @@ static void gfx_s2dex_bg_copy(uObjBg* bg) {
                     0);
     gfx_dp_set_tile_size(G_TX_RENDERTILE, 0, 0, bg->b.imageW, bg->b.imageH);
     gfx_dp_texture_rectangle(bg->b.frameX, bg->b.frameY, bg->b.frameX + bg->b.imageW - 4,
-                             bg->b.frameY + bg->b.imageH - 4, G_TX_RENDERTILE, bg->b.imageX << 3, bg->b.imageY << 3,
-                             4 << 10, 1 << 10, false);
+                             bg->b.frameY + bg->b.imageH - 4, G_TX_RENDERTILE, uls, bg->b.imageY << 3, dsdx, 1 << 10,
+                             false);
 }
 
 static inline void* seg_addr(uintptr_t w1) {


### PR DESCRIPTION
This implements the missing s-axis (horizontal) flipping for `gSPBgRectCopy` as detailed here http://n64devkit.square7.ch/n64man/gsp/gSPBgRectCopy.htm for Fast3D.

The `imageFlip` flag only supports horizontal flipping, and the flipping logic happens within this macro by reversing the dsdx value and starting the s-axis on the right edge instead of left edge.

This is relevant for "mirror world" mode in SoH to flip static backgrounds.