### PR TITLE
add custom gSPExtraGeometryMode macros and command for inverting culling

### DIFF
--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -183,6 +183,7 @@
 
 // RDP Cmd
 #define G_SETGRAYSCALE 0x39
+#define G_EXTRAGEOMETRYMODE 0x3a
 #define G_SETINTENSITY 0x40
 
 /*
@@ -358,6 +359,11 @@
 #define G_CLIPPING_H (G_CLIPPING / 0x10000)
 #endif
 #endif
+
+/*
+ * G_EXTRAGEOMETRY flags: set extra custom geometry modes
+ */
+#define G_EX_INVERT_CULLING 0x00000001
 
 /* Need these defined for Sprite Microcode */
 #ifdef _LANGUAGE_ASSEMBLY
@@ -2652,6 +2658,17 @@ typedef union {
 
 #define gsSPGrayscale(state) \
     { (_SHIFTL(G_SETGRAYSCALE, 24, 8)), (state) }
+
+#define gSPExtraGeometryMode(pkt, c, s)                                                 \
+    _DW({                                                                               \
+        Gfx* _g = (Gfx*)(pkt);                                                          \
+                                                                                        \
+        _g->words.w0 = _SHIFTL(G_EXTRAGEOMETRYMODE, 24, 8) | _SHIFTL(~(u32)(c), 0, 24); \
+        _g->words.w1 = (u32)(s);                                                        \
+    })
+
+#define gSPSetExtraGeometryMode(pkt, word) gSPExtraGeometryMode((pkt), 0, word)
+#define gSPClearExtraGeometryMode(pkt, word) gSPExtraGeometryMode((pkt), word, 0)
 
 #ifdef F3DEX_GBI_2
 /*

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -116,6 +116,8 @@ static struct RSP {
     uint32_t geometry_mode;
     int16_t fog_mul, fog_offset;
 
+    uint32_t extra_geometry_mode;
+
     struct {
         // U0.16
         uint16_t s, t;
@@ -1382,6 +1384,11 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
             cross = -cross;
         }
 
+        // If inverted culling is requested, negate the cross
+        if ((rsp.extra_geometry_mode & G_EX_INVERT_CULLING) == 1) {
+            cross = -cross;
+        }
+
         switch (rsp.geometry_mode & G_CULL_BOTH) {
             case G_CULL_FRONT:
                 if (cross <= 0) {
@@ -1767,6 +1774,11 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
 static void gfx_sp_geometry_mode(uint32_t clear, uint32_t set) {
     rsp.geometry_mode &= ~clear;
     rsp.geometry_mode |= set;
+}
+
+static void gfx_sp_extra_geometry_mode(uint32_t clear, uint32_t set) {
+    rsp.extra_geometry_mode &= ~clear;
+    rsp.extra_geometry_mode |= set;
 }
 
 static void gfx_adjust_viewport_or_scissor(XYWidthHeight* area) {
@@ -3035,6 +3047,9 @@ static void gfx_run_dl(Gfx* cmd) {
                     gfx_s2dex_bg_copy((uObjBg*)cmd->words.w1); // not seg_addr here it seems
                 }
 
+                break;
+            case G_EXTRAGEOMETRYMODE:
+                gfx_sp_extra_geometry_mode(~C0(0, 24), cmd->words.w1);
                 break;
         }
         ++cmd;


### PR DESCRIPTION
This adds a new custom op code `G_EXTRAGEOMETRYMODE` and macros `gSPExtraGeometryMode` to allow inverting culling. This command and macros follows the same pattern as `gSPGeometryMode` by giving us an extra 24 bits of control.

I originally was thinking about just using an unused bit in the original `gSPGeometryMode` opcode, but wasn't sure if that is the best idea. It seemed some of the original bits depend on the GBI mode, and some bits are reserved by the microcode, so I couldn't tell what was safe to do.

This is needed for Mirror World in SoH. The idea is we can call `gSPSetExtraGeometryMode(gfx_pointer++, G_EX_INVERT_CULLING);` to set the display buffer for inverted culling, then call the clear method when we no longer need it.

Let me know if this pattern is ok or if I should reorganize the methods/defines somewhere else (feels like maybe we should add a more clear distinction between our custom op codes vs the original hardware ones, but thats out of scope for this PR)