### PR TITLE
Replace mVariables map by unordered map to optimize get functions

### DIFF
--- a/src/config/ConsoleVariable.h
+++ b/src/config/ConsoleVariable.h
@@ -4,7 +4,7 @@
 #include <nlohmann/json.hpp>
 #include <stdint.h>
 #include <memory>
-#include <map>
+#include <unordered_map>
 #include <string>
 
 namespace LUS {
@@ -56,6 +56,6 @@ class ConsoleVariable {
     void LoadLegacy();
 
   private:
-    std::map<std::string, std::shared_ptr<CVar>, std::less<>> mVariables;
+    std::unordered_map<std::string, std::shared_ptr<CVar>> mVariables;
 };
 } // namespace LUS


### PR DESCRIPTION
mVariables is used to store config values as a simple dict.
There is no need to use a map as we don't need to keep track of insertion order of keys.
I propose to replace the map by unordered map.

On soh the getinteger function seems to be 2x faster (1,8% -> 0,9% of cpu usage):

<img width="639" alt="Screenshot 2024-01-02 at 17 04 30" src="https://github.com/Kenix3/libultraship/assets/6125066/3e050429-74f0-40f8-a8dd-0f7b1c82cf57">

<img width="721" alt="Screenshot 2024-01-02 at 17 04 04" src="https://github.com/Kenix3/libultraship/assets/6125066/ea3bca77-c1c1-40f7-9d01-bcbdb2efb3bc">

