### PR TITLE
Display handling

### DIFF
--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -227,8 +227,9 @@ static void set_fullscreen(bool on, bool call_callback) {
 
     if (on) {
         // OTRTODO: Get mode from config.
+        int display_in_use = SDL_GetWindowDisplayIndex(wnd);
         SDL_DisplayMode mode;
-        SDL_GetDesktopDisplayMode(0, &mode);
+        SDL_GetDesktopDisplayMode(display_in_use, &mode);
         window_width = mode.w;
         window_height = mode.h;
         SDL_ShowCursor(false);

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -224,12 +224,16 @@ static void set_fullscreen(bool on, bool call_callback) {
         return;
     }
     fullscreen_state = on;
+    int display_in_use = SDL_GetWindowDisplayIndex(wnd);
+    SDL_DisplayMode mode;
+    if (display_in_use < 0) {
+        SDL_GetDesktopDisplayMode(0, &mode);
+    } else {
+        SDL_GetDesktopDisplayMode(display_in_use, &mode);
+    }
 
     if (on) {
         // OTRTODO: Get mode from config.
-        int display_in_use = SDL_GetWindowDisplayIndex(wnd);
-        SDL_DisplayMode mode;
-        SDL_GetDesktopDisplayMode(display_in_use, &mode);
         window_width = mode.w;
         window_height = mode.h;
         SDL_ShowCursor(false);
@@ -239,6 +243,10 @@ static void set_fullscreen(bool on, bool call_callback) {
         window_height = conf->GetInt("Window.Height", 480);
         int32_t posX = conf->GetInt("Window.PositionX", 100);
         int32_t posY = conf->GetInt("Window.PositionY", 100);
+        if (display_in_use < 0) { // Fallback to default if out of bounds
+            posX = 100;
+            posY = 100;
+        }
         SDL_SetWindowPosition(wnd, posX, posY);
     }
     SDL_SetWindowSize(wnd, window_width, window_height);
@@ -324,7 +332,6 @@ static void gfx_sdl_init(const char* game_name, const char* gfx_api_name, bool s
     } else {
         flags = flags | SDL_WINDOW_METAL;
     }
-
     wnd = SDL_CreateWindow(title, posX, posY, window_width, window_height, flags);
     LUS::GuiWindowInitData window_impl;
 

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -332,6 +332,13 @@ static void gfx_sdl_init(const char* game_name, const char* gfx_api_name, bool s
     } else {
         flags = flags | SDL_WINDOW_METAL;
     }
+
+    int display_in_use = SDL_GetWindowDisplayIndex(wnd);
+    if (display_in_use < 0) { // Fallback to default if out of bounds
+        posX = 100;
+        posY = 100;
+    }
+
     wnd = SDL_CreateWindow(title, posX, posY, window_width, window_height, flags);
     LUS::GuiWindowInitData window_impl;
 

--- a/src/window/Window.cpp
+++ b/src/window/Window.cpp
@@ -63,6 +63,8 @@ void Window::Init() {
 
     mIsFullscreen =
         LUS::Context::GetInstance()->GetConfig()->GetBool("Window.Fullscreen.Enabled", false) || steamDeckGameMode;
+    mPosX = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.PositionX", mPosX);
+    mPosY = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.PositionY", mPosY);
 
     if (mIsFullscreen) {
         mWidth = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.Fullscreen.Width",
@@ -72,8 +74,6 @@ void Window::Init() {
     } else {
         mWidth = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.Width", 640);
         mHeight = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.Height", 480);
-        mPosX = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.PositionX", mPosX);
-        mPosY = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.PositionY", mPosY);
     }
 
     mAvailableWindowBackends = std::make_shared<std::vector<WindowBackend>>();


### PR DESCRIPTION
Small rework of how monitors and monitor changes are handled
- [DirectX] "Match Refresh Rate" button uses the refresh rate of the monitor the window is on (also fixes it on VRR displays)
- [DirectX, OpenGL] Fallback to default position (100,100 on primary), if top left corner of the window is not on any monitor
- [OpenGL] Fix fullscreen size for secondary displays
- [DirectX, OpenGL] Fullscreen re-engages on the correct monitor if you exited in fullscreen 

Split off from https://github.com/Kenix3/libultraship/pull/312, so testing things is hopefully easier.

Should fix https://github.com/Kenix3/libultraship/issues/297 and should also fix https://github.com/HarbourMasters/Shipwright/issues/3028.