### PR TITLE
Fix potential loss of timer precision

### DIFF
--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -566,11 +566,13 @@ static void gfx_dxgi_handle_events(void) {
 }
 
 static uint64_t qpc_to_ns(uint64_t qpc) {
-    return qpc / dxgi.qpc_freq * 1000000000 + qpc % dxgi.qpc_freq * 1000000000 / dxgi.qpc_freq;
+    qpc *= 1000000000;
+    return qpc / dxgi.qpc_freq;
 }
 
 static uint64_t qpc_to_100ns(uint64_t qpc) {
-    return qpc / dxgi.qpc_freq * 10000000 + qpc % dxgi.qpc_freq * 10000000 / dxgi.qpc_freq;
+    qpc *= 10000000;
+    return qpc / dxgi.qpc_freq;
 }
 
 static bool gfx_dxgi_start_frame(void) {

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -533,7 +533,8 @@ static bool gfx_sdl_start_frame(void) {
 
 static uint64_t qpc_to_100ns(uint64_t qpc) {
     const uint64_t qpc_freq = SDL_GetPerformanceFrequency();
-    return qpc / qpc_freq * 10000000 + qpc % qpc_freq * 10000000 / qpc_freq;
+    qpc *= 10000000;
+    return qpc / qpc_freq;
 }
 
 static inline void sync_framerate_with_timer(void) {


### PR DESCRIPTION
To guard against loss-of-precision, we convert to microseconds *before* dividing by ticks-per-second.

Recommended to do it like this according to [Microsoft Docs](https://learn.microsoft.com/en-us/windows/win32/sysinfo/acquiring-high-resolution-time-stamps).