### PR TITLE
Fix: Reverse endian convert romsize check

### DIFF
--- a/extern/ZAPDUtils/Utils/BitConverter.h
+++ b/extern/ZAPDUtils/Utils/BitConverter.h
@@ -184,7 +184,7 @@ public:
 
 	// Rewrites the rom data in-place to be in BigEndian/z64 format
 	static inline void RomToBigEndian(uint8_t* rom, size_t romSize) {
-		if (romSize > 0) {
+		if (romSize <= 0) {
 			return;
 		}
 


### PR DESCRIPTION
Accidentally inverted the romsize check, setting it back to make it actually work