### PR TITLE
Revert "Fix potential loss of timer precision (#376)"

### DIFF
--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -593,13 +593,11 @@ static void gfx_dxgi_handle_events(void) {
 }
 
 static uint64_t qpc_to_ns(uint64_t qpc) {
-    qpc *= 1000000000;
-    return qpc / dxgi.qpc_freq;
+    return qpc / dxgi.qpc_freq * 1000000000 + qpc % dxgi.qpc_freq * 1000000000 / dxgi.qpc_freq;
 }
 
 static uint64_t qpc_to_100ns(uint64_t qpc) {
-    qpc *= 10000000;
-    return qpc / dxgi.qpc_freq;
+    return qpc / dxgi.qpc_freq * 10000000 + qpc % dxgi.qpc_freq * 10000000 / dxgi.qpc_freq;
 }
 
 static bool gfx_dxgi_start_frame(void) {

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -540,8 +540,7 @@ static bool gfx_sdl_start_frame(void) {
 
 static uint64_t qpc_to_100ns(uint64_t qpc) {
     const uint64_t qpc_freq = SDL_GetPerformanceFrequency();
-    qpc *= 10000000;
-    return qpc / qpc_freq;
+    return qpc / qpc_freq * 10000000 + qpc % qpc_freq * 10000000 / qpc_freq;
 }
 
 static inline void sync_framerate_with_timer(void) {


### PR DESCRIPTION
Reproduction steps:
- Check out latest develop branch (on SoH)
- To prevent the performance issue I caused on File Select screen, wipe your shipofharkinian.json (if there is an active spoiler file it's parsing JSON every frame)
- Set up cmake project in release mode
- Build in release mode
- Navigate to file select screen
- Wait like 10 seconds into the file select sequence
- Observe static sound
- Revert #376 locally
- Repeat the above
- Observe lack of static sound

I won't pretend to understand what's going on here, but logging the results of the function before/after the change show huge differences in their output, maybe there is some code somewhere that relies on the precision loss? No idea.

[Ship_of_Harkinian.log](https://github.com/Kenix3/libultraship/files/13555333/Ship_of_Harkinian.log)

