### PR TITLE
Expose tex clear funcs and fix more Metal issues with blended textures (cherry-pick)

### DIFF
--- a/src/graphic/Fast3D/gfx_metal.cpp
+++ b/src/graphic/Fast3D/gfx_metal.cpp
@@ -654,10 +654,10 @@ void gfx_metal_end_frame(void) {
         fb.has_ended_encoding = false;
         fb.has_bounded_vertex_buffer = false;
         fb.has_bounded_fragment_buffer = false;
-        fb.last_bound_textures[0] = nullptr;
-        fb.last_bound_textures[1] = nullptr;
-        fb.last_bound_samplers[0] = nullptr;
-        fb.last_bound_samplers[1] = nullptr;
+        for (int i = 0; i < SHADER_MAX_TEXTURES; i++) {
+            fb.last_bound_textures[i] = nullptr;
+            fb.last_bound_samplers[i] = nullptr;
+        }
         fb.last_depth_test = -1;
         fb.last_depth_mask = -1;
         fb.last_zmode_decal = -1;

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -570,7 +570,7 @@ static std::string gfx_get_base_texture_path(const std::string& path) {
     return path;
 }
 
-static void gfx_texture_cache_delete(const uint8_t* orig_addr) {
+void gfx_texture_cache_delete(const uint8_t* orig_addr) {
     while (gfx_texture_cache.map.bucket_count() > 0) {
         TextureCacheKey key = { orig_addr, { 0 }, 0, 0 }; // bucket index only depends on the address
         size_t bucket = gfx_texture_cache.map.bucket(key);
@@ -3340,4 +3340,12 @@ void gfx_register_blended_texture(const char* name, uint8_t* mask, uint8_t* repl
     }
 
     masked_textures[name] = MaskedTextureEntry{ mask, replacement };
+}
+
+void gfx_unregister_blended_texture(const char* name) {
+    if (gfx_check_image_signature(name)) {
+        name += 7;
+    }
+
+    masked_textures.erase(name);
 }

--- a/src/graphic/Fast3D/gfx_pc.h
+++ b/src/graphic/Fast3D/gfx_pc.h
@@ -82,6 +82,7 @@ void gfx_run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_replacemen
 void gfx_end_frame(void);
 void gfx_set_target_fps(int);
 void gfx_set_maximum_frame_latency(int latency);
+void gfx_texture_cache_delete(const uint8_t* orig_addr);
 extern "C" void gfx_texture_cache_clear();
 extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height);
 void gfx_get_pixel_depth_prepare(float x, float y);
@@ -89,5 +90,6 @@ uint16_t gfx_get_pixel_depth(float x, float y);
 void gfx_push_current_dir(char* path);
 int32_t gfx_check_image_signature(const char* imgData);
 void gfx_register_blended_texture(const char* name, uint8_t* mask, uint8_t* replacement = nullptr);
+void gfx_unregister_blended_texture(const char* name);
 
 #endif


### PR DESCRIPTION
This exposes the texture cache clearing func so that it can be used outside of draw commands. I also added and exposed an unregister blended texture effect so that they can be cleaned up when not needed.

Additionally I resolved another issue with Metal shaders not working properly with blended effects, where the "last bound" textures on the frame buffer specifically for the mask and blended texture IDs were not cleared compared to DirectX.

Used with https://github.com/HarbourMasters/Shipwright/pull/3773

(cherry-picked from https://github.com/Kenix3/libultraship/commit/96c8a8929c18c1bffd7d92a35a589f74cf16fc59)