### PR TITLE
Fix OpenGL framebuffer depth reads

### DIFF
--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -1021,7 +1021,9 @@ gfx_opengl_get_pixel_depth(int fb_id, const std::set<std::pair<float, float>>& c
 
     Framebuffer& fb = framebuffers[fb_id];
 
-    if (coordinates.size() == 1) {
+    // When looking up one value and the framebuffer is single-sampled, we can read pixels directly
+    // Otherwise we need to blit first to a new buffer then read it
+    if (coordinates.size() == 1 && fb.msaa_level <= 1) {
         uint32_t depth_stencil_value;
         glBindFramebuffer(GL_FRAMEBUFFER, fb.fbo);
         int x = coordinates.begin()->first;

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -302,6 +302,7 @@ static void gfx_sdl_init(const char* game_name, const char* gfx_api_name, bool s
 
     if (use_opengl) {
         SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
+        SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
         SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     } else {
         SDL_SetHint(SDL_HINT_RENDER_DRIVER, "metal");


### PR DESCRIPTION
We have an optimization for reading depth values in OpenGL when there is only one coordinate, and that is to skip the blit and just read directly.

The problem with this, is `glReadPixels` does not work on multi-sampled framebuffers. In the case of msaa, you have to blit first to a single-sampled buffer, then the pixels can be read.

This PR adds a check for MSAA <= 1 when choosing if we can use the optimized read.

Additionally, the default framebuffer setup by SDL was missing a stencil size, where as all the other buffers we create in Fast3D do have a stencil set. I've added the attribute as it is required in our depth test due to the format being `GL_DEPTH24_STENCIL8`.

---

Without these fixes, the depth read silently fails and leads to things like the sun lens flare/torch glows sometimes not rendering in OOT.