### PR TITLE
add clearMtx address for pal gc mq and pal1.0 support

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2512,6 +2512,7 @@ static void gfx_run_dl(Gfx* cmd) {
                     mtxAddr == SEG_ADDR(0, 0x12DB40) || // GC NMQ D
                     mtxAddr == SEG_ADDR(0, 0xFBC20) ||  // GC PAL
                     mtxAddr == SEG_ADDR(0, 0xFBC01) ||  // GC MQ PAL
+                    mtxAddr == SEG_ADDR(0, 0xFCD00) ||  // PAL1.0
                     mtxAddr == SEG_ADDR(0, 0xFCD40)     // PAL1.1
                 ) {
                     mtxAddr = clearMtx;

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2508,8 +2508,12 @@ static void gfx_run_dl(Gfx* cmd) {
             case G_MTX: {
                 uintptr_t mtxAddr = cmd->words.w1;
 
-                if (mtxAddr == SEG_ADDR(0, 0x12DB20) || mtxAddr == SEG_ADDR(0, 0x12DB40) ||
-                    mtxAddr == SEG_ADDR(0, 0xFBC20) || mtxAddr == SEG_ADDR(0, 0xFCD40)) {
+                if (mtxAddr == SEG_ADDR(0, 0x12DB20) || // GC MQ D
+                    mtxAddr == SEG_ADDR(0, 0x12DB40) || // GC NMQ D
+                    mtxAddr == SEG_ADDR(0, 0xFBC20) ||  // GC PAL
+                    mtxAddr == SEG_ADDR(0, 0xFBC01) ||  // GC MQ PAL
+                    mtxAddr == SEG_ADDR(0, 0xFCD40)     // PAL1.1
+                ) {
                     mtxAddr = clearMtx;
                 }
 


### PR DESCRIPTION
Adds the clear matrix address necessary to support PAL GC MQ and PAL1.0 N64.

As I explore more rom support (NTSC at this point, as all PAL should be handled by now), I'd like to find a solution that does not involve hard coding this into LUS.