### PR TITLE
Fix cursor not showing when starting fullscreen with the menubar already open

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -136,10 +136,6 @@ void Gui::Init(GuiWindowInitData windowImpl) {
     ImGui::GetStyle().ScaleAllSizes(2);
 #endif
 
-    if (Context::GetInstance()->GetWindow()->IsFullscreen()) {
-        Context::GetInstance()->GetWindow()->SetCursorVisibility(GetMenuBar() && GetMenuBar()->IsVisible());
-    }
-
     CVarClear("gNewFileDropped");
     CVarClear("gDroppedFile");
 
@@ -654,6 +650,10 @@ void Gui::SetMenuBar(std::shared_ptr<GuiMenuBar> menuBar) {
 
     if (GetMenuBar()) {
         GetMenuBar()->Init();
+    }
+
+    if (Context::GetInstance()->GetWindow()->IsFullscreen()) {
+        Context::GetInstance()->GetWindow()->SetCursorVisibility(GetMenuBar() && GetMenuBar()->IsVisible());
     }
 }
 


### PR DESCRIPTION
Currently, the cursor's visibility when starting in fullscreen would call `GetMenuBar()` and check visibility, but at the point it was being called, mMenuBar hadn't been set, and thus was empty and the check would always return false. This moves the check into `SetMenuBar()` instead so it's checked and visibility is set properly immediately upon initialization.