### PR TITLE
Fix Stats Window crash

### DIFF
--- a/src/window/gui/StatsWindow.cpp
+++ b/src/window/gui/StatsWindow.cpp
@@ -29,7 +29,11 @@ void StatsWindow::DrawElement() {
 #else
     ImGui::Text("Platform: Unknown");
 #endif
-    ImGui::Text("Status: %.3f ms/frame (%.1f FPS)", 1000.0f / framerate, framerate);
+    if (framerate != 0.0f) {
+        ImGui::Text("Status: %.3f ms/frame (%.1f FPS)", 1000.0f / framerate, framerate);
+    } else {
+        ImGui::Text("Status: ? ms/frame (0.0 FPS)");
+    }
     ImGui::End();
     ImGui::PopStyleColor();
 }


### PR DESCRIPTION
There have been some reports that show a crash originating in the Stats Window DrawElement

The only thing that makes sense to me is that the frametime could potentially be 0 leading to a divide-by-zero exception when computing the ms/frame.

This just adds a check for zero and prints out a `?` instead.

Alternatively, there is https://github.com/Kenix3/libultraship/pull/381 if we feel that is better representation for ms/frame calculation.

<details>

<summary>Crash Details</summary>

```
[2023-11-20 11:51:29.292] [D:\a\Shipwright\Shipwright\libultraship\src\debug\CrashHandler.cpp:72] [critical] Exception: 0xe06d7363
Registers: 
RAX: 0x00007FF8D471B86B
RCX: 0x00000000000E0012
RDX: 0x0000000000000090
RBX: 0x00007FF60125A8E8
RSP: 0x000000AA01F5E990
RBP: 0x000000AA01F5EBD1
RSI: 0x000000AA01F5EB00
RDI: 0x0000000019930520
R9:  0x0000000000000001
R10: 0x000001F50B720000
R11: 0x000001F50B720424
R12: 0x0000000000004B00
R13: 0x0000000000002A30
R14: 0x000001F50DE59408
R15: 0x00007FF8CB6DD270
RIP: 0x00007FF8D1FACF19
EFLAGS: 0x00000202
At RaiseExceptionAddr: 0x00007FF8D1FACEB0
In: C:\WINDOWS\System32\KERNELBASE.dll
_CxxThrowException in D:\a\_work\1\s\src\vctools\crt\vcruntime\src\eh\throw.cppLine: 78At ?ThrowIfFailed@@YAXJ@ZAddr: 0x00007FF600C3C7B0
In: B:\SteamLibrary\steamapps\common\Ocarina of Time PC Port\Update\soh.exe
At ?DrawElement@StatsWindow@LUS@@EEAAXXZAddr: 0x00007FF600C33640
In: B:\SteamLibrary\steamapps\common\Ocarina of Time PC Port\Update\soh.exe
At ?gfx_start_frame@@YAXXZAddr: 0x00007FF600BE6380
In: B:\SteamLibrary\steamapps\common\Ocarina of Time PC Port\Update\soh.exe
Graph_StartFrame in D:\a\Shipwright\Shipwright\soh\soh\OTRGlobals.cppLine: 1224RunFrame in D:\a\Shipwright\Shipwright\soh\src\code\graph.cLine: 492At ?gfx_dxgi_get_swap_chain@@YAPEAUIDXGISwapChain1@@XZAddr: 0x00007FF600C3D190
In: B:\SteamLibrary\steamapps\common\Ocarina of Time PC Port\Update\soh.exe
At CallWindowProcWAddr: 0x00007FF8D41FE460
In: C:\WINDOWS\System32\USER32.dll
At DispatchMessageWAddr: 0x00007FF8D41FE040
In: C:\WINDOWS\System32\USER32.dll
At SendMessageTimeoutWAddr: 0x00007FF8D4210B50
In: C:\WINDOWS\System32\USER32.dll
At KiUserCallbackDispatcherAddr: 0x00007FF8D4790E40
In: C:\WINDOWS\SYSTEM32\ntdll.dll
At NtUserDispatchMessageAddr: 0x00007FF8D27216F0
In: C:\WINDOWS\System32\win32u.dll
At DispatchMessageWAddr: 0x00007FF8D41FE040
In: C:\WINDOWS\System32\USER32.dll
At ?gfx_dxgi_init@@YAXPEBD0_NIIHH@ZAddr: 0x00007FF600C3AA10
In: B:\SteamLibrary\steamapps\common\Ocarina of Time PC Port\Update\soh.exe
Graph_ProcessFrame in D:\a\Shipwright\Shipwright\soh\soh\OTRGlobals.cppLine: 1131Graph_ThreadEntry in D:\a\Shipwright\Shipwright\soh\src\code\graph.cLine: 523Main in D:\a\Shipwright\Shipwright\soh\src\code\main.cLine: 144SDL_main in D:\a\Shipwright\Shipwright\soh\src\code\main.cLine: 70main_getcmdline in D:\a\vcpkg\buildtrees\sdl2\src\ase-2.28.4-0db1cebd43.clean\src\main\windows\SDL_windows_main.cLine: 80__scrt_common_main_seh in D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inlLine: 288At BaseThreadInitThunkAddr: 0x00007FF8D2977330
In: C:\WINDOWS\System32\KERNEL32.DLL
At RtlUserThreadStartAddr: 0x00007FF8D4742690
In: C:\WINDOWS\SYSTEM32\ntdll.dll
Build Information:
Game Version: MacReady Charlie (8.0.2)
Build Date: Nov 16 2023 04:33:48
```

</details>