### PR TITLE
utilize the user configuration directory for configs and savefiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.16.0)
 
+option(NON_PORTABLE "Build a non-portable version" OFF)
+
 project(libultraship LANGUAGES C CXX)
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     enable_language(OBJCXX)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,9 +9,12 @@ endif()
 
 #=================== Top-Level ===================
 
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/install_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/install_config.h @ONLY)
+
 set(Source_Files__TopLevel
     ${CMAKE_CURRENT_SOURCE_DIR}/Context.h
     ${CMAKE_CURRENT_SOURCE_DIR}/Context.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/install_config.h
 )
 
 source_group("" FILES ${Source_Files__TopLevel})
@@ -351,7 +354,7 @@ endif()
 #=================== Packages & Includes ===================
 
 target_include_directories(libultraship
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../extern
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../extern ${CMAKE_CURRENT_BINARY_DIR}
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../extern/spdlog/include ${CMAKE_CURRENT_SOURCE_DIR}/../extern/stb
 )
 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -272,7 +272,7 @@ std::string Context::GetAppInstallationPath() {
         // Find the last '/' and remove everything after it
         int lastSlash = progpath.find_last_of("/");
         if (lastSlash != std::string::npos) {
-            progpath.erase(last_slash);
+            progpath.erase(lastSlash);
         }
 
         return progpath;

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -254,9 +254,9 @@ std::string Context::GetShortName() {
     return mShortName;
 }
 
-std::string Context::GetAppBundlePath() {
-#ifdef SHIP_BIN_DIR
-    return SHIP_BIN_DIR;
+std::string Context::GetAppInstallationPath() {
+#ifdef NON_PORTABLE
+    return CMAKE_INSTALL_PREFIX;
 #else
 #ifdef __APPLE__
     FolderManager folderManager;
@@ -275,6 +275,7 @@ std::string Context::GetAppDirectoryPath(std::string appname) {
     }
 #endif
 
+#ifdef NON_PORTABLE
     if (appname.empty()) {
         appname = GetInstance()->mShortName;
     }
@@ -284,12 +285,13 @@ std::string Context::GetAppDirectoryPath(std::string appname) {
         SDL_free(prefpath);
         return ret;
     }
+#endif
 
     return ".";
 }
 
-std::string Context::GetPathRelativeToAppBundle(const std::string path) {
-    return GetAppBundlePath() + "/" + path;
+std::string Context::GetPathRelativeToAppInstallation(const std::string path) {
+    return GetAppInstallationPath() + "/" + path;
 }
 
 std::string Context::GetPathRelativeToAppDirectory(const std::string path, std::string appname) {
@@ -305,7 +307,7 @@ std::string Context::LocateFileAcrossAppDirs(const std::string path, std::string
         return fpath;
     }
     // app install dir
-    fpath = GetPathRelativeToAppBundle(path);
+    fpath = GetPathRelativeToAppInstallation(path);
     if (std::filesystem::exists(fpath)) {
         return fpath;
     }

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -267,7 +267,7 @@ std::string Context::GetAppBundlePath() {
 #endif
 }
 
-std::string Context::GetAppDirectoryPath() {
+std::string Context::GetAppDirectoryPath(const std::string appname) {
 #if defined(__linux__) || defined(__APPLE__)
     char* fpath = std::getenv("SHIP_HOME");
     if (fpath != NULL) {
@@ -275,7 +275,7 @@ std::string Context::GetAppDirectoryPath() {
     }
 #endif
 
-    char* prefpath = SDL_GetPrefPath(NULL, GetInstance()->mShortName.c_str());
+    char* prefpath = SDL_GetPrefPath(NULL, appname.c_str());
     if (prefpath != NULL) {
         std::string ret(prefpath);
         SDL_free(prefpath);
@@ -289,15 +289,15 @@ std::string Context::GetPathRelativeToAppBundle(const std::string path) {
     return GetAppBundlePath() + "/" + path;
 }
 
-std::string Context::GetPathRelativeToAppDirectory(const std::string path) {
-    return GetAppDirectoryPath() + "/" + path;
+std::string Context::GetPathRelativeToAppDirectory(const std::string path, const std::string appname) {
+    return GetAppDirectoryPath(appname) + "/" + path;
 }
 
-std::string Context::LocateFileAcrossAppDirs(const std::string path) {
+std::string Context::LocateFileAcrossAppDirs(const std::string path, const std::string appname) {
     std::string fpath;
 
     // app configuration dir
-    fpath = GetPathRelativeToAppDirectory(path);
+    fpath = GetPathRelativeToAppDirectory(path, appname);
     if (std::filesystem::exists(fpath)) {
         return fpath;
     }

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -275,7 +275,7 @@ std::string Context::GetAppDirectoryPath() {
     }
 #endif
 
-    char *prefpath = SDL_GetPrefPath(NULL, "soh");
+    char* prefpath = SDL_GetPrefPath(NULL, "soh");
     if (prefpath != NULL) {
         std::string ret(prefpath);
         SDL_free(prefpath);

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -270,8 +270,8 @@ std::string Context::GetAppInstallationPath() {
         progpath.resize(len);
 
         // Find the last '/' and remove everything after it
-        int last_slash = progpath.find_last_of("/");
-        if (last_slash != std::string::npos) {
+        int lastSlash = progpath.find_last_of("/");
+        if (lastSlash != std::string::npos) {
             progpath.erase(last_slash);
         }
 
@@ -283,7 +283,7 @@ std::string Context::GetAppInstallationPath() {
 #endif
 }
 
-std::string Context::GetAppDirectoryPath(std::string appname) {
+std::string Context::GetAppDirectoryPath(std::string appName) {
 #if defined(__linux__) || defined(__APPLE__)
     char* fpath = std::getenv("SHIP_HOME");
     if (fpath != NULL) {
@@ -292,10 +292,10 @@ std::string Context::GetAppDirectoryPath(std::string appname) {
 #endif
 
 #ifdef NON_PORTABLE
-    if (appname.empty()) {
-        appname = GetInstance()->mShortName;
+    if (appName.empty()) {
+        appName = GetInstance()->mShortName;
     }
-    char* prefpath = SDL_GetPrefPath(NULL, appname.c_str());
+    char* prefpath = SDL_GetPrefPath(NULL, appName.c_str());
     if (prefpath != NULL) {
         std::string ret(prefpath);
         SDL_free(prefpath);
@@ -310,15 +310,15 @@ std::string Context::GetPathRelativeToAppInstallation(const std::string path) {
     return GetAppInstallationPath() + "/" + path;
 }
 
-std::string Context::GetPathRelativeToAppDirectory(const std::string path, std::string appname) {
-    return GetAppDirectoryPath(appname) + "/" + path;
+std::string Context::GetPathRelativeToAppDirectory(const std::string path, std::string appName) {
+    return GetAppDirectoryPath(appName) + "/" + path;
 }
 
-std::string Context::LocateFileAcrossAppDirs(const std::string path, std::string appname) {
+std::string Context::LocateFileAcrossAppDirs(const std::string path, std::string appName) {
     std::string fpath;
 
     // app configuration dir
-    fpath = GetPathRelativeToAppDirectory(path, appname);
+    fpath = GetPathRelativeToAppDirectory(path, appName);
     if (std::filesystem::exists(fpath)) {
         return fpath;
     }

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -267,7 +267,7 @@ std::string Context::GetAppBundlePath() {
 #endif
 }
 
-std::string Context::GetAppDirectoryPath(const std::string appname) {
+std::string Context::GetAppDirectoryPath() {
 #if defined(__linux__) || defined(__APPLE__)
     char* fpath = std::getenv("SHIP_HOME");
     if (fpath != NULL) {
@@ -275,7 +275,7 @@ std::string Context::GetAppDirectoryPath(const std::string appname) {
     }
 #endif
 
-    char* prefpath = SDL_GetPrefPath(NULL, appname.c_str());
+    char* prefpath = SDL_GetPrefPath(NULL, GetInstance()->mShortName.c_str());
     if (prefpath != NULL) {
         std::string ret(prefpath);
         SDL_free(prefpath);
@@ -289,15 +289,15 @@ std::string Context::GetPathRelativeToAppBundle(const std::string path) {
     return GetAppBundlePath() + "/" + path;
 }
 
-std::string Context::GetPathRelativeToAppDirectory(const std::string path, const std::string appname) {
-    return GetAppDirectoryPath(appname) + "/" + path;
+std::string Context::GetPathRelativeToAppDirectory(const std::string path) {
+    return GetAppDirectoryPath() + "/" + path;
 }
 
-std::string Context::LocateFileAcrossAppDirs(const std::string path, const std::string appname) {
+std::string Context::LocateFileAcrossAppDirs(const std::string path) {
     std::string fpath;
 
     // app configuration dir
-    fpath = GetPathRelativeToAppDirectory(path, appname);
+    fpath = GetPathRelativeToAppDirectory(path);
     if (std::filesystem::exists(fpath)) {
         return fpath;
     }

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -267,7 +267,7 @@ std::string Context::GetAppBundlePath() {
 #endif
 }
 
-std::string Context::GetAppDirectoryPath() {
+std::string Context::GetAppDirectoryPath(std::string appname) {
 #if defined(__linux__) || defined(__APPLE__)
     char* fpath = std::getenv("SHIP_HOME");
     if (fpath != NULL) {
@@ -275,7 +275,10 @@ std::string Context::GetAppDirectoryPath() {
     }
 #endif
 
-    char* prefpath = SDL_GetPrefPath(NULL, GetInstance()->mShortName.c_str());
+    if (appname.empty()) {
+        appname = GetInstance()->mShortName;
+    }
+    char* prefpath = SDL_GetPrefPath(NULL, appname.c_str());
     if (prefpath != NULL) {
         std::string ret(prefpath);
         SDL_free(prefpath);
@@ -289,15 +292,15 @@ std::string Context::GetPathRelativeToAppBundle(const std::string path) {
     return GetAppBundlePath() + "/" + path;
 }
 
-std::string Context::GetPathRelativeToAppDirectory(const std::string path) {
-    return GetAppDirectoryPath() + "/" + path;
+std::string Context::GetPathRelativeToAppDirectory(const std::string path, std::string appname) {
+    return GetAppDirectoryPath(appname) + "/" + path;
 }
 
-std::string Context::LocateFileAcrossAppDirs(const std::string path) {
+std::string Context::LocateFileAcrossAppDirs(const std::string path, std::string appname) {
     std::string fpath;
 
     // app configuration dir
-    fpath = GetPathRelativeToAppDirectory(path);
+    fpath = GetPathRelativeToAppDirectory(path, appname);
     if (std::filesystem::exists(fpath)) {
         return fpath;
     }

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -268,9 +268,9 @@ std::string Context::GetAppInstallationPath() {
     int len = readlink("/proc/self/exe", &progpath[0], progpath.size() - 1);
     if (len != -1) {
         progpath.resize(len);
-        
+
         // Find the last '/' and remove everything after it
-        size last_slash = progpath.find_last_of("/");
+        int last_slash = progpath.find_last_of("/");
         if (last_slash != std::string::npos) {
             progpath.erase(last_slash);
         }

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -263,6 +263,22 @@ std::string Context::GetAppInstallationPath() {
     return folderManager.getMainBundlePath();
 #endif
 
+#ifdef __linux__
+    std::string progpath(PATH_MAX, '\0');
+    int len = readlink("/proc/self/exe", &progpath[0], progpath.size() - 1);
+    if (len != -1) {
+        progpath.resize(len);
+        
+        // Find the last '/' and remove everything after it
+        size last_slash = progpath.find_last_of("/");
+        if (last_slash != std::string::npos) {
+            progpath.erase(last_slash);
+        }
+
+        return progpath;
+    }
+#endif
+
     return ".";
 #endif
 }

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -275,7 +275,7 @@ std::string Context::GetAppDirectoryPath() {
     }
 #endif
 
-    char* prefpath = SDL_GetPrefPath(NULL, "soh");
+    char* prefpath = SDL_GetPrefPath(NULL, GetInstance()->mShortName.c_str());
     if (prefpath != NULL) {
         std::string ret(prefpath);
         SDL_free(prefpath);

--- a/src/Context.h
+++ b/src/Context.h
@@ -29,6 +29,7 @@ class Context {
     static std::string GetAppDirectoryPath();
     static std::string GetPathRelativeToAppDirectory(const std::string path);
     static std::string GetPathRelativeToAppBundle(const std::string path);
+    static std::string LocateFileAcrossAppDirs(const std::string path);
 
     Context(std::string name, std::string shortName, std::string configFilePath);
     ~Context();

--- a/src/Context.h
+++ b/src/Context.h
@@ -26,10 +26,10 @@ class Context {
                                                    uint32_t reservedThreadCount = 1);
 
     static std::string GetAppBundlePath();
-    static std::string GetAppDirectoryPath();
-    static std::string GetPathRelativeToAppDirectory(const std::string path);
+    static std::string GetAppDirectoryPath(const std::string appname);
+    static std::string GetPathRelativeToAppDirectory(const std::string path, const std::string appname);
     static std::string GetPathRelativeToAppBundle(const std::string path);
-    static std::string LocateFileAcrossAppDirs(const std::string path);
+    static std::string LocateFileAcrossAppDirs(const std::string path, const std::string appname);
 
     Context(std::string name, std::string shortName, std::string configFilePath);
     ~Context();

--- a/src/Context.h
+++ b/src/Context.h
@@ -26,10 +26,10 @@ class Context {
                                                    uint32_t reservedThreadCount = 1);
 
     static std::string GetAppBundlePath();
-    static std::string GetAppDirectoryPath(const std::string appname);
-    static std::string GetPathRelativeToAppDirectory(const std::string path, const std::string appname);
+    static std::string GetAppDirectoryPath();
+    static std::string GetPathRelativeToAppDirectory(const std::string path);
     static std::string GetPathRelativeToAppBundle(const std::string path);
-    static std::string LocateFileAcrossAppDirs(const std::string path, const std::string appname);
+    static std::string LocateFileAcrossAppDirs(const std::string path);
 
     Context(std::string name, std::string shortName, std::string configFilePath);
     ~Context();

--- a/src/Context.h
+++ b/src/Context.h
@@ -26,10 +26,10 @@ class Context {
                                                    uint32_t reservedThreadCount = 1);
 
     static std::string GetAppBundlePath();
-    static std::string GetAppDirectoryPath();
-    static std::string GetPathRelativeToAppDirectory(const std::string path);
+    static std::string GetAppDirectoryPath(std::string appname = "");
+    static std::string GetPathRelativeToAppDirectory(const std::string path, std::string appname = "");
     static std::string GetPathRelativeToAppBundle(const std::string path);
-    static std::string LocateFileAcrossAppDirs(const std::string path);
+    static std::string LocateFileAcrossAppDirs(const std::string path, std::string appname = "");
 
     Context(std::string name, std::string shortName, std::string configFilePath);
     ~Context();

--- a/src/Context.h
+++ b/src/Context.h
@@ -26,10 +26,10 @@ class Context {
                                                    uint32_t reservedThreadCount = 1);
 
     static std::string GetAppInstallationPath();
-    static std::string GetAppDirectoryPath(std::string appname = "");
-    static std::string GetPathRelativeToAppDirectory(const std::string path, std::string appname = "");
+    static std::string GetAppDirectoryPath(std::string appName = "");
+    static std::string GetPathRelativeToAppDirectory(const std::string path, std::string appName = "");
     static std::string GetPathRelativeToAppInstallation(const std::string path);
-    static std::string LocateFileAcrossAppDirs(const std::string path, std::string appname = "");
+    static std::string LocateFileAcrossAppDirs(const std::string path, std::string appName = "");
 
     Context(std::string name, std::string shortName, std::string configFilePath);
     ~Context();

--- a/src/Context.h
+++ b/src/Context.h
@@ -25,10 +25,10 @@ class Context {
                                                    const std::unordered_set<uint32_t>& validHashes = {},
                                                    uint32_t reservedThreadCount = 1);
 
-    static std::string GetAppBundlePath();
+    static std::string GetAppInstallationPath();
     static std::string GetAppDirectoryPath(std::string appname = "");
     static std::string GetPathRelativeToAppDirectory(const std::string path, std::string appname = "");
-    static std::string GetPathRelativeToAppBundle(const std::string path);
+    static std::string GetPathRelativeToAppInstallation(const std::string path);
     static std::string LocateFileAcrossAppDirs(const std::string path, std::string appname = "");
 
     Context(std::string name, std::string shortName, std::string configFilePath);

--- a/src/install_config.h.in
+++ b/src/install_config.h.in
@@ -1,0 +1,1 @@
+#cmakedefine SHIP_BIN_DIR "@SHIP_BIN_DIR@"

--- a/src/install_config.h.in
+++ b/src/install_config.h.in
@@ -1,1 +1,2 @@
-#cmakedefine SHIP_BIN_DIR "@SHIP_BIN_DIR@"
+#define CMAKE_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@"
+#cmakedefine NON_PORTABLE

--- a/src/public/libultra/os.cpp
+++ b/src/public/libultra/os.cpp
@@ -14,8 +14,8 @@ int32_t osContInit(OSMesgQueue* mq, uint8_t* controllerBits, OSContStatus* statu
     }
 
 #ifndef __SWITCH__
-    const char* controllerDb = "gamecontrollerdb.txt";
-    int mappingsAdded = SDL_GameControllerAddMappingsFromFile(controllerDb);
+    std::string controllerDb = LUS::Context::LocateFileAcrossAppDirs("gamecontrollerdb.txt");
+    int mappingsAdded = SDL_GameControllerAddMappingsFromFile(controllerDb.c_str());
     if (mappingsAdded >= 0) {
         SPDLOG_INFO("Added SDL game controllers from \"{}\" ({})", controllerDb, mappingsAdded);
     } else {


### PR DESCRIPTION
This change is based from the [patch in this unofficial AUR package](https://aur.archlinux.org/cgit/aur.git/tree/lus-install-paths.patch?h=soh&id=1ec450651c23837ed1a158e2d61440c732b72710) and has been implemented for quite some time now, so the goal of it is to address or introduce some issues or ideas related to installation paths on Linux systems or anything path related.

Some of the few key changes are:

- The **`Context::GetAppDirectoryPath`** function now returns the location of the user's application data directory using [`SDL_GetPrefPath`](https://wiki.libsdl.org/SDL2/SDL_GetPrefPath). This means any game configurations or save files will be stored and read from that directory. This can be overridden by the `SHIP_HOME` environment variable. By default, this function returns `~/.local/share/soh` on Linux or `%APPDATA%\soh` on Windows.
- The **`Context::GetAppBundlePath`** (replaced with *`Context::GetAppInstallationPath`*) function now hardcodes the installation path utilizing `CMAKE_INSTALL_PREFIX` instead of the `SHIP_BIN_DIR` environment variable, by activating `NON_PORTABLE` in the configure flags. (In the aforementioned AUR package the installation prefix is set to `/opt/soh`). ~~Also, I've removed the SHIP_BIN_DIR env var as said and done it's only exclusive to Ship.~~ **Update: When on Linux and is portable, it now gives the program's path instead, thus SHIP_BIN_DIR is not needed.**
- Added **`Context::LocateFileAcrossAppDirs`** to search for a given file in the above paths. If the file is not found, it prepends `./` to the file path without checking. 

~~Note that this modifies where application data (typically configuration and save files) is stored.~~ **Update: I've added the configure option `-DNON_PORTABLE=ON` to seperate portability and system-installed** Now these files are located in the OS-specific directories mentioned above instead of the current directory where the program is running. When the game launches unless you did move them, it will reset to the original state. Let me know what are other problems arise from this. Additionally you can check for any other potential issues that I haven't looked upon.