### PR TITLE
don't `&= ~` when an SDL button isn't pressed

### DIFF
--- a/src/controller/SDLController.cpp
+++ b/src/controller/SDLController.cpp
@@ -162,8 +162,6 @@ void SDLController::ReadDevice(int32_t portIndex) {
         if (profile->Mappings.contains(i)) {
             if (SDL_GameControllerGetButton(mController, static_cast<SDL_GameControllerButton>(i))) {
                 GetPressedButtons(portIndex) |= profile->Mappings[i];
-            } else {
-                GetPressedButtons(portIndex) &= ~profile->Mappings[i];
             }
         }
     }


### PR DESCRIPTION
we already clear out pressed buttons before looping through and setting them
https://github.com/Kenix3/libultraship/blob/1c580200635339d0d9c0722c601303369b39d467/src/controller/SDLController.cpp#L159

if we keep this as-is then multiple physical buttons per n64 button won't work (only the one that is later in the `SDL_GameControllerButton` enum will count). 