### PR TITLE
Better timer for better framepacing

### DIFF
--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -491,7 +491,7 @@ static bool gfx_dxgi_start_frame(void) {
         if (estimated_vsync_interval_ns < 2000 || estimated_vsync_interval_ns > 1000000000) {
             // Unreasonable, maybe a monitor change
             estimated_vsync_interval_ns = 16666666;
-            estimated_vsync_interval = estimated_vsync_interval_ns * dxgi.qpc_freq / 1000000000;
+            estimated_vsync_interval = (double)estimated_vsync_interval_ns * dxgi.qpc_freq / 1000000000;
         }
 
         dxgi.detected_hz = (float)((double)1000000000 / (double)estimated_vsync_interval_ns);
@@ -585,7 +585,7 @@ static bool gfx_dxgi_start_frame(void) {
 
 static void gfx_dxgi_swap_buffers_begin(void) {
     LARGE_INTEGER t;
-    // dxgi.use_timer = true;
+    dxgi.use_timer = true;
     if (dxgi.use_timer || (dxgi.tearing_support && !dxgi.is_vsync_enabled)) {
         ComPtr<ID3D11Device> device;
         dxgi.swap_chain_device.As(&device);

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -588,12 +588,17 @@ static void gfx_dxgi_swap_buffers_begin(void) {
         QueryPerformanceCounter(&t);
         int64_t next = qpc_to_100ns(dxgi.previous_present_time.QuadPart) +
                        FRAME_INTERVAL_NS_NUMERATOR / (FRAME_INTERVAL_NS_DENOMINATOR * 100);
-        int64_t left = next - qpc_to_100ns(t.QuadPart);
+        int64_t left = next - qpc_to_100ns(t.QuadPart) - 15000UL;
         if (left > 0) {
             LARGE_INTEGER li;
             li.QuadPart = -left;
             SetWaitableTimer(dxgi.timer, &li, 0, nullptr, nullptr, false);
             WaitForSingleObject(dxgi.timer, INFINITE);
+
+            do {
+                YieldProcessor();
+                QueryPerformanceCounter(&t);
+            } while (t.QuadPart < next);
         }
     }
     QueryPerformanceCounter(&t);

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -303,7 +303,13 @@ void gfx_dxgi_init(const char* game_name, const char* gfx_api_name, bool start_i
 
     dxgi.target_fps = 60;
     dxgi.maximum_frame_latency = 1;
-    dxgi.timer = CreateWaitableTimer(nullptr, false, nullptr);
+
+    // Use high-resolution timer by default on Windows 10 (so that NtSetTimerResolution (...) hacks are not needed)
+    dxgi.timer = CreateWaitableTimerExW(nullptr, nullptr, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+    // Fallback to low resolution timer if unsupported by the OS
+    if (dxgi.timer == nullptr) {
+        dxgi.timer = CreateWaitableTimer(nullptr, FALSE, nullptr);
+    }
 
     // Prepare window title
 


### PR DESCRIPTION
New frame timing approach for DirectX renderer:
   - always use timer instead of relying on V-Sync
   - improved timer precision to minimize missed frames (also fixes #299)
   - Sadly something I coudn't fix with that:
   If the window is on a secondary monitor that runs on a lower refresh rate than the primary, the rendering is also composed via DWM (Composed: Flip) and you're setting the FPS higer than your primary monitor: then it starts to stutter horribly. (This seems also happening with Sulu). But one shoudn't push the limiter higher up than their refresh rate with V-Sync on anyway. 😛

Thanks to Aemony and Kaldaien from Special K, who helped a lot with this.

Split off from https://github.com/Kenix3/libultraship/pull/312, so testing things is hopefully easier.