### PR TITLE
feat: allow creating uninitialized context

### DIFF
--- a/src/Context.h
+++ b/src/Context.h
@@ -24,7 +24,8 @@ class Context {
                                                    const std::vector<std::string>& otrFiles = {},
                                                    const std::unordered_set<uint32_t>& validHashes = {},
                                                    uint32_t reservedThreadCount = 1);
-
+    static std::shared_ptr<Context> CreateUninitializedInstance(const std::string name, const std::string shortName,
+                                                                const std::string configFilePath);
     static std::string GetAppBundlePath();
     static std::string GetAppDirectoryPath(std::string appName = "");
     static std::string GetPathRelativeToAppDirectory(const std::string path, std::string appName = "");


### PR DESCRIPTION
example switch to allow cvar use before full init in SoH
### Before
```cpp
context = LUS::Context::CreateInstance("Ship of Harkinian", appShortName, "shipofharkinian.json", OTRFiles, {}, 3);
```
### After
```cpp
// init just what we need
context = LUS::Context::CreateUninitializedInstance("Ship of Harkinian", appShortName, "shipofharkinian.json");
context->InitLogging();
context->InitConfiguration();
context->InitConsoleVariables();

// prove we can get a value from a cvar now
int blarg = CVarGetInteger("gInterpolationFPS", 3);

// finish up the init
context->Init(OTRFiles, {}, 3);
```