### PR TITLE
Add color clamping to metal shader

### DIFF
--- a/src/graphic/Fast3D/gfx_metal_shader.cpp
+++ b/src/graphic/Fast3D/gfx_metal_shader.cpp
@@ -253,6 +253,13 @@ MTL::VertexDescriptor* gfx_metal_build_shader(char buf[4096], size_t& num_floats
     append_line(buf, &len, "}");
     // end vertex shader
 
+    append_line(buf, &len, "float3 mod(float3 a, float3 b) {");
+    append_line(
+        buf, &len,
+        "    return float3(a.x - b.x * floor(a.x / b.x), a.y - b.y * floor(a.y / b.y), a.z - b.z * floor(a.z / b.z));");
+    append_line(buf, &len, "}");
+    append_line(buf, &len, "#define WRAP(x, low, high) mod((x)-(low), (high)-(low)) + (low)");
+
     // fragment shader
     if (three_point_filtering) {
         append_line(
@@ -387,7 +394,14 @@ MTL::VertexDescriptor* gfx_metal_build_shader(char buf[4096], size_t& num_floats
                            cc_features.do_mix[c][0], cc_features.opt_alpha, false, cc_features.opt_alpha);
         }
         append_line(buf, &len, ";");
+
+        if (c == 0) {
+            append_str(buf, &len, "texel.xyz = WRAP(texel.xyz, -1.01, 1.01);");
+        }
     }
+
+    append_str(buf, &len, "texel.xyz = WRAP(texel.xyz, -0.51, 1.51);");
+    append_str(buf, &len, "texel.xyz = clamp(texel.xyz, 0.0, 1.0);");
 
     if (cc_features.opt_fog) {
         if (cc_features.opt_alpha) {


### PR DESCRIPTION
Adds the color clamping added to DX/OpenGL in https://github.com/HarbourMasters/Shipwright/pull/1753 and adjusted in #390 to metal

Verified that without the fix from #390 the issues on sarias song also persisted on metal, and verified with the fix that both saria's song and ganon's attack look correct.

before
<img width="768" alt="Screenshot 2023-12-13 at 12 18 51 AM" src="https://github.com/Kenix3/libultraship/assets/126511172/27915e78-1b96-47b4-8062-df44c6402067">
after
<img width="768" alt="Screenshot 2023-12-13 at 12 17 56 AM" src="https://github.com/Kenix3/libultraship/assets/126511172/6275bd74-f9b7-42af-ae31-97810cc1a6a0">
