### PR TITLE
stick sensitivity

### DIFF
--- a/src/controller/controldevice/controller/ControllerStick.h
+++ b/src/controller/controldevice/controller/ControllerStick.h
@@ -8,6 +8,7 @@
 
 namespace LUS {
 
+#define DEFAULT_STICK_SENSITIVITY_PERCENTAGE 100
 #define DEFAULT_STICK_DEADZONE_PERCENTAGE 20
 #define DEFAULT_NOTCH_SNAP_ANGLE 0
 
@@ -35,6 +36,11 @@ class ControllerStick {
     bool AddOrEditAxisDirectionMappingFromRawPress(Direction direction, std::string id);
     void Process(int8_t& x, int8_t& y);
 
+    void ResetSensitivityToDefault();
+    void SetSensitivity(uint8_t sensitivityPercentage);
+    uint8_t GetSensitivityPercentage();
+    bool SensitivityIsDefault();
+
     void ResetDeadzoneToDefault();
     void SetDeadzone(uint8_t deadzonePercentage);
     uint8_t GetDeadzonePercentage();
@@ -59,6 +65,9 @@ class ControllerStick {
 
     uint8_t mPortIndex;
     Stick mStick;
+
+    uint8_t mSensitivityPercentage;
+    float mSensitivity;
 
     // TODO: handle deadzones separately for X and Y?
     uint8_t mDeadzonePercentage;

--- a/src/window/gui/InputEditorWindow.cpp
+++ b/src/window/gui/InputEditorWindow.cpp
@@ -548,6 +548,21 @@ void InputEditorWindow::DrawStickSection(uint8_t port, uint8_t stick, int32_t id
     DrawStickDirectionLine(ICON_FA_ARROW_RIGHT, port, stick, RIGHT, color);
     ImGui::EndGroup();
     if (ImGui::TreeNode(StringHelper::Sprintf("Analog Stick Options##%d", id).c_str())) {
+        ImGui::Text("Sensitivity:");
+        ImGui::SetNextItemWidth(160.0f);
+
+        int32_t sensitivityPercentage = controllerStick->GetSensitivityPercentage();
+        if (ImGui::SliderInt(StringHelper::Sprintf("##Sensitivity%d", id).c_str(), &sensitivityPercentage, 0, 200,
+                             "%d%%", ImGuiSliderFlags_AlwaysClamp)) {
+            controllerStick->SetSensitivity(sensitivityPercentage);
+        }
+        if (!controllerStick->SensitivityIsDefault()) {
+            ImGui::SameLine();
+            if (ImGui::Button(StringHelper::Sprintf("Reset to Default###resetStickSensitivity%d", id).c_str())) {
+                controllerStick->ResetSensitivityToDefault();
+            }
+        }
+
         ImGui::Text("Deadzone:");
         ImGui::SetNextItemWidth(160.0f);
 


### PR DESCRIPTION
i know there was discussion of something more robust than this to handle deadzones for ess or a "move the control stick in a circle to find the range" solution, but this is a simple way to make it so people can use n64 controller adapters that don't provide a full range to sdl (which doesn't respect range calibration using jstest on linux because of some evdev stuff that gets real messy to try to fix as a user)

the mapping string matches another adapter, so it won't make it into the upstream gamecontrollerdb, but the one i used to test was
```
030083a08f0e00001330000010010000,Mayflash N64 Adapter,a:b1,b:b2,start:b9,leftshoulder:b6,leftstick:-a1,rightstick:-a2,dpup:h0.1,dpleft:h0.8,dpdown:h0.4,dpright:h0.2,lefttrigger:b8,righttrigger:b7,platform:Linux,
```
