### PR TITLE
Fix bogus type conversion for window position (dxgi)

### DIFF
--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include <windows.h>
+#include <windowsx.h> // GET_X_LPARAM(), GET_Y_LPARAM()
 #include <wrl/client.h>
 #include <dxgi1_3.h>
 #include <dxgi1_4.h>
@@ -247,8 +248,8 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
             dxgi.current_height = HIWORD(l_param);
             break;
         case WM_MOVE:
-            dxgi.posX = LOWORD(l_param);
-            dxgi.posY = HIWORD(l_param);
+            dxgi.posX = GET_X_LPARAM(l_param);
+            dxgi.posY = GET_Y_LPARAM(l_param);
             break;
         case WM_DESTROY:
             PostQuitMessage(0);


### PR DESCRIPTION
Related to https://github.com/HarbourMasters/Shipwright/issues/3028. The window should now save and use coordinates correctly when on a monitor above or below the primary (negative coordinates).
Does NOT fix the window going off screen when your screen layout changed in between two starts.

EDIT: removed "fix" keyword, so it doesn't close the issue (no full fix). 