### PR TITLE
Fix busy loop for dxgi framepacing

### DIFF
--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -777,6 +777,7 @@ static void gfx_dxgi_swap_buffers_begin(void) {
             do {
                 YieldProcessor();
                 QueryPerformanceCounter(&t);
+                t.QuadPart = qpc_to_100ns(t.QuadPart);
             } while (t.QuadPart < next);
         }
     }


### PR DESCRIPTION
Fix for busy loop for dxgi framepacing. Negates #391, and also fixes frame timing and skipping with FPS settings higher than monitor's refresh rate for some people.