### PR TITLE
Allow stick deadzones to be applied for thumbstick -> button mapping

### DIFF
--- a/src/controller/ControlDeck.cpp
+++ b/src/controller/ControlDeck.cpp
@@ -209,6 +209,7 @@ void ControlDeck::LoadSettings() {
                     profile->RumbleStrength = config->GetFloat(NESTED("Rumble.Strength", ""));
                     profile->UseGyro = config->GetBool(NESTED("Gyro.Enabled", ""));
                     profile->NotchProximityThreshold = config->GetInt(NESTED("Notches.ProximityThreshold", ""));
+                    profile->UseStickDeadzoneForButtons = config->GetBool(NESTED("UseStickDeadzoneForButtons", ""));
 
                     for (auto const& val : rawProfile["AxisDeadzones"].items()) {
                         profile->AxisDeadzones[std::stoi(val.key())] = val.value();
@@ -265,6 +266,7 @@ void ControlDeck::SaveSettings() {
             config->SetFloat(NESTED("Rumble.Strength", ""), profile->RumbleStrength);
             config->SetBool(NESTED("Gyro.Enabled", ""), profile->UseGyro);
             config->SetInt(NESTED("Notches.ProximityThreshold", ""), profile->NotchProximityThreshold);
+            config->SetBool(NESTED("UseStickDeadzoneForButtons", ""), profile->UseStickDeadzoneForButtons);
 
             // Clear all sections with a one controller to many relationship.
             const static std::vector<std::string> sClearSections = { "Mappings", "AxisDeadzones", "AxisMinimumPress",

--- a/src/controller/Controller.h
+++ b/src/controller/Controller.h
@@ -25,6 +25,7 @@ struct DeviceProfile {
     int32_t Version = 0;
     bool UseRumble = false;
     bool UseGyro = false;
+    bool UseStickDeadzoneForButtons = false;
     float RumbleStrength = 1.0f;
     int32_t NotchProximityThreshold = 0;
     std::unordered_map<int32_t, float> AxisDeadzones;

--- a/src/controller/SDLController.h
+++ b/src/controller/SDLController.h
@@ -27,6 +27,7 @@ class SDLController : public Controller {
   private:
     SDL_GameController* mController;
     bool mSupportsGyro;
+    float NormaliseStickValue(float axisValue);
     void NormalizeStickAxis(SDL_GameControllerAxis axisX, SDL_GameControllerAxis axisY, int32_t portIndex);
     bool Close();
 };

--- a/src/window/gui/InputEditorWindow.cpp
+++ b/src/window/gui/InputEditorWindow.cpp
@@ -377,16 +377,15 @@ void InputEditorWindow::DrawControllerSchema() {
     DrawButton("Left", BTN_CLEFT, mCurrentPort, &mBtnReading);
     DrawButton("Right", BTN_CRIGHT, mCurrentPort, &mBtnReading);
     ImGui::Dummy(ImVec2(0, 5));
-    EndGroupPanel(0.0f);
+    #ifdef __SWITCH__
+        EndGroupPanel(isKeyboard ? 53.0f : 122.0f);
+    #else
+        EndGroupPanel(isKeyboard ? 53.0f : 94.0f);
+    #endif
 
     ImGui::SetCursorPosX(cursor.x);
-#ifdef __SWITCH__
-    ImGui::SetCursorPosY(cursor.y + 167);
-#elif defined(__WIIU__)
-    ImGui::SetCursorPosY(cursor.y + 120 * 2);
-#else
-    ImGui::SetCursorPosY(cursor.y + 120);
-#endif
+    ImGui::SameLine();
+
     BeginGroupPanel("Options", ImVec2(158, 20));
     float cursorX = ImGui::GetCursorPosX() + 5;
     ImGui::SetCursorPosX(cursorX);
@@ -426,6 +425,14 @@ void InputEditorWindow::DrawControllerSchema() {
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip(
                 "%s", "How near in degrees to a virtual notch angle you have to be for it to snap to nearest notch");
+        }
+
+        if (ImGui::Checkbox("Stick Deadzones For Buttons", &profile->UseStickDeadzoneForButtons)) {
+            Context::GetInstance()->GetControlDeck()->SaveSettings();
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip(
+                "%s", "Uses the stick deadzone values when sticks are mapped to buttons");
         }
     }
 


### PR DESCRIPTION
When mapping thumbsticks to buttons the deadzones are ignored. There is an option `AxisMinimumPress` to control the behaviour, but there is no UI option to actually modify it, so it's hardcoded as `7680.0f` and can only be changed by modifying the config JSON directly.

Rather than making a new thumbstick UI with deadzones I figured it made sense to add a boolean checkbox that would allow you to apply your thumbstick deadzones for thumbstick -> button mapping.

I'm not really familiar with drawing UI in C++ so most of the options menu stuff is copied/pasted & modified from existing code. Please shout if it's wrong and let me know what to change 🙏 