### PR TITLE
Remove detection of unused PulseAudio audio libary.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -465,11 +465,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     target_link_libraries(libultraship PRIVATE ${OSX_FOUNDATION} ${OSX_AVFOUNDATION} ${METAL} ${QUARTZCORE} ${CMAKE_DL_LIBS})
 endif()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    find_package(PulseAudio)
-    target_link_libraries(libultraship PRIVATE ${PULSEAUDIO_LIBRARY})
-endif()
-
 if (USE_OPENGLES)
     if (CMAKE_SYSTEM_NAME STREQUAL "Android")
         find_library(OPENGLES_LIBRARY GLESv3)

--- a/src/audio/Audio.cpp
+++ b/src/audio/Audio.cpp
@@ -37,9 +37,6 @@ void Audio::Init() {
 #ifdef _WIN32
     mAvailableAudioBackends->push_back(AudioBackend::WASAPI);
 #endif
-#ifdef __linux
-    mAvailableAudioBackends->push_back(AudioBackend::PULSE);
-#endif
     mAvailableAudioBackends->push_back(AudioBackend::SDL);
 
     SetAudioBackend(Context::GetInstance()->GetConfig()->GetAudioBackend());

--- a/src/audio/Audio.h
+++ b/src/audio/Audio.h
@@ -6,7 +6,7 @@
 #include "audio/AudioPlayer.h"
 
 namespace LUS {
-enum class AudioBackend { WASAPI, PULSE, SDL };
+enum class AudioBackend { WASAPI, SDL };
 
 class Audio {
   public:


### PR DESCRIPTION
On GNU/Linux, SDL2 audio is now used instead of PulseAudio, which abstracts the underlying audio system as intended (on GNU/Linux it can ALSA, PipeWire, PulseAudio, etc. and there's no need to access them directly since SDL2 makes a perfect job abstracting that).

PulseAudio is not used anywhere in the code, so trying to detect it is unnecessary.
This makes the PulseAudio dependency finally go away, since this detection at build time is all that remains.