### PR TITLE
More "Advanced Resolution Mode" functionality.

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -490,8 +490,8 @@ void Gui::ApplyResolutionChanges() {
         newHeight = verticalPixelCount;
     } else { // Use the window's resolution
         if (aspectRatioIsEnabled) {
-            if (((float)gfx_current_game_window_viewport.width / gfx_current_game_window_viewport.height) >
-                (aspectRatioX / aspectRatioY)) {
+            if (((float)gfx_current_game_window_viewport.height / gfx_current_game_window_viewport.width) <
+                (aspectRatioY / aspectRatioX)) {
                 // when pillarboxed
                 newWidth = uint32_t(float(gfx_current_dimensions.height / aspectRatioY) * aspectRatioX);
             } else { // when letterboxed
@@ -524,9 +524,10 @@ int16_t Gui::GetIntegerScaleFactor() {
 
         if (CVarGetInteger("gAdvancedResolution.IntegerScale.NeverExceedBounds", 1)) {
             // Screen bounds take priority over whatever Factor is set to.
+
             // The same comparison as below, but checked against the configured factor
-            if (((float)gfx_current_game_window_viewport.width / gfx_current_game_window_viewport.height) >
-                ((float)gfx_current_dimensions.width / gfx_current_dimensions.height)) {
+            if (((float)gfx_current_game_window_viewport.height / gfx_current_game_window_viewport.width) <
+                ((float)gfx_current_dimensions.height / gfx_current_dimensions.width)) {
                 if (factor > gfx_current_game_window_viewport.height / gfx_current_dimensions.height) {
                     // Scale to window height
                     factor = gfx_current_game_window_viewport.height / gfx_current_dimensions.height;
@@ -547,8 +548,8 @@ int16_t Gui::GetIntegerScaleFactor() {
         int16_t factor = 1;
 
         // Compare aspect ratios of game framebuffer and GUI
-        if (((float)gfx_current_game_window_viewport.width / gfx_current_game_window_viewport.height) >
-            ((float)gfx_current_dimensions.width / gfx_current_dimensions.height)) {
+        if (((float)gfx_current_game_window_viewport.height / gfx_current_game_window_viewport.width) <
+            ((float)gfx_current_dimensions.height / gfx_current_dimensions.width)) {
             // Scale to window height
             factor = gfx_current_game_window_viewport.height / gfx_current_dimensions.height;
         } else {

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -518,6 +518,31 @@ void Gui::ApplyResolutionChanges() {
     // centring the image is done in Gui::StartFrame().
 }
 
+int16_t Gui::GetIntegerScaleFactor() {
+    if (!CVarGetInteger("gAdvancedResolution.IntegerScaleFitAutomatically", 0)) {
+        int16_t factor = CVarGetInteger("gAdvancedResolution.IntegerScaleFactor", 1);
+        if (factor < 1) {
+            factor = 1;
+        }
+        return factor;
+    } else { // Skip the preferred value and automatically determine from window size
+        int16_t factor = 1;
+        // Compare aspect ratios of game framebuffer and GUI dimensions
+        if (((float)gfx_current_game_window_viewport.width / gfx_current_game_window_viewport.height) >
+            ((float)gfx_current_dimensions.width / gfx_current_dimensions.height)) {
+            // Scale to window height
+            factor = gfx_current_game_window_viewport.height / gfx_current_dimensions.height;
+        } else {
+            // Scale to window width
+            factor = gfx_current_game_window_viewport.width / gfx_current_dimensions.width;
+        }
+        if (factor < 1) {
+            factor = 1;
+        }
+        return factor;
+    }
+}
+
 void Gui::StartFrame() {
     const ImVec2 mainPos = ImGui::GetWindowPos();
     ImVec2 size = ImGui::GetContentRegionAvail();
@@ -545,7 +570,7 @@ void Gui::StartFrame() {
                 size = ImVec2(sWdth, sHght);
             }
         } else { // in pixel perfect mode it's much easier
-            const int factor = CVarGetInteger("gAdvancedResolution.IntegerScaleFactor", 1);
+            const int factor = GetIntegerScaleFactor();
             float sPosX = size.x / 2 - (gfx_current_dimensions.width * factor) / 2;
             float sPosY = size.y / 2 - (gfx_current_dimensions.height * factor) / 2;
             pos = ImVec2(sPosX, sPosY);

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -91,6 +91,7 @@ class Gui {
     void ImGuiRenderDrawData(ImDrawData* data);
     ImTextureID GetTextureById(int32_t id);
     void ApplyResolutionChanges();
+    int16_t GetIntegerScaleFactor();
 
   private:
     struct GuiTexture {


### PR DESCRIPTION
Second wave of #335 to add a few things missed the first time or fix issues that have since come up, such as moving integer scaling auto-fit functionality to LUS.

Adds a new function to determine integer scaling factor, with smarter testing for screen bounds, and a few more CVars to customise behavior.

See: https://github.com/HarbourMasters/Shipwright/pull/3130