### PR TITLE
fix: allow mapping the same keyboard key to multiple ports

### DIFF
--- a/src/controller/controldeck/ControlDeck.cpp
+++ b/src/controller/controldeck/ControlDeck.cpp
@@ -51,7 +51,7 @@ bool ControlDeck::ProcessKeyboardEvent(KbEventType eventType, KbScancode scancod
         auto controller = port->GetConnectedController();
 
         if (controller != nullptr) {
-            result = result || controller->ProcessKeyboardEvent(eventType, scancode);
+            result = controller->ProcessKeyboardEvent(eventType, scancode) || result;
         }
     }
 


### PR DESCRIPTION
the order of the conditional was preventing `ProcessKeyboardEvent` from running on a later port when the key had already been processed on an earlier port. This reorders the condition to ensure we process the event on all ports.