### PR TITLE
Use current display for fullscreen size (SDL)

### DIFF
--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -227,8 +227,9 @@ static void set_fullscreen(bool on, bool call_callback) {
 
     if (on) {
         // OTRTODO: Get mode from config.
+        int display_in_use = SDL_GetWindowDisplayIndex(wnd);
         SDL_DisplayMode mode;
-        SDL_GetDesktopDisplayMode(0, &mode);
+        SDL_GetDesktopDisplayMode(display_in_use, &mode);
         window_width = mode.w;
         window_height = mode.h;
         SDL_ShowCursor(false);


### PR DESCRIPTION
Used to always use the dimensions of the primary monitor, which of course lead to weird behavior, when not on the primary monitor. Related to https://github.com/HarbourMasters/Shipwright/issues/2991?
Does NOT fix the window going off screen when your screen layout changed in between two starts.

EDIT: removed "fix" keyword, as I can't test Linux and I actually don't know if this fixes that. I know it fixes some issues in Windows. 