### PR TITLE
Fix holes in color clamped effects

### DIFF
--- a/src/graphic/Fast3D/gfx_direct3d_common.cpp
+++ b/src/graphic/Fast3D/gfx_direct3d_common.cpp
@@ -389,7 +389,7 @@ void gfx_direct3d_common_build_shader(char buf[8192], size_t& len, size_t& num_f
         append_line(buf, &len, ";");
 
         if (c == 0) {
-            append_str(buf, &len, "texel = WRAP(texel, -1.01, 1.01);");
+            append_str(buf, &len, "texel.rgb = WRAP(texel.rgb, -1.01, 1.01);");
         }
     }
 
@@ -397,8 +397,8 @@ void gfx_direct3d_common_build_shader(char buf[8192], size_t& len, size_t& num_f
         append_line(buf, &len, "    if (texel.a > 0.19) texel.a = 1.0; else discard;");
     }
 
-    append_str(buf, &len, "texel = WRAP(texel, -0.51, 1.51);");
-    append_str(buf, &len, "texel = clamp(texel, 0.0, 1.0);");
+    append_str(buf, &len, "texel.rgb = WRAP(texel.rgb, -0.51, 1.51);");
+    append_str(buf, &len, "texel.rgb = clamp(texel.rgb, 0.0, 1.0);");
     // TODO discard if alpha is 0?
     if (cc_features.opt_fog) {
         if (cc_features.opt_alpha) {

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -534,12 +534,12 @@ static struct ShaderProgram* gfx_opengl_create_and_load_new_shader(uint64_t shad
         append_line(fs_buf, &fs_len, ";");
 
         if (c == 0) {
-            append_str(fs_buf, &fs_len, "texel = WRAP(texel, -1.01, 1.01);");
+            append_str(fs_buf, &fs_len, "texel.rgb = WRAP(texel.rgb, -1.01, 1.01);");
         }
     }
 
-    append_str(fs_buf, &fs_len, "texel = WRAP(texel, -0.51, 1.51);");
-    append_str(fs_buf, &fs_len, "texel = clamp(texel, 0.0, 1.0);");
+    append_str(fs_buf, &fs_len, "texel.rgb = WRAP(texel.rgb, -0.51, 1.51);");
+    append_str(fs_buf, &fs_len, "texel.rgb = clamp(texel.rgb, 0.0, 1.0);");
     // TODO discard if alpha is 0?
     if (cc_features.opt_fog) {
         if (cc_features.opt_alpha) {


### PR DESCRIPTION
Limits color clamping to RGB instead of RGBA; fixes a few bugged graphics in SoH.
Before:
![image](https://github.com/Kenix3/libultraship/assets/42286723/771618e7-ae77-4034-b879-9f35a0349199)
After:
![image](https://github.com/Kenix3/libultraship/assets/42286723/40a05543-367c-431c-87c8-22adc830b5d0)
