### PR TITLE
fix blended textures for dx, opengl, and metal

### DIFF
--- a/src/graphic/Fast3D/gfx_direct3d_common.cpp
+++ b/src/graphic/Fast3D/gfx_direct3d_common.cpp
@@ -350,6 +350,19 @@ void gfx_direct3d_common_build_shader(char buf[8192], size_t& len, size_t& num_f
                 }
                 len += sprintf(buf + len, "    } else {\r\n");
                 len += sprintf(buf + len, "        texVal%d = g_texture%d.Sample(g_sampler%d, tc%d);\r\n", i, i, i, i);
+                if (cc_features.used_masks[i]) {
+                    if (cc_features.used_blend[i]) {
+                        len += sprintf(buf + len,
+                                       "        float4 blendVal%d = g_textureBlend%d.Sample(g_sampler%d, tc%d);\r\n", i,
+                                       i, i, i);
+                    } else {
+                        len += sprintf(buf + len, "        float4 blendVal%d = float4(0, 0, 0, 0);\r\n", i);
+                    }
+                    len += sprintf(buf + len,
+                                   "        texVal%d = lerp(texVal%d, blendVal%d, "
+                                   "g_textureMask%d.Sample(g_sampler%d, tc%d).a);\r\n",
+                                   i, i, i, i, i, i);
+                }
                 len += sprintf(buf + len, "    }\r\n");
             } else {
                 len +=

--- a/src/graphic/Fast3D/gfx_metal_shader.cpp
+++ b/src/graphic/Fast3D/gfx_metal_shader.cpp
@@ -125,7 +125,7 @@ static void append_formula(char* buf, size_t* len, const uint8_t c[2][4], bool d
 
 // MARK: - Public Methods
 
-MTL::VertexDescriptor* gfx_metal_build_shader(char buf[4096], size_t& num_floats, const CCFeatures& cc_features,
+MTL::VertexDescriptor* gfx_metal_build_shader(char buf[8192], size_t& num_floats, const CCFeatures& cc_features,
                                               bool three_point_filtering) {
 
     size_t len = 0;

--- a/src/graphic/Fast3D/gfx_metal_shader.h
+++ b/src/graphic/Fast3D/gfx_metal_shader.h
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include "gfx_cc.h"
 
-MTL::VertexDescriptor* gfx_metal_build_shader(char buf[4096], size_t& num_floats, const CCFeatures& cc_features,
+MTL::VertexDescriptor* gfx_metal_build_shader(char buf[8192], size_t& num_floats, const CCFeatures& cc_features,
                                               bool three_point_filtering);
 
 #endif /* GFX_METAL_SHADER_H */

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -901,10 +901,10 @@ static void import_texture_raw(int tile, bool importReplacement) {
     // if texture type is CI4 or CI8 we need to apply tlut to it
     switch (type) {
         case LUS::TextureType::Palette4bpp:
-            import_texture_ci4(tile, false);
+            import_texture_ci4(tile, importReplacement);
             return;
         case LUS::TextureType::Palette8bpp:
-            import_texture_ci8(tile, false);
+            import_texture_ci8(tile, importReplacement);
             return;
         default:
             break;
@@ -1565,6 +1565,12 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
             if (linear_filter != rendering_state.textures[i]->second.linear_filter ||
                 cms != rendering_state.textures[i]->second.cms || cmt != rendering_state.textures[i]->second.cmt) {
                 gfx_flush();
+
+                // Set the same sampler params on the blended texture. Needed for opengl.
+                if (rdp.loaded_texture[i].blended) {
+                    gfx_rapi->set_sampler_parameters(SHADER_FIRST_REPLACEMENT_TEXTURE + i, linear_filter, cms, cmt);
+                }
+
                 gfx_rapi->set_sampler_parameters(i, linear_filter, cms, cmt);
                 rendering_state.textures[i]->second.linear_filter = linear_filter;
                 rendering_state.textures[i]->second.cms = cms;


### PR DESCRIPTION
#### This PR adds some fixes around the masked/blended texture shaders

The blended textures shader effect was not fully implemented on DirectX. DirectX has 3 code paths:
1. Tri-point filtering is off
2. Tri-point filtering is on with linear filtering enabled for the texture
3. Tri-point filtering is on but linear filtering is disabled for the texture

This third path was missing the logic for masked/blended texture effects. I have copied the patterns from code path 1 to here.

---

OpenGL, unlike the other renders, seems to require a dedicated sampler for each texture. We were only setting a sampler for the main textures (index 0 and 1), but not for the blended textures (index 4 and 5). This meant that any parameters needed for the texture were not applied to the blended texture in OpenGL like `GL_MIRRORED_REPEAT` to mirror a texture outside the texture coordinates. This PR checks if the texture has a blended texture and then applies the same sampler parameters to the blended texture index so OpenGL renders the texture as expected.

---

I also noticed a buffer size mismatch in the metal shader where it was updated to 8192 in the parent caller that passes the buffer through, but the function signature was still at the old size.