### PR TITLE
add RomToBigEndian method to rewrite rom data as z64 format

### DIFF
--- a/extern/ZAPDUtils/Utils/BitConverter.h
+++ b/extern/ZAPDUtils/Utils/BitConverter.h
@@ -181,4 +181,25 @@ public:
 		std::memcpy(&value, &floatData, sizeof(value));
 		return value;
 	}
+
+	// Rewrites the rom data in-place to be in BigEndian/z64 format
+	static inline void RomToBigEndian(uint8_t* rom, size_t romSize) {
+		// Use the first byte to determine byte order
+		uint8_t firstByte = rom[0];
+
+		switch (firstByte) {
+			case 0x37: // v64
+				for (int32_t pos = 0; pos < (romSize / 2); pos++) {
+					((uint16_t*)rom)[pos] = ToUInt16BE(rom, pos * 2);
+				}
+				break;
+			case 0x40: // n64
+				for (int32_t pos = 0; pos < (romSize / 4); pos++) {
+					((uint32_t*)rom)[pos] = ToUInt32BE(rom, pos * 4);
+				}
+				break;
+			case 0x80: // z64
+				break; // Already BE, no need to swap
+		}
+	}
 };

--- a/extern/ZAPDUtils/Utils/BitConverter.h
+++ b/extern/ZAPDUtils/Utils/BitConverter.h
@@ -184,6 +184,10 @@ public:
 
 	// Rewrites the rom data in-place to be in BigEndian/z64 format
 	static inline void RomToBigEndian(uint8_t* rom, size_t romSize) {
+		if (romSize > 0) {
+			return;
+		}
+
 		// Use the first byte to determine byte order
 		uint8_t firstByte = rom[0];
 


### PR DESCRIPTION
Adds a method to ZAPDUtils to convert rom data into z64 format. This can be leveraged by ZAPDTR, OTRExporter, and the SoH built-in extractor to support z64, n64, and v64 rom formats.

If it is preferable to return a new array instead of modifying in-place the existing array, then I can make that change.