### PR TITLE
New frame timing approach, fix "Match Refresh Rate" button

### DIFF
--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -147,8 +147,11 @@ template <typename Fun> static void run_as_dpi_aware(Fun f) {
 }
 
 static void apply_maximum_frame_latency(bool first) {
+    DXGI_SWAP_CHAIN_DESC       swap_desc = {};
+    dxgi.swap_chain->GetDesc (&swap_desc);
+    
     ComPtr<IDXGISwapChain2> swap_chain2;
-    if (dxgi.swap_chain->QueryInterface(__uuidof(IDXGISwapChain2), &swap_chain2) == S_OK) {
+    if ((swap_desc.Flags & DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT) && dxgi.swap_chain->QueryInterface(__uuidof(IDXGISwapChain2), &swap_chain2) == S_OK) {
         ThrowIfFailed(swap_chain2->SetMaximumFrameLatency(dxgi.maximum_frame_latency));
         if (first) {
             dxgi.waitable_object = swap_chain2->GetFrameLatencyWaitableObject();

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -147,11 +147,12 @@ template <typename Fun> static void run_as_dpi_aware(Fun f) {
 }
 
 static void apply_maximum_frame_latency(bool first) {
-    DXGI_SWAP_CHAIN_DESC       swap_desc = {};
-    dxgi.swap_chain->GetDesc (&swap_desc);
-    
+    DXGI_SWAP_CHAIN_DESC swap_desc = {};
+    dxgi.swap_chain->GetDesc(&swap_desc);
+
     ComPtr<IDXGISwapChain2> swap_chain2;
-    if ((swap_desc.Flags & DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT) && dxgi.swap_chain->QueryInterface(__uuidof(IDXGISwapChain2), &swap_chain2) == S_OK) {
+    if ((swap_desc.Flags & DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT) &&
+        dxgi.swap_chain->QueryInterface(__uuidof(IDXGISwapChain2), &swap_chain2) == S_OK) {
         ThrowIfFailed(swap_chain2->SetMaximumFrameLatency(dxgi.maximum_frame_latency));
         if (first) {
             dxgi.waitable_object = swap_chain2->GetFrameLatencyWaitableObject();
@@ -385,8 +386,7 @@ static void gfx_dxgi_set_cursor_visibility(bool visible) {
     if (visible) {
         do {
             cursorVisibilityCounter = ShowCursor(true);
-        } while (cursorVisibilityCounter < 0 &&
-               ++cursorVisibilityTries   < _MAX_TRIES);
+        } while (cursorVisibilityCounter < 0 && ++cursorVisibilityTries < _MAX_TRIES);
     } else {
         do {
             cursorVisibilityCounter = ShowCursor(false);
@@ -583,7 +583,7 @@ static bool gfx_dxgi_start_frame(void) {
     // Get the present interval the user wants instead (V-Sync toggle).
     if (dxgi.is_vsync_enabled != CVarGetInteger("gVsyncEnabled", 1)) {
         // Make sure only 0 or 1 is set, as present interval technically accepts a range from 0 to 4.
-        dxgi.is_vsync_enabled = !!CVarGetInteger("gVsyncEnabled", 1);
+        dxgi.is_vsync_enabled = CVarGetInteger("gVsyncEnabled", 1);
     }
     dxgi.length_in_vsync_frames = dxgi.is_vsync_enabled;
     return true;
@@ -607,7 +607,7 @@ static void gfx_dxgi_swap_buffers_begin(void) {
     dxgi.previous_present_time = t;
     if (dxgi.tearing_support && !dxgi.length_in_vsync_frames) {
         // 512: DXGI_PRESENT_ALLOW_TEARING - allows for true V-Sync off with flip model
-        ThrowIfFailed(dxgi.swap_chain->Present(dxgi.length_in_vsync_frames, 512));
+        ThrowIfFailed(dxgi.swap_chain->Present(dxgi.length_in_vsync_frames, DXGI_PRESENT_ALLOW_TEARING));
     } else {
         ThrowIfFailed(dxgi.swap_chain->Present(dxgi.length_in_vsync_frames, 0));
     }
@@ -624,27 +624,16 @@ static void gfx_dxgi_swap_buffers_end(void) {
     QueryPerformanceCounter(&t0);
     QueryPerformanceCounter(&t1);
 
-    if (dxgi.applied_maximum_frame_latency > dxgi.maximum_frame_latency ||
-        dxgi.is_vsync_enabled != CVarGetInteger("gVsyncEnabled", 1)) {
-        // There seems to be a bug that if latency is decreased, there is no effect of that operation, so recreate
-        // swap chain
+    if (dxgi.applied_maximum_frame_latency > dxgi.maximum_frame_latency) {
+        // If latency is decreased, you have to wait the same amout of times as the old latency was set to
         if (dxgi.waitable_object != nullptr) {
-            if (!dxgi.dropped_frame) {
-                // Wait the last time on this swap chain
+            int times_to_wait = dxgi.applied_maximum_frame_latency;
+            while (times_to_wait > 0) {
                 WaitForSingleObject(dxgi.waitable_object, INFINITE);
+                times_to_wait--;
             }
-            CloseHandle(dxgi.waitable_object);
-            dxgi.waitable_object = nullptr;
         }
-
-        dxgi.before_destroy_swap_chain_fn();
-        dxgi.swap_chain.Reset();
-        dxgi.is_vsync_enabled = CVarGetInteger("gVsyncEnabled", 1);
-        gfx_dxgi_create_swap_chain(dxgi.swap_chain_device.Get(), move(dxgi.before_destroy_swap_chain_fn));
-
-        dxgi.frame_timestamp = 0;
-        dxgi.frame_stats.clear();
-        dxgi.pending_frame_stats.clear();
+        apply_maximum_frame_latency(false);
 
         return; // Make sure we don't wait a second time on the waitable object, since that would hang the program
     } else if (dxgi.applied_maximum_frame_latency != dxgi.maximum_frame_latency) {

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -372,11 +372,21 @@ static void gfx_dxgi_set_cursor_visibility(bool visible) {
     // https://devblogs.microsoft.com/oldnewthing/20091217-00/?p=15643
     // ShowCursor uses a counter, not a boolean value, and increments or decrements that value when called
     // This means we need to keep calling it until we get the value we want
+
+    //
+    //  NOTE:  If you continue calling until you "get the value you want" and there is no mouse attached,
+    //  it will lock the software up.  Windows always returns -1 if there is no mouse!
+    //
+
+    const int _MAX_TRIES = 15; // Prevent spinning infinitely if no mouse is plugged in
+
+    int cursorVisibilityTries = 0;
     int cursorVisibilityCounter;
     if (visible) {
         do {
             cursorVisibilityCounter = ShowCursor(true);
-        } while (cursorVisibilityCounter < 0);
+        } while (cursorVisibilityCounter < 0 &&
+               ++cursorVisibilityTries   < _MAX_TRIES);
     } else {
         do {
             cursorVisibilityCounter = ShowCursor(false);

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -677,12 +677,17 @@ static void gfx_dxgi_swap_buffers_begin(void) {
         QueryPerformanceCounter(&t);
         int64_t next = qpc_to_100ns(dxgi.previous_present_time.QuadPart) +
                        FRAME_INTERVAL_NS_NUMERATOR / (FRAME_INTERVAL_NS_DENOMINATOR * 100);
-        int64_t left = next - qpc_to_100ns(t.QuadPart);
+        int64_t left = next - qpc_to_100ns(t.QuadPart) - 15000UL;
         if (left > 0) {
             LARGE_INTEGER li;
             li.QuadPart = -left;
             SetWaitableTimer(dxgi.timer, &li, 0, nullptr, nullptr, false);
             WaitForSingleObject(dxgi.timer, INFINITE);
+
+            do {
+                YieldProcessor();
+                QueryPerformanceCounter(&t);
+            } while (t.QuadPart < next);
         }
     }
     QueryPerformanceCounter(&t);

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -727,13 +727,17 @@ static void gfx_dxgi_swap_buffers_end(void) {
 
     if (dxgi.applied_maximum_frame_latency > dxgi.maximum_frame_latency) {
         // If latency is decreased, you have to wait the same amout of times as the old latency was set to
+        int times_to_wait = dxgi.applied_maximum_frame_latency;
+        int latency = dxgi.maximum_frame_latency;
+        dxgi.maximum_frame_latency = 1;
+        apply_maximum_frame_latency(false);
         if (dxgi.waitable_object != nullptr) {
-            int times_to_wait = dxgi.applied_maximum_frame_latency;
             while (times_to_wait > 0) {
                 WaitForSingleObject(dxgi.waitable_object, INFINITE);
                 times_to_wait--;
             }
         }
+        dxgi.maximum_frame_latency = latency;
         apply_maximum_frame_latency(false);
 
         return; // Make sure we don't wait a second time on the waitable object, since that would hang the program

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -13,6 +13,7 @@
 #include <dxgi1_4.h>
 #include <dxgi1_5.h>
 #include <versionhelpers.h>
+#include <d3d11.h>
 
 #include <shellscalingapi.h>
 
@@ -673,7 +674,21 @@ static bool gfx_dxgi_start_frame(void) {
 
 static void gfx_dxgi_swap_buffers_begin(void) {
     LARGE_INTEGER t;
+    // dxgi.use_timer = true;
     if (dxgi.use_timer || (dxgi.tearing_support && !dxgi.is_vsync_enabled)) {
+        ComPtr<ID3D11Device> device;
+        dxgi.swap_chain_device.As(&device);
+
+        if (device != nullptr) {
+            ComPtr<ID3D11DeviceContext> dev_ctx;
+            device->GetImmediateContext(&dev_ctx);
+
+            if (dev_ctx != nullptr) {
+                // Always flush the immediate context before forcing a CPU-wait, otherwise the GPU might only start
+                // working when the SwapChain is presented.
+                dev_ctx->Flush();
+            }
+        }
         QueryPerformanceCounter(&t);
         int64_t next = qpc_to_100ns(dxgi.previous_present_time.QuadPart) +
                        FRAME_INTERVAL_NS_NUMERATOR / (FRAME_INTERVAL_NS_DENOMINATOR * 100);


### PR DESCRIPTION
- Minor fixes for edge cases
   - fix lockup if no mouse connected
   - better check for waitable SwapChain
   - no need to recreate the SwapChain when jitter fix is turned off
- "Match Refresh Rate" button uses the refresh rate of the monitor the window is on
   - also fixes it on VRR displays
- New frame timing approach
   - always use timer instead of relying on V-Sync
   - improved timer precision to minimize missed frames (also fixes #299)
   - Sadly one oddly specific downside I coudn't fix:
   If the window is on a secondary monitor that runs on a lower refresh rate than the primary, the rendering is also composed via DWM (Composed: Flip) and you're setting the FPS higer than your primary monitor: then it starts to stutter horribly. But one shoudn't push the limiter higher up than their refresh rate with V-Sync on anyway. 😛

Thanks to Aemony and Kaldaien from Special K, who helped a lot with this.