### PR TITLE
fix: put `SDL_WndProc` behind `_WIN32` ifdef

### DIFF
--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -62,7 +62,10 @@ static void (*on_fullscreen_changed_callback)(bool is_now_fullscreen);
 static bool (*on_key_down_callback)(int scancode);
 static bool (*on_key_up_callback)(int scancode);
 static void (*on_all_keys_up_callback)(void);
+
+#ifdef _WIN32
 LONG_PTR SDL_WndProc;
+#endif
 
 const SDL_Scancode lus_to_sdl_table[] = {
     SDL_SCANCODE_UNKNOWN,


### PR DESCRIPTION
This was added in https://github.com/Kenix3/libultraship/pull/365

It is only used in `_WIN32` `#ifdef` blocks

https://github.com/Kenix3/libultraship/blob/ef0c348c87e07859c850ac8cd553daa808c2bf34/src/graphic/Fast3D/gfx_sdl2.cpp#L290-L303

https://github.com/Kenix3/libultraship/blob/ef0c348c87e07859c850ac8cd553daa808c2bf34/src/graphic/Fast3D/gfx_sdl2.cpp#L366-L374