### PR TITLE
Restore osGetTime/osGetCount to match n64 specs

### DIFF
--- a/src/public/libultra/os.cpp
+++ b/src/public/libultra/os.cpp
@@ -1,5 +1,11 @@
 #include "libultraship/libultraship.h"
 #include <SDL2/SDL.h>
+#include <ratio>
+
+// Establish a chrono duration for the N64 46.875MHz clock rate
+typedef std::ratio<3000, 64> n64ClockRatio;
+typedef std::ratio_divide<std::micro, n64ClockRatio> n64CycleRate;
+typedef std::chrono::duration<long long, n64CycleRate> n64CycleRateDuration;
 
 extern "C" {
 uint8_t __osMaxControllers = MAXCONTROLLERS;
@@ -39,12 +45,16 @@ void osContGetReadData(OSContPad* pad) {
     LUS::Context::GetInstance()->GetControlDeck()->WriteToPad(pad);
 }
 
+// Returns the OS time matching the N64 46.875MHz cycle rate
+// LUSTODO: This should be adjusted to return the time since "boot"
 uint64_t osGetTime(void) {
-    return std::chrono::steady_clock::now().time_since_epoch().count();
+    return std::chrono::duration_cast<n64CycleRateDuration>(std::chrono::steady_clock::now().time_since_epoch())
+        .count();
 }
 
+// Returns the CPU clock count matching the N64 46.875Mhz cycle rate
 uint32_t osGetCount(void) {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+    return std::chrono::duration_cast<n64CycleRateDuration>(std::chrono::steady_clock::now().time_since_epoch())
         .count();
 }
 


### PR DESCRIPTION
`osGetTime`/`osGetCount` where returning the values based on modern machine cycle rates at the nanosecond level.
The specifications for N64 report these methods as running at 48.675MHz for the CPU clock cycle.

I've added a set of ratio and custom chrono duration values to allow us to return accurate values from these methods for ports that depend on them for things like in-game timers.

The only detail I didn't implement yet is that the main difference between `osGetTime` and `osGetCount`, is that `osGetTime` specifically returns the time since last "boot". I'm not sure how we would want to handle that detail, but for now its not immediately needed.

I am also unsure if LUS should still provide a "modern" osGetTime that returns normalized seconds/miliseconds values.