### PR TITLE
Implements Config Versioning

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -57,39 +57,12 @@ Context::Context(std::string name, std::string shortName, std::string configFile
     : mName(std::move(name)), mShortName(std::move(shortName)), mConfigFilePath(std::move(configFilePath)) {
 }
 
-void Context::CreateDefaultSettings() {
-    if (GetConfig()->IsNewInstance()) {
-        GetConfig()->SetInt("Window.Width", 640);
-        GetConfig()->SetInt("Window.Height", 480);
-        GetConfig()->SetInt("Window.PositionX", 100);
-        GetConfig()->SetInt("Window.PositionY", 100);
-
-        GetConfig()->SetString("Window.GfxBackend", "");
-        GetConfig()->SetString("Window.GfxApi", "");
-        GetConfig()->SetString("Window.AudioBackend", "");
-
-        GetConfig()->SetBool("Window.Fullscreen.Enabled", false);
-        GetConfig()->SetInt("Window.Fullscreen.Width", 1920);
-        GetConfig()->SetInt("Window.Fullscreen.Height", 1080);
-
-        GetConfig()->SetString("Game.SaveName", "");
-        GetConfig()->SetString("Game.Main Archive", "");
-        GetConfig()->SetString("Game.Patches Archive", "");
-
-        GetConfig()->SetInt("Shortcuts.Fullscreen", KbScancode::LUS_KB_F11);
-        GetConfig()->SetInt("Shortcuts.Console", KbScancode::LUS_KB_OEM_3);
-
-        GetConfig()->Save();
-    }
-}
-
 void Context::Init(const std::vector<std::string>& otrFiles, const std::unordered_set<uint32_t>& validHashes,
                    uint32_t reservedThreadCount) {
     InitLogging();
     InitConfiguration();
     InitConsoleVariables();
     InitResourceManager(otrFiles, validHashes, reservedThreadCount);
-    CreateDefaultSettings();
     InitControlDeck();
     InitCrashHandler();
     InitConsole();

--- a/src/Context.h
+++ b/src/Context.h
@@ -50,7 +50,6 @@ class Context {
     std::string GetName();
     std::string GetShortName();
 
-    void CreateDefaultSettings();
     void InitLogging();
     void InitConfiguration();
     void InitConsoleVariables();

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -273,15 +273,15 @@ bool Config::RegisterConfigVersionUpdater(std::shared_ptr<ConfigVersionUpdater> 
 void Config::RunVersionUpdates() {
     for (auto [_, versionUpdater] : mVersionUpdaters) {
         uint32_t version = GetUInt("ConfigVersion", 0);
-        if (version == versionUpdater->GetVersion()) {
+        if (version < versionUpdater->GetVersion()) {
             versionUpdater->Update(this);
-            SetUInt("ConfigVersion", version + 1);
+            SetUInt("ConfigVersion", versionUpdater->GetVersion());
         }
     }
     Save();
 }
 
-ConfigVersionUpdater::ConfigVersionUpdater(uint32_t version) : mVersion(version) {
+ConfigVersionUpdater::ConfigVersionUpdater(uint32_t toVersion) : mVersion(toVersion) {
 }
 
 uint32_t ConfigVersionUpdater::GetVersion() {

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -272,9 +272,10 @@ void Config::RegisterConfigVersion(std::shared_ptr<ConfigVersionUpdater> version
 void Config::RunVersionUpdates() {
     uint32_t version = GetUInt("ConfigVersion", 0);
     for (uint32_t i = version; i < mVersions.size(); i++) {
-        mVersions[i]->Update(std::shared_ptr<Config>(this));
+        mVersions[i]->Update(this);
         SetUInt("ConfigVersion", i + 1);
     }
+    Save();
 }
 
 } // namespace LUS

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -265,4 +265,16 @@ void Config::SetWindowBackend(WindowBackend backend) {
     }
 }
 
+void Config::RegisterConfigVersion(std::shared_ptr<ConfigVersionUpdater> version) {
+    mVersions.push_back(version);
+}
+
+void Config::RunVersionUpdates() {
+    uint32_t version = GetUInt("ConfigVersion", 0);
+    for (uint32_t i = version; i < mVersions.size(); i++) {
+        mVersions[i]->Update(std::shared_ptr<Config>(this));
+        SetUInt("ConfigVersion", i + 1);
+    }
+}
+
 } // namespace LUS

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -281,7 +281,7 @@ void Config::RunVersionUpdates() {
     Save();
 }
 
-ConfigVersionUpdater::ConfigVersionUpdater(uint32_t version_) : mVersion(version_) {
+ConfigVersionUpdater::ConfigVersionUpdater(uint32_t version) : mVersion(version) {
 }
 
 uint32_t ConfigVersionUpdater::GetVersion() {

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -22,13 +22,14 @@ namespace LUS {
 class ConfigVersionUpdater {
   protected:
     uint32_t mVersion;
+
   public:
-    ConfigVersionUpdater(uint32_t version_);
+    ConfigVersionUpdater(uint32_t version);
     /**
      * @brief Performs actions on a Config object via the provided pointer to update it
      * to the next version. (i.e. removing/changing default values or renaming options)
-     * 
-     * @param conf 
+     *
+     * @param conf
      */
     virtual void Update(Config* conf) = 0;
 
@@ -69,8 +70,8 @@ class Config {
 
     /**
      * @brief Adds a ConfigVersionUpdater instance to the list to be run later via RunVersionUpdates
-     * 
-     * @param versionUpdater 
+     *
+     * @param versionUpdater
      * @return true if the insert was successful, or
      * @return false if the insert failed, i.e. if the list already has a ConfigVersionUpdater with
      * a matching version.
@@ -80,7 +81,7 @@ class Config {
     /**
      * @brief Runs the Update function on each ConfigVersionUpdater instance if the version matches\
      * the current ConfigVersion value of the config object.
-     * 
+     *
      */
     void RunVersionUpdates();
 

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -8,9 +8,36 @@
 #include "window/Window.h"
 
 namespace LUS {
+
+/**
+ * @brief Abstract class representing a Config Version Updater, intended to express how to
+ * upgrade a Configuration file from one version of a config to another (i.e. removing
+ * default values, changing option names, etc.) It can be used by subclassing `ConfigVersionUpdater`,
+ * implementing the Update function, and implementing the Constructor passing the version that the
+ * Config is being updated from to this class' constructor from the child class' default constructor.
+ * For example: \code ConfigVersion0Updater() : ConfigVersionUpdater(0) {} \endcode
+ * Finally, give an instance of this subclass to a Config object via
+ * RegisterConfigVersionUpdater and call RunVersionUpdates.
+ */
 class ConfigVersionUpdater {
+  protected:
+    uint32_t mVersion;
   public:
+    ConfigVersionUpdater(uint32_t version_);
+    /**
+     * @brief Performs actions on a Config object via the provided pointer to update it
+     * to the next version. (i.e. removing/changing default values or renaming options)
+     * 
+     * @param conf 
+     */
     virtual void Update(Config* conf) = 0;
+
+    /**
+     * @brief Get the value of mVersion
+     * 
+     * @return uint32_t 
+     */
+    uint32_t GetVersion();
 };
 class Config {
   public:
@@ -40,7 +67,21 @@ class Config {
     WindowBackend GetWindowBackend();
     void SetWindowBackend(WindowBackend backend);
 
-    void RegisterConfigVersion(std::shared_ptr<ConfigVersionUpdater> version);
+    /**
+     * @brief Adds a ConfigVersionUpdater instance to the list to be run later via RunVersionUpdates
+     * 
+     * @param versionUpdater 
+     * @return true if the insert was successful, or
+     * @return false if the insert failed, i.e. if the list already has a ConfigVersionUpdater with
+     * a matching version.
+     */
+    bool RegisterConfigVersionUpdater(std::shared_ptr<ConfigVersionUpdater> versionUpdater);
+
+    /**
+     * @brief Runs the Update function on each ConfigVersionUpdater instance if the version matches\
+     * the current ConfigVersion value of the config object.
+     * 
+     */
     void RunVersionUpdates();
 
   protected:
@@ -54,6 +95,6 @@ class Config {
     nlohmann::json mNestedJson;
     std::string mPath;
     bool mIsNewInstance;
-    std::vector<std::shared_ptr<ConfigVersionUpdater>> mVersions;
+    std::map<uint32_t, std::shared_ptr<ConfigVersionUpdater>> mVersionUpdaters;
 };
 } // namespace LUS

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -14,8 +14,8 @@ namespace LUS {
  * upgrade a Configuration file from one version of a config to another (i.e. removing
  * default values, changing option names, etc.) It can be used by subclassing `ConfigVersionUpdater`,
  * implementing the Update function, and implementing the Constructor passing the version that the
- * Config is being updated from to this class' constructor from the child class' default constructor.
- * For example: \code ConfigVersion0Updater() : ConfigVersionUpdater(0) {} \endcode
+ * Config is being updated to to this class' constructor from the child class' default constructor.
+ * For example: \code ConfigVersion1Updater() : ConfigVersionUpdater(1) {} \endcode
  * Finally, give an instance of this subclass to a Config object via
  * RegisterConfigVersionUpdater and call RunVersionUpdates.
  */
@@ -24,7 +24,7 @@ class ConfigVersionUpdater {
     uint32_t mVersion;
 
   public:
-    ConfigVersionUpdater(uint32_t version);
+    ConfigVersionUpdater(uint32_t toVersion);
     /**
      * @brief Performs actions on a Config object via the provided pointer to update it
      * to the next version. (i.e. removing/changing default values or renaming options)

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -8,6 +8,10 @@
 #include "window/Window.h"
 
 namespace LUS {
+class ConfigVersionUpdater {
+  public:
+    virtual void Update(std::shared_ptr<Config> conf) = 0;
+};
 class Config {
   public:
     Config(std::string path);
@@ -36,6 +40,9 @@ class Config {
     WindowBackend GetWindowBackend();
     void SetWindowBackend(WindowBackend backend);
 
+    void RegisterConfigVersion(std::shared_ptr<ConfigVersionUpdater> version);
+    void RunVersionUpdates();
+
   protected:
     nlohmann::json Nested(const std::string& key);
     static std::string FormatNestedKey(const std::string& key);
@@ -47,5 +54,6 @@ class Config {
     nlohmann::json mNestedJson;
     std::string mPath;
     bool mIsNewInstance;
+    std::vector<std::shared_ptr<ConfigVersionUpdater>> mVersions;
 };
 } // namespace LUS

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -35,8 +35,8 @@ class ConfigVersionUpdater {
 
     /**
      * @brief Get the value of mVersion
-     * 
-     * @return uint32_t 
+     *
+     * @return uint32_t
      */
     uint32_t GetVersion();
 };

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -10,7 +10,7 @@
 namespace LUS {
 class ConfigVersionUpdater {
   public:
-    virtual void Update(std::shared_ptr<Config> conf) = 0;
+    virtual void Update(Config* conf) = 0;
 };
 class Config {
   public:

--- a/src/window/Window.cpp
+++ b/src/window/Window.cpp
@@ -70,8 +70,8 @@ void Window::Init() {
         mHeight = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.Fullscreen.Height",
                                                                    steamDeckGameMode ? 800 : 1080);
     } else {
-        mWidth = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.Width", mWidth);
-        mHeight = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.Height", mHeight);
+        mWidth = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.Width", 640);
+        mHeight = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.Height", 480);
         mPosX = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.PositionX", mPosX);
         mPosY = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.PositionY", mPosY);
     }


### PR DESCRIPTION
Implements config versioning in such a way that it does not have to be used. Applications who wish to use config versioning have to opt in by implementing a subclass of `CustomVersionUpdater`, pushing at least one instance of it via `RegisterConfigVersion` and then calling `RunVersionUpdates`. Otherwise configs continue to work exactly as they always have. I've also removed `CreateDefaultSettings`, as their default values are already handled correctly if they are missing from the config file. This pushes us toward the goal of "if a value is in the config file, it was set by the user, if not, it is default and we can freely change it if needed". To avoid the F10->F11 debacle we are running into now. The config versioning then allows SoH (or any other apps that got the `CreateDefaultSetting` stuff before it was deleted) to override the config files to be able to fix the bad shortcut by removing the default values from the config in the update function.