### PR TITLE
Skip main mpq version file check if there are no valid hashes

### DIFF
--- a/src/resource/Archive.cpp
+++ b/src/resource/Archive.cpp
@@ -393,6 +393,11 @@ void Archive::GenerateCrcMap() {
 }
 
 bool Archive::ProcessOtrVersion(HANDLE mpqHandle) {
+    // Skip when there are no valid hashes to check against
+    if (mValidHashes.empty()) {
+        return true;
+    }
+
     auto t = LoadFileFromHandle("version", false, mpqHandle);
     if (t != nullptr && t->IsLoaded) {
         auto stream = std::make_shared<MemoryStream>(t->Buffer.data(), t->Buffer.size());
@@ -400,7 +405,7 @@ bool Archive::ProcessOtrVersion(HANDLE mpqHandle) {
         LUS::Endianness endianness = (LUS::Endianness)reader->ReadUByte();
         reader->SetEndianness(endianness);
         uint32_t version = reader->ReadUInt32();
-        if (mValidHashes.empty() || mValidHashes.contains(version)) {
+        if (mValidHashes.contains(version)) {
             PushGameVersion(version);
             return true;
         }


### PR DESCRIPTION
We already we're allowing the version check to succeed if there were no valid hashes provided, but the check required at least that there was a `version` file of some sort in the otr to begin with.

If a port doesn't want to use the version checking by LUS, they shouldn't be required to provide a `version` file at all in their otr.