### PR TITLE
Remove linking against unused legacy OpenGL GLX implementation.

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -123,7 +123,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         target_link_libraries(ImGui PUBLIC ${OPENGL_GLESv2_LIBRARY} GLEW::GLEW)
         add_compile_definitions(IMGUI_IMPL_OPENGL_ES3)
     else()
-        target_link_libraries(ImGui PUBLIC ${OPENGL_glx_LIBRARY} ${OPENGL_opengl_LIBRARY} GLEW::GLEW)
+        target_link_libraries(ImGui PUBLIC ${OPENGL_opengl_LIBRARY} GLEW::GLEW)
     endif()
 endif()
 


### PR DESCRIPTION
Originally, f3d used GLX-specific code for context initialization.

LUS has moved away from that, and expects SDL to be used for abstraction (we aren't doing any X specific stuff that would require us to include GLX).

Based on this (and local tests on GNU/Linux systems with Xorg/Wayland and KMS/DRM only) it's safe to simply remove `${OPENGL_glx_LIBRARY}` from that line.