### PR TITLE
Keyboard resize fix

### DIFF
--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -42,8 +42,6 @@ using namespace Microsoft::WRL; // For ComPtr
 
 static struct {
     HWND h_wnd;
-    bool in_paint;
-    bool recursive_paint_detected;
 
     // These four only apply in windowed mode.
     uint32_t current_width, current_height; // Width and height of client areas
@@ -378,23 +376,6 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
         case WM_DESTROY:
             PostQuitMessage(0);
             break;
-        case WM_PAINT:
-            if (dxgi.in_paint) {
-                dxgi.recursive_paint_detected = true;
-                return DefWindowProcW(h_wnd, message, w_param, l_param);
-            } else {
-                if (dxgi.run_one_game_iter != nullptr) {
-                    dxgi.in_paint = true;
-                    dxgi.run_one_game_iter();
-                    dxgi.in_paint = false;
-                    if (dxgi.recursive_paint_detected) {
-                        dxgi.recursive_paint_detected = false;
-                        InvalidateRect(h_wnd, nullptr, false);
-                        UpdateWindow(h_wnd);
-                    }
-                }
-            }
-            break;
         case WM_ACTIVATEAPP:
             if (dxgi.on_all_keys_up != nullptr) {
                 dxgi.on_all_keys_up();
@@ -554,11 +535,8 @@ static void gfx_dxgi_set_keyboard_callbacks(bool (*on_key_down)(int scancode), b
 
 static void gfx_dxgi_main_loop(void (*run_one_game_iter)(void)) {
     dxgi.run_one_game_iter = run_one_game_iter;
-
-    MSG msg;
-    while (GetMessage(&msg, nullptr, 0, 0) && dxgi.is_running) {
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
+    while (dxgi.is_running) {
+        dxgi.run_one_game_iter();
     }
 }
 
@@ -570,11 +548,15 @@ static void gfx_dxgi_get_dimensions(uint32_t* width, uint32_t* height, int32_t* 
 }
 
 static void gfx_dxgi_handle_events(void) {
-    /*MSG msg;
+    MSG msg;
     while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+        if (msg.message == WM_QUIT) {
+            dxgi.is_running = false;
+            break;
+        }
         TranslateMessage(&msg);
         DispatchMessage(&msg);
-    }*/
+    }
 }
 
 static uint64_t qpc_to_ns(uint64_t qpc) {

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -373,8 +373,8 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
                 GetMonitorHzPeriod(dxgi.h_Monitor, dxgi.detected_hz, dxgi.display_period);
             }
             break;
-        case WM_DESTROY:
-            PostQuitMessage(0);
+        case WM_CLOSE:
+            dxgi.is_running = false;
             break;
         case WM_ACTIVATEAPP:
             if (dxgi.on_all_keys_up != nullptr) {

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -378,7 +378,9 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
             break;
         case WM_ENDSESSION:
             // This hopefully gives the game a chance to shut down, before windows kills it.
-            dxgi.is_running = false;
+            if (w_param == TRUE) {
+                dxgi.is_running = false;
+            }
             break;
         case WM_ACTIVATEAPP:
             if (dxgi.on_all_keys_up != nullptr) {

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -376,6 +376,10 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
         case WM_CLOSE:
             dxgi.is_running = false;
             break;
+        case WM_ENDSESSION:
+            // This hopefully gives the game a chance to shut down, before windows kills it.
+            dxgi.is_running = false;
+            break;
         case WM_ACTIVATEAPP:
             if (dxgi.on_all_keys_up != nullptr) {
                 dxgi.on_all_keys_up();


### PR DESCRIPTION
Use the function that was already there for the message queue and just run dxgi.run_one_game_iter() in a loop. This should be more in line with how this works in SDL/OpenGL.

Fixes bugged (jittery) resize/move with keyboard through the window menu. Although the game pauses when moved/resized or the window menu is open (also like in SDL/OpenGL).

Before:
https://github.com/Kenix3/libultraship/assets/962946/c2e9f37c-31f8-4d32-ad3e-0f595faf40c8

After the changes:
https://github.com/Kenix3/libultraship/assets/962946/d6b3afdd-a53a-4771-a1e5-ea2c098ae5f8
