### PR TITLE
rename "Installation" back to "Bundle"

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -254,7 +254,7 @@ std::string Context::GetShortName() {
     return mShortName;
 }
 
-std::string Context::GetAppInstallationPath() {
+std::string Context::GetAppBundlePath() {
 #ifdef NON_PORTABLE
     return CMAKE_INSTALL_PREFIX;
 #else
@@ -306,8 +306,8 @@ std::string Context::GetAppDirectoryPath(std::string appName) {
     return ".";
 }
 
-std::string Context::GetPathRelativeToAppInstallation(const std::string path) {
-    return GetAppInstallationPath() + "/" + path;
+std::string Context::GetPathRelativeToAppBundle(const std::string path) {
+    return GetAppBundlePath() + "/" + path;
 }
 
 std::string Context::GetPathRelativeToAppDirectory(const std::string path, std::string appName) {
@@ -323,7 +323,7 @@ std::string Context::LocateFileAcrossAppDirs(const std::string path, std::string
         return fpath;
     }
     // app install dir
-    fpath = GetPathRelativeToAppInstallation(path);
+    fpath = GetPathRelativeToAppBundle(path);
     if (std::filesystem::exists(fpath)) {
         return fpath;
     }

--- a/src/Context.h
+++ b/src/Context.h
@@ -25,10 +25,10 @@ class Context {
                                                    const std::unordered_set<uint32_t>& validHashes = {},
                                                    uint32_t reservedThreadCount = 1);
 
-    static std::string GetAppInstallationPath();
+    static std::string GetAppBundlePath();
     static std::string GetAppDirectoryPath(std::string appName = "");
     static std::string GetPathRelativeToAppDirectory(const std::string path, std::string appName = "");
-    static std::string GetPathRelativeToAppInstallation(const std::string path);
+    static std::string GetPathRelativeToAppBundle(const std::string path);
     static std::string LocateFileAcrossAppDirs(const std::string path, std::string appName = "");
 
     Context(std::string name, std::string shortName, std::string configFilePath);


### PR DESCRIPTION
As per request, I should not touch existing method names just for disgust. In continuation of #307 