### PR TITLE
another stupid hack...

### DIFF
--- a/extern/StormLib/src/FileStream.cpp
+++ b/extern/StormLib/src/FileStream.cpp
@@ -132,7 +132,7 @@ static bool BaseFile_Create(TFileStream * pStream)
     return true;
 }
 
-static bool BaseFile_Open(TFileStream * pStream, const TCHAR * szFileName, DWORD dwStreamFlags)
+static bool BaseFile_Open(TFileStream * pStream, const char * szFileName, DWORD dwStreamFlags)
 {
 #ifdef STORMLIB_WINDOWS
     {
@@ -669,7 +669,7 @@ static void BaseMap_Init(TFileStream * pStream)
 //-----------------------------------------------------------------------------
 // Local functions - base HTTP file support
 
-static const TCHAR * BaseHttp_ExtractServerName(const TCHAR * szFileName, TCHAR * szServerName)
+static const char * BaseHttp_ExtractServerName(const char * szFileName, char * szServerName)
 {
     // Check for HTTP
     if(!_tcsnicmp(szFileName, _T("http://"), 7))
@@ -692,7 +692,7 @@ static const TCHAR * BaseHttp_ExtractServerName(const TCHAR * szFileName, TCHAR 
     return szFileName;
 }
 
-static bool BaseHttp_Open(TFileStream * pStream, const TCHAR * szFileName, DWORD dwStreamFlags)
+static bool BaseHttp_Open(TFileStream * pStream, const char * szFileName, DWORD dwStreamFlags)
 {
 #ifdef STORMLIB_WINDOWS
 
@@ -714,7 +714,7 @@ static bool BaseHttp_Open(TFileStream * pStream, const TCHAR * szFileName, DWORD
                                                 0);
     if(pStream->Base.Http.hInternet != NULL)
     {
-        TCHAR szServerName[MAX_PATH];
+        char szServerName[MAX_PATH];
         DWORD dwFlags = INTERNET_FLAG_KEEP_CONNECTION | INTERNET_FLAG_NO_UI | INTERNET_FLAG_NO_CACHE_WRITE;
 
         // Initiate connection with the server
@@ -739,7 +739,7 @@ static bool BaseHttp_Open(TFileStream * pStream, const TCHAR * szFileName, DWORD
                     DWORD dwFileSize = 0;
                     DWORD dwDataSize;
                     DWORD dwIndex = 0;
-                    TCHAR StatusCode[0x08];
+                    char StatusCode[0x08];
 
                     // Check if the file succeeded to open
                     dwDataSize = sizeof(StatusCode);
@@ -816,7 +816,7 @@ static bool BaseHttp_Read(
         HINTERNET hRequest;
         LPCTSTR szFileName;
         LPBYTE pbBuffer = (LPBYTE)pvBuffer;
-        TCHAR szRangeRequest[0x80];
+        char szRangeRequest[0x80];
         DWORD dwStartOffset = (DWORD)ByteOffset;
         DWORD dwEndOffset = dwStartOffset + dwBytesToRead;
 
@@ -1090,13 +1090,13 @@ static STREAM_INIT StreamBaseInit[4] =
 // The stream structure is created as flat block, variable length
 // The file name is placed after the end of the stream structure data
 static TFileStream * AllocateFileStream(
-    const TCHAR * szFileName,
+    const char * szFileName,
     size_t StreamSize,
     DWORD dwStreamFlags)
 {
     TFileStream * pMaster = NULL;
     TFileStream * pStream;
-    const TCHAR * szNextFile = szFileName;
+    const char * szNextFile = szFileName;
     size_t FileNameSize;
 
     // Sanity check
@@ -1107,7 +1107,7 @@ static TFileStream * AllocateFileStream(
     // In that case, we use the part after "*" as master file name
     while(szNextFile[0] != 0 && szNextFile[0] != _T('*'))
         szNextFile++;
-    FileNameSize = (size_t)((szNextFile - szFileName) * sizeof(TCHAR));
+    FileNameSize = (size_t)((szNextFile - szFileName) * sizeof(char));
 
     // If we have a next file, we need to open it as master stream
     // Note that we don't care if the master stream exists or not,
@@ -1126,7 +1126,7 @@ static TFileStream * AllocateFileStream(
     }
 
     // Allocate the stream structure for the given stream type
-    pStream = (TFileStream *)STORM_ALLOC(BYTE, StreamSize + FileNameSize + sizeof(TCHAR));
+    pStream = (TFileStream *)STORM_ALLOC(BYTE, StreamSize + FileNameSize + sizeof(char));
     if(pStream != NULL)
     {
         // Zero the entire structure
@@ -1135,9 +1135,9 @@ static TFileStream * AllocateFileStream(
         pStream->dwFlags = dwStreamFlags;
 
         // Initialize the file name
-        pStream->szFileName = (TCHAR *)((BYTE *)pStream + StreamSize);
+        pStream->szFileName = (char *)((BYTE *)pStream + StreamSize);
         memcpy(pStream->szFileName, szFileName, FileNameSize);
-        pStream->szFileName[FileNameSize / sizeof(TCHAR)] = 0;
+        pStream->szFileName[FileNameSize / sizeof(char)] = 0;
 
         // Initialize the stream functions
         StreamBaseInit[dwStreamFlags & 0x03](pStream);
@@ -1440,7 +1440,7 @@ static bool FlatStream_CreateMirror(TBlockStream * pStream)
     return true;
 }
 
-static TFileStream * FlatStream_Open(const TCHAR * szFileName, DWORD dwStreamFlags)
+static TFileStream * FlatStream_Open(const char * szFileName, DWORD dwStreamFlags)
 {
     TBlockStream * pStream;
     ULONGLONG ByteOffset = 0;
@@ -1860,7 +1860,7 @@ static bool PartStream_CreateMirror(TBlockStream * pStream)
 }
 
 
-static TFileStream * PartStream_Open(const TCHAR * szFileName, DWORD dwStreamFlags)
+static TFileStream * PartStream_Open(const char * szFileName, DWORD dwStreamFlags)
 {
     TBlockStream * pStream;
 
@@ -2177,7 +2177,7 @@ static bool MpqeStream_BlockRead(
     return true;
 }
 
-static TFileStream * MpqeStream_Open(const TCHAR * szFileName, DWORD dwStreamFlags)
+static TFileStream * MpqeStream_Open(const char * szFileName, DWORD dwStreamFlags)
 {
     TEncryptedStream * pStream;
 
@@ -2306,14 +2306,14 @@ static void Block4Stream_Close(TBlockStream * pStream)
     return;
 }
 
-static TFileStream * Block4Stream_Open(const TCHAR * szFileName, DWORD dwStreamFlags)
+static TFileStream * Block4Stream_Open(const char * szFileName, DWORD dwStreamFlags)
 {
     TBaseProviderData * NewBaseArray = NULL;
     ULONGLONG RemainderBlock;
     ULONGLONG BlockCount;
     ULONGLONG FileSize;
     TBlockStream * pStream;
-    TCHAR * szNameBuff;
+    char * szNameBuff;
     size_t nNameLength;
     DWORD dwBaseFiles = 0;
     DWORD dwBaseFlags;
@@ -2340,7 +2340,7 @@ static TFileStream * Block4Stream_Open(const TCHAR * szFileName, DWORD dwStreamF
     pStream->BlockRead     = (BLOCK_READ)Block4Stream_BlockRead;
 
     // Allocate work space for numeric names
-    szNameBuff = STORM_ALLOC(TCHAR, nNameLength + 4);
+    szNameBuff = STORM_ALLOC(char, nNameLength + 4);
     if(szNameBuff != NULL)
     {
         // Set the base flags
@@ -2441,7 +2441,7 @@ static TFileStream * Block4Stream_Open(const TCHAR * szFileName, DWORD dwStreamF
  */
 
 TFileStream * FileStream_CreateFile(
-    const TCHAR * szFileName,
+    const char * szFileName,
     DWORD dwStreamFlags)
 {
     TFileStream * pStream;
@@ -2497,7 +2497,7 @@ TFileStream * FileStream_CreateFile(
  */
 
 TFileStream * FileStream_OpenFile(
-    const TCHAR * szFileName,
+    const char * szFileName,
     DWORD dwStreamFlags)
 {
     DWORD dwProvider = dwStreamFlags & STREAM_PROVIDERS_MASK;
@@ -2533,7 +2533,7 @@ TFileStream * FileStream_OpenFile(
  *
  * \a pStream Pointer to an open stream
  */
-const TCHAR * FileStream_GetFileName(TFileStream * pStream)
+const char * FileStream_GetFileName(TFileStream * pStream)
 {
     assert(pStream != NULL);
     return pStream->szFileName;
@@ -2546,7 +2546,7 @@ const TCHAR * FileStream_GetFileName(TFileStream * pStream)
  * \a pdwStreamProvider Pointer to a DWORD variable that receives stream provider (STREAM_PROVIDER_XXX)
  */
 
-size_t FileStream_Prefix(const TCHAR * szFileName, DWORD * pdwProvider)
+size_t FileStream_Prefix(const char * szFileName, DWORD * pdwProvider)
 {
     size_t nPrefixLength1 = 0;
     size_t nPrefixLength2 = 0;

--- a/extern/StormLib/src/FileStream.h
+++ b/extern/StormLib/src/FileStream.h
@@ -24,7 +24,7 @@ typedef bool (*STREAM_CREATE)(
 
 typedef bool (*STREAM_OPEN)(
     struct TFileStream * pStream,       // Pointer to an unopened stream
-    const TCHAR * szFileName,           // Pointer to file name to be open
+    const char * szFileName,           // Pointer to file name to be open
     DWORD dwStreamFlags                 // Stream flags
     );
 
@@ -179,7 +179,7 @@ struct TFileStream
 
     // Stream provider data
     TFileStream * pMaster;                  // Master stream (e.g. MPQ on a web server)
-    TCHAR * szFileName;                     // File name (self-relative pointer)
+    char * szFileName;                     // File name (self-relative pointer)
 
     ULONGLONG StreamSize;                   // Stream size (can be less than file size)
     ULONGLONG StreamPos;                    // Stream position

--- a/extern/StormLib/src/SBaseCommon.cpp
+++ b/extern/StormLib/src/SBaseCommon.cpp
@@ -151,7 +151,7 @@ void StringCreatePseudoFileName(char * szBuffer, size_t cchMaxChars, unsigned in
 // Utility functions (UNICODE) only exist in the ANSI version of the library
 // In ANSI builds, TCHAR = char, so we don't need these functions implemented
 
-#ifdef _UNICODE
+#if 0
 void StringCopy(TCHAR * szTarget, size_t cchTarget, const char * szSource)
 {
     if(cchTarget > 0)

--- a/extern/StormLib/src/SBaseCommon.cpp
+++ b/extern/StormLib/src/SBaseCommon.cpp
@@ -149,10 +149,10 @@ void StringCreatePseudoFileName(char * szBuffer, size_t cchMaxChars, unsigned in
 
 //-----------------------------------------------------------------------------
 // Utility functions (UNICODE) only exist in the ANSI version of the library
-// In ANSI builds, TCHAR = char, so we don't need these functions implemented
+// In ANSI builds, char = char, so we don't need these functions implemented
 
 #if 0
-void StringCopy(TCHAR * szTarget, size_t cchTarget, const char * szSource)
+void StringCopy(char * szTarget, size_t cchTarget, const char * szSource)
 {
     if(cchTarget > 0)
     {
@@ -166,7 +166,7 @@ void StringCopy(TCHAR * szTarget, size_t cchTarget, const char * szSource)
     }
 }
 
-void StringCopy(char * szTarget, size_t cchTarget, const TCHAR * szSource)
+void StringCopy(char * szTarget, size_t cchTarget, const char * szSource)
 {
     if(cchTarget > 0)
     {
@@ -180,7 +180,7 @@ void StringCopy(char * szTarget, size_t cchTarget, const TCHAR * szSource)
     }
 }
 
-void StringCopy(TCHAR * szTarget, size_t cchTarget, const TCHAR * szSource)
+void StringCopy(char * szTarget, size_t cchTarget, const char * szSource)
 {
     if(cchTarget > 0)
     {
@@ -189,12 +189,12 @@ void StringCopy(TCHAR * szTarget, size_t cchTarget, const TCHAR * szSource)
         if(cchSource >= cchTarget)
             cchSource = cchTarget - 1;
 
-        memcpy(szTarget, szSource, cchSource * sizeof(TCHAR));
+        memcpy(szTarget, szSource, cchSource * sizeof(char));
         szTarget[cchSource] = 0;
     }
 }
 
-void StringCat(TCHAR * szTarget, size_t cchTargetMax, const TCHAR * szSource)
+void StringCat(char * szTarget, size_t cchTargetMax, const char * szSource)
 {
     // Get the current length of the target
     size_t cchTarget = _tcslen(szTarget);

--- a/extern/StormLib/src/SFileAddFile.cpp
+++ b/extern/StormLib/src/SFileAddFile.cpp
@@ -887,7 +887,7 @@ bool WINAPI SFileFinishFile(HANDLE hFile)
 
 bool WINAPI SFileAddFileEx(
     HANDLE hMpq,
-    const TCHAR * szFileName,
+    const char * szFileName,
     const char * szArchivedName,
     DWORD dwFlags,
     DWORD dwCompression,            // Compression of the first sector
@@ -1025,7 +1025,7 @@ bool WINAPI SFileAddFileEx(
 }
 
 // Adds a data file into the archive
-bool WINAPI SFileAddFile(HANDLE hMpq, const TCHAR * szFileName, const char * szArchivedName, DWORD dwFlags)
+bool WINAPI SFileAddFile(HANDLE hMpq, const char * szFileName, const char * szArchivedName, DWORD dwFlags)
 {
     return SFileAddFileEx(hMpq,
                           szFileName,
@@ -1036,7 +1036,7 @@ bool WINAPI SFileAddFile(HANDLE hMpq, const TCHAR * szFileName, const char * szA
 }
 
 // Adds a WAVE file into the archive
-bool WINAPI SFileAddWave(HANDLE hMpq, const TCHAR * szFileName, const char * szArchivedName, DWORD dwFlags, DWORD dwQuality)
+bool WINAPI SFileAddWave(HANDLE hMpq, const char * szFileName, const char * szArchivedName, DWORD dwFlags, DWORD dwQuality)
 {
     DWORD dwCompression = 0;
 

--- a/extern/StormLib/src/SFileCompactArchive.cpp
+++ b/extern/StormLib/src/SFileCompactArchive.cpp
@@ -46,7 +46,7 @@ static DWORD CheckIfAllFilesKnown(TMPQArchive * ha)
     return dwErrCode;
 }
 
-static DWORD CheckIfAllKeysKnown(TMPQArchive * ha, const TCHAR * szListFile, LPDWORD pFileKeys)
+static DWORD CheckIfAllKeysKnown(TMPQArchive * ha, const char * szListFile, LPDWORD pFileKeys)
 {
     TFileEntry * pFileTableEnd = ha->pFileTable + ha->dwFileTableSize;
     TFileEntry * pFileEntry;
@@ -523,14 +523,14 @@ bool WINAPI SFileSetCompactCallback(HANDLE hMpq, SFILE_COMPACT_CALLBACK pfnCompa
     return true;
 }
 
-bool WINAPI SFileCompactArchive(HANDLE hMpq, const TCHAR * szListFile, bool /* bReserved */)
+bool WINAPI SFileCompactArchive(HANDLE hMpq, const char * szListFile, bool /* bReserved */)
 {
     TFileStream * pTempStream = NULL;
     TMPQArchive * ha = (TMPQArchive *)hMpq;
     ULONGLONG ByteOffset;
     ULONGLONG ByteCount;
     LPDWORD pFileKeys = NULL;
-    TCHAR szTempFile[MAX_PATH+1] = _T("");
+    char szTempFile[MAX_PATH+1] = _T("");
     DWORD dwErrCode = ERROR_SUCCESS;
 
     // Test the valid parameters

--- a/extern/StormLib/src/SFileCreateArchive.cpp
+++ b/extern/StormLib/src/SFileCreateArchive.cpp
@@ -69,7 +69,7 @@ static DWORD WriteNakedMPQHeader(TMPQArchive * ha)
 //-----------------------------------------------------------------------------
 // Creates a new MPQ archive.
 
-bool WINAPI SFileCreateArchive(const TCHAR * szMpqName, DWORD dwCreateFlags, DWORD dwMaxFileCount, HANDLE * phMpq)
+bool WINAPI SFileCreateArchive(const char * szMpqName, DWORD dwCreateFlags, DWORD dwMaxFileCount, HANDLE * phMpq)
 {
     SFILE_CREATE_MPQ CreateInfo;
 
@@ -98,7 +98,7 @@ bool WINAPI SFileCreateArchive(const TCHAR * szMpqName, DWORD dwCreateFlags, DWO
     return SFileCreateArchive2(szMpqName, &CreateInfo, phMpq);
 }
 
-bool WINAPI SFileCreateArchive2(const TCHAR * szMpqName, PSFILE_CREATE_MPQ pCreateInfo, HANDLE * phMpq)
+bool WINAPI SFileCreateArchive2(const char * szMpqName, PSFILE_CREATE_MPQ pCreateInfo, HANDLE * phMpq)
 {
     TFileStream * pStream = NULL;           // File stream
     TMPQArchive * ha = NULL;                // MPQ archive handle

--- a/extern/StormLib/src/SFileExtractFile.cpp
+++ b/extern/StormLib/src/SFileExtractFile.cpp
@@ -12,7 +12,7 @@
 #include "StormLib.h"
 #include "StormCommon.h"
 
-bool WINAPI SFileExtractFile(HANDLE hMpq, const char * szToExtract, const TCHAR * szExtracted, DWORD dwSearchScope)
+bool WINAPI SFileExtractFile(HANDLE hMpq, const char * szToExtract, const char * szExtracted, DWORD dwSearchScope)
 {
     TFileStream * pLocalFile = NULL;
     HANDLE hMpqFile = NULL;

--- a/extern/StormLib/src/SFileFindFile.cpp
+++ b/extern/StormLib/src/SFileFindFile.cpp
@@ -380,7 +380,7 @@ static void FreeMPQSearch(TMPQSearch *& hs)
 //-----------------------------------------------------------------------------
 // Public functions
 
-HANDLE WINAPI SFileFindFirstFile(HANDLE hMpq, const char * szMask, SFILE_FIND_DATA * lpFindFileData, const TCHAR * szListFile)
+HANDLE WINAPI SFileFindFirstFile(HANDLE hMpq, const char * szMask, SFILE_FIND_DATA * lpFindFileData, const char * szListFile)
 {
     TMPQArchive * ha = (TMPQArchive *)hMpq;
     TMPQSearch * hs = NULL;

--- a/extern/StormLib/src/SFileGetFileInfo.cpp
+++ b/extern/StormLib/src/SFileGetFileInfo.cpp
@@ -157,7 +157,7 @@ static bool GetInfo_PatchChain(TMPQFile * hf, void * pvFileInfo, DWORD cbFileInf
         cchCharsNeeded += _tcslen(FileStream_GetFileName(hfTemp->ha->pStream)) + 1;
 
     // Verify whether the caller gave us valid buffer with enough size
-    if(!GetInfo_BufferCheck(pvFileInfo, cbFileInfo, (DWORD)(cchCharsNeeded * sizeof(TCHAR)), pcbLengthNeeded))
+    if(!GetInfo_BufferCheck(pvFileInfo, cbFileInfo, (DWORD)(cchCharsNeeded * sizeof(char)), pcbLengthNeeded))
         return false;
 
     // Copy each patch name
@@ -168,7 +168,7 @@ static bool GetInfo_PatchChain(TMPQFile * hf, void * pvFileInfo, DWORD cbFileInf
         nLength = _tcslen(szPatchName) + 1;
 
         // Copy the file name
-        memcpy(szFileInfo, szPatchName, nLength * sizeof(TCHAR));
+        memcpy(szFileInfo, szPatchName, nLength * sizeof(char));
         szFileInfo += nLength;
     }
 
@@ -194,7 +194,7 @@ bool WINAPI SFileGetFileInfo(
     LPDWORD pcbLengthNeeded)
 {
     MPQ_SIGNATURE_INFO SignatureInfo;
-    const TCHAR * szSrcFileInfo;
+    const char * szSrcFileInfo;
     TMPQArchive * ha = NULL;
     TFileEntry * pFileEntry = NULL;
     TMPQHeader * pHeader = NULL;
@@ -224,7 +224,7 @@ bool WINAPI SFileGetFileInfo(
     {
         case SFileMpqFileName:
             szSrcFileInfo = FileStream_GetFileName(ha->pStream);
-            cbSrcFileInfo = (DWORD)((_tcslen(szSrcFileInfo) + 1) * sizeof(TCHAR));
+            cbSrcFileInfo = (DWORD)((_tcslen(szSrcFileInfo) + 1) * sizeof(char));
             return GetInfo(pvFileInfo, cbFileInfo, szSrcFileInfo, cbSrcFileInfo, pcbLengthNeeded);
 
         case SFileMpqStreamBitmap:
@@ -595,7 +595,7 @@ bool WINAPI SFileGetFileName(HANDLE hFile, char * szFileName)
         {
             if(szFileName != NULL)
             {
-                const TCHAR * szStreamName = FileStream_GetFileName(hf->pStream);
+                const char * szStreamName = FileStream_GetFileName(hf->pStream);
                 StringCopy(szFileName, MAX_PATH, szStreamName);
             }
             dwErrCode = ERROR_SUCCESS;

--- a/extern/StormLib/src/SFileListFile.cpp
+++ b/extern/StormLib/src/SFileListFile.cpp
@@ -144,7 +144,7 @@ static TListFileCache * CreateListFileCache(
 
 static TListFileCache * CreateListFileCache(
     HANDLE hMpq,
-    const TCHAR * szListFile,
+    const char * szListFile,
     const char * szWildCard,
     DWORD dwMaxSize,
     DWORD dwFlags)
@@ -532,7 +532,7 @@ DWORD SListFileSaveToMpq(TMPQArchive * ha)
 static DWORD SFileAddArbitraryListFile(
     TMPQArchive * ha,
     HANDLE hMpq,
-    const TCHAR * szListFile,
+    const char * szListFile,
     DWORD dwMaxSize)
 {
     TListFileCache * pCache = NULL;
@@ -637,7 +637,7 @@ static bool DoListFileSearch(TListFileCache * pCache, SFILE_FIND_DATA * lpFindFi
 // File functions
 
 // Adds a listfile into the MPQ archive.
-DWORD WINAPI SFileAddListFile(HANDLE hMpq, const TCHAR * szListFile)
+DWORD WINAPI SFileAddListFile(HANDLE hMpq, const char * szListFile)
 {
     TMPQArchive * ha = (TMPQArchive *)hMpq;
     DWORD dwErrCode = ERROR_SUCCESS;
@@ -666,7 +666,7 @@ DWORD WINAPI SFileAddListFile(HANDLE hMpq, const TCHAR * szListFile)
 //-----------------------------------------------------------------------------
 // Enumerating files in listfile
 
-HANDLE WINAPI SListFileFindFirstFile(HANDLE hMpq, const TCHAR * szListFile, const char * szMask, SFILE_FIND_DATA * lpFindFileData)
+HANDLE WINAPI SListFileFindFirstFile(HANDLE hMpq, const char * szListFile, const char * szMask, SFILE_FIND_DATA * lpFindFileData)
 {
     TListFileCache * pCache = NULL;
 

--- a/extern/StormLib/src/SFileOpenArchive.cpp
+++ b/extern/StormLib/src/SFileOpenArchive.cpp
@@ -223,7 +223,7 @@ LCID WINAPI SFileSetLocale(LCID lcFileLocale)
 //   phMpq      - Pointer to store open archive handle
 
 bool WINAPI SFileOpenArchive(
-    const TCHAR * szMpqName,
+    const char * szMpqName,
     DWORD dwPriority,
     DWORD dwFlags,
     HANDLE * phMpq)

--- a/extern/StormLib/src/SFileOpenFileEx.cpp
+++ b/extern/StormLib/src/SFileOpenFileEx.cpp
@@ -72,7 +72,7 @@ static bool OpenLocalFile(const char * szFileName, HANDLE * PtrFile)
 {
     TFileStream * pStream;
     TMPQFile * hf = NULL;
-    TCHAR szFileNameT[MAX_PATH];
+    char szFileNameT[MAX_PATH];
 
     // Convert the file name to UNICODE (if needed)
     StringCopy(szFileNameT, _countof(szFileNameT), szFileName);

--- a/extern/StormLib/src/SFilePatchArchives.cpp
+++ b/extern/StormLib/src/SFilePatchArchives.cpp
@@ -576,10 +576,10 @@ static bool FindPatchPrefix_WoW_13164_13623(TMPQArchive * haBase, TMPQArchive * 
 
 static bool CheckPatchPrefix_SC2_ArchiveName(
     TMPQArchive * haPatch,
-    const TCHAR * szPathPtr,
-    const TCHAR * szSeparator,
-    const TCHAR * szPathEnd,
-    const TCHAR * szExpectedString,
+    const char * szPathPtr,
+    const char * szSeparator,
+    const char * szPathEnd,
+    const char * szExpectedString,
     size_t cchExpectedString)
 {
     char szPatchPrefix[MAX_SC2_PATCH_PREFIX+0x41];
@@ -611,10 +611,10 @@ static bool CheckPatchPrefix_SC2_ArchiveName(
 
 static bool FindPatchPrefix_SC2_ArchiveName(TMPQArchive * haBase, TMPQArchive * haPatch)
 {
-    const TCHAR * szPathBegin = FileStream_GetFileName(haBase->pStream);
-    const TCHAR * szSeparator = NULL;
-    const TCHAR * szPathEnd = szPathBegin + _tcslen(szPathBegin);
-    const TCHAR * szPathPtr;
+    const char * szPathBegin = FileStream_GetFileName(haBase->pStream);
+    const char * szSeparator = NULL;
+    const char * szPathEnd = szPathBegin + _tcslen(szPathBegin);
+    const char * szPathPtr;
     int nSlashCount = 0;
     int nDotCount = 0;
 
@@ -671,7 +671,7 @@ static bool FindPatchPrefix_SC2_ArchiveName(TMPQArchive * haBase, TMPQArchive * 
 // Patch Prefix : Mods\Core.SC2Mod\Base.SC2Data
 //
 
-static bool ExtractPatchPrefixFromFile(const TCHAR * szHelperFile, char * szPatchPrefix, size_t nMaxChars, size_t * PtrLength)
+static bool ExtractPatchPrefixFromFile(const char * szHelperFile, char * szPatchPrefix, size_t nMaxChars, size_t * PtrLength)
 {
     TFileStream * pStream;
     ULONGLONG FileSize = 0;
@@ -730,7 +730,7 @@ static bool ExtractPatchPrefixFromFile(const TCHAR * szHelperFile, char * szPatc
 
 static bool FindPatchPrefix_SC2_HelperFile(TMPQArchive * haBase, TMPQArchive * haPatch)
 {
-    TCHAR szHelperFile[MAX_PATH+1];
+    char szHelperFile[MAX_PATH+1];
     char szPatchPrefix[MAX_SC2_PATCH_PREFIX+0x41];
     size_t nLength = 0;
     bool bResult = false;
@@ -1087,7 +1087,7 @@ void Patch_Finalize(TMPQPatcher * pPatcher)
 
 bool WINAPI SFileOpenPatchArchive(
     HANDLE hMpq,
-    const TCHAR * szPatchMpqName,
+    const char * szPatchMpqName,
     const char * szPatchPathPrefix,
     DWORD dwFlags)
 {

--- a/extern/StormLib/src/SFileVerify.cpp
+++ b/extern/StormLib/src/SFileVerify.cpp
@@ -140,10 +140,10 @@ static bool decode_base64_key(const char * szKeyBase64, rsa_key * key)
 }
 
 static void GetPlainAnsiFileName(
-    const TCHAR * szFileName,
+    const char * szFileName,
     char * szPlainName)
 {
-    const TCHAR * szPlainNameT = GetPlainFileName(szFileName);
+    const char * szPlainNameT = GetPlainFileName(szFileName);
 
     // Convert the plain name to ANSI
     while(*szPlainNameT != 0)

--- a/extern/StormLib/src/StormCommon.h
+++ b/extern/StormLib/src/StormCommon.h
@@ -194,10 +194,10 @@ void StringCat(char * szTarget, size_t cchTargetMax, const char * szSource);
 void StringCreatePseudoFileName(char * szBuffer, size_t cchMaxChars, unsigned int nIndex, const char * szExtension);
 
 #if 0
-void StringCopy(TCHAR * szTarget, size_t cchTarget, const char * szSource);
-void StringCopy(char * szTarget, size_t cchTarget, const TCHAR * szSource);
-void StringCopy(TCHAR * szTarget, size_t cchTarget, const TCHAR * szSource);
-void StringCat(TCHAR * szTarget, size_t cchTargetMax, const TCHAR * szSource);
+void StringCopy(char * szTarget, size_t cchTarget, const char * szSource);
+void StringCopy(char * szTarget, size_t cchTarget, const char * szSource);
+void StringCopy(char * szTarget, size_t cchTarget, const char * szSource);
+void StringCat(char * szTarget, size_t cchTargetMax, const char * szSource);
 #endif
 
 //-----------------------------------------------------------------------------

--- a/extern/StormLib/src/StormCommon.h
+++ b/extern/StormLib/src/StormCommon.h
@@ -193,7 +193,7 @@ char * StringCopy(char * szTarget, size_t cchTarget, const char * szSource);
 void StringCat(char * szTarget, size_t cchTargetMax, const char * szSource);
 void StringCreatePseudoFileName(char * szBuffer, size_t cchMaxChars, unsigned int nIndex, const char * szExtension);
 
-#ifdef _UNICODE
+#if 0
 void StringCopy(TCHAR * szTarget, size_t cchTarget, const char * szSource);
 void StringCopy(char * szTarget, size_t cchTarget, const TCHAR * szSource);
 void StringCopy(TCHAR * szTarget, size_t cchTarget, const TCHAR * szSource);

--- a/extern/StormLib/src/StormLib.h
+++ b/extern/StormLib/src/StormLib.h
@@ -410,7 +410,7 @@ typedef DWORD (*HASH_STRING)(const char * szFileName, DWORD dwHashType);
 typedef enum _SFileInfoClass
 {
     // Info classes for archives
-    SFileMpqFileName,                       // Name of the archive file (TCHAR [])
+    SFileMpqFileName,                       // Name of the archive file (char [])
     SFileMpqStreamBitmap,                   // Array of bits, each bit means availability of one block (BYTE [])
     SFileMpqUserDataOffset,                 // Offset of the user data header (ULONGLONG)
     SFileMpqUserDataHeader,                 // Raw (unfixed) user data header (TMPQUserData)
@@ -452,7 +452,7 @@ typedef enum _SFileInfoClass
     SFileMpqFlags,                          // Nonzero if the MPQ is read only (DWORD)
 
     // Info classes for files
-    SFileInfoPatchChain,                    // Chain of patches where the file is (TCHAR [])
+    SFileInfoPatchChain,                    // Chain of patches where the file is (char [])
     SFileInfoFileEntry,                     // The file entry for the file (TFileEntry)
     SFileInfoHashEntry,                     // Hash table entry for the file (TMPQHash)
     SFileInfoHashIndex,                     // Index of the hash table entry (DWORD)
@@ -965,10 +965,10 @@ struct TStreamBitmap
 };
 
 // UNICODE versions of the file access functions
-TFileStream * FileStream_CreateFile(const TCHAR * szFileName, DWORD dwStreamFlags);
-TFileStream * FileStream_OpenFile(const TCHAR * szFileName, DWORD dwStreamFlags);
-const TCHAR * FileStream_GetFileName(TFileStream * pStream);
-size_t FileStream_Prefix(const TCHAR * szFileName, DWORD * pdwProvider);
+TFileStream * FileStream_CreateFile(const char * szFileName, DWORD dwStreamFlags);
+TFileStream * FileStream_OpenFile(const char * szFileName, DWORD dwStreamFlags);
+const char * FileStream_GetFileName(TFileStream * pStream);
+size_t FileStream_Prefix(const char * szFileName, DWORD * pdwProvider);
 
 bool FileStream_SetCallback(TFileStream * pStream, SFILE_DOWNLOAD_CALLBACK pfnCallback, void * pvUserData);
 
@@ -1015,9 +1015,9 @@ LCID   WINAPI SFileSetLocale(LCID lcFileLocale);
 //-----------------------------------------------------------------------------
 // Functions for archive manipulation
 
-bool   WINAPI SFileOpenArchive(const TCHAR * szMpqName, DWORD dwPriority, DWORD dwFlags, HANDLE * phMpq);
-bool   WINAPI SFileCreateArchive(const TCHAR * szMpqName, DWORD dwCreateFlags, DWORD dwMaxFileCount, HANDLE * phMpq);
-bool   WINAPI SFileCreateArchive2(const TCHAR * szMpqName, PSFILE_CREATE_MPQ pCreateInfo, HANDLE * phMpq);
+bool   WINAPI SFileOpenArchive(const char * szMpqName, DWORD dwPriority, DWORD dwFlags, HANDLE * phMpq);
+bool   WINAPI SFileCreateArchive(const char * szMpqName, DWORD dwCreateFlags, DWORD dwMaxFileCount, HANDLE * phMpq);
+bool   WINAPI SFileCreateArchive2(const char * szMpqName, PSFILE_CREATE_MPQ pCreateInfo, HANDLE * phMpq);
 
 bool   WINAPI SFileSetDownloadCallback(HANDLE hMpq, SFILE_DOWNLOAD_CALLBACK DownloadCB, void * pvUserData);
 bool   WINAPI SFileFlushArchive(HANDLE hMpq);
@@ -1026,11 +1026,11 @@ bool   WINAPI SFileCloseArchive(HANDLE hMpq);
 // Adds another listfile into MPQ. The currently added listfile(s) remain,
 // so you can use this API to combining more listfiles.
 // Note that this function is internally called by SFileFindFirstFile
-DWORD  WINAPI SFileAddListFile(HANDLE hMpq, const TCHAR * szListFile);
+DWORD  WINAPI SFileAddListFile(HANDLE hMpq, const char * szListFile);
 
 // Archive compacting
 bool   WINAPI SFileSetCompactCallback(HANDLE hMpq, SFILE_COMPACT_CALLBACK CompactCB, void * pvUserData);
-bool   WINAPI SFileCompactArchive(HANDLE hMpq, const TCHAR * szListFile, bool bReserved);
+bool   WINAPI SFileCompactArchive(HANDLE hMpq, const char * szListFile, bool bReserved);
 
 // Changing the maximum file count
 DWORD  WINAPI SFileGetMaxFileCount(HANDLE hMpq);
@@ -1044,7 +1044,7 @@ bool   WINAPI SFileUpdateFileAttributes(HANDLE hMpq, const char * szFileName);
 //-----------------------------------------------------------------------------
 // Functions for manipulation with patch archives
 
-bool   WINAPI SFileOpenPatchArchive(HANDLE hMpq, const TCHAR * szPatchMpqName, const char * szPatchPathPrefix, DWORD dwFlags);
+bool   WINAPI SFileOpenPatchArchive(HANDLE hMpq, const char * szPatchMpqName, const char * szPatchPathPrefix, DWORD dwFlags);
 bool   WINAPI SFileIsPatchedArchive(HANDLE hMpq);
 
 //-----------------------------------------------------------------------------
@@ -1064,7 +1064,7 @@ bool   WINAPI SFileGetFileName(HANDLE hFile, char * szFileName);
 bool   WINAPI SFileFreeFileInfo(void * pvFileInfo, SFileInfoClass InfoClass);
 
 // High-level extract function
-bool   WINAPI SFileExtractFile(HANDLE hMpq, const char * szToExtract, const TCHAR * szExtracted, DWORD dwSearchScope);
+bool   WINAPI SFileExtractFile(HANDLE hMpq, const char * szToExtract, const char * szExtracted, DWORD dwSearchScope);
 
 //-----------------------------------------------------------------------------
 // Functions for file and archive verification
@@ -1086,11 +1086,11 @@ DWORD  WINAPI SFileVerifyArchive(HANDLE hMpq);
 //-----------------------------------------------------------------------------
 // Functions for file searching
 
-HANDLE WINAPI SFileFindFirstFile(HANDLE hMpq, const char * szMask, SFILE_FIND_DATA * lpFindFileData, const TCHAR * szListFile);
+HANDLE WINAPI SFileFindFirstFile(HANDLE hMpq, const char * szMask, SFILE_FIND_DATA * lpFindFileData, const char * szListFile);
 bool   WINAPI SFileFindNextFile(HANDLE hFind, SFILE_FIND_DATA * lpFindFileData);
 bool   WINAPI SFileFindClose(HANDLE hFind);
 
-HANDLE WINAPI SListFileFindFirstFile(HANDLE hMpq, const TCHAR * szListFile, const char * szMask, SFILE_FIND_DATA * lpFindFileData);
+HANDLE WINAPI SListFileFindFirstFile(HANDLE hMpq, const char * szListFile, const char * szMask, SFILE_FIND_DATA * lpFindFileData);
 bool   WINAPI SListFileFindNextFile(HANDLE hFind, SFILE_FIND_DATA * lpFindFileData);
 bool   WINAPI SListFileFindClose(HANDLE hFind);
 
@@ -1104,9 +1104,9 @@ bool   WINAPI SFileCreateFile(HANDLE hMpq, const char * szArchivedName, ULONGLON
 bool   WINAPI SFileWriteFile(HANDLE hFile, const void * pvData, DWORD dwSize, DWORD dwCompression);
 bool   WINAPI SFileFinishFile(HANDLE hFile);
 
-bool   WINAPI SFileAddFileEx(HANDLE hMpq, const TCHAR * szFileName, const char * szArchivedName, DWORD dwFlags, DWORD dwCompression, DWORD dwCompressionNext);
-bool   WINAPI SFileAddFile(HANDLE hMpq, const TCHAR * szFileName, const char * szArchivedName, DWORD dwFlags);
-bool   WINAPI SFileAddWave(HANDLE hMpq, const TCHAR * szFileName, const char * szArchivedName, DWORD dwFlags, DWORD dwQuality);
+bool   WINAPI SFileAddFileEx(HANDLE hMpq, const char * szFileName, const char * szArchivedName, DWORD dwFlags, DWORD dwCompression, DWORD dwCompressionNext);
+bool   WINAPI SFileAddFile(HANDLE hMpq, const char * szFileName, const char * szArchivedName, DWORD dwFlags);
+bool   WINAPI SFileAddWave(HANDLE hMpq, const char * szFileName, const char * szArchivedName, DWORD dwFlags, DWORD dwQuality);
 bool   WINAPI SFileRemoveFile(HANDLE hMpq, const char * szFileName, DWORD dwSearchScope);
 bool   WINAPI SFileRenameFile(HANDLE hMpq, const char * szOldFileName, const char * szNewFileName);
 bool   WINAPI SFileSetFileLocale(HANDLE hFile, LCID lcNewLocale);

--- a/extern/StormLib/src/StormLib.h
+++ b/extern/StormLib/src/StormLib.h
@@ -108,7 +108,7 @@ extern "C" {
 #if defined(_MSC_VER) && !defined(STORMLIB_NO_AUTO_LINK)
   #ifndef WDK_BUILD
     #ifdef _DEBUG                                 // DEBUG VERSIONS
-      #ifndef _UNICODE
+      #if 1
         #ifdef _DLL
           #pragma comment(lib, "StormLibDAD.lib") // Debug Ansi CRT-DLL version
         #else
@@ -122,7 +122,7 @@ extern "C" {
         #endif
       #endif
     #else                                         // RELEASE VERSIONS
-      #ifndef _UNICODE
+      #if 1
         #ifdef _DLL
           #pragma comment(lib, "StormLibRAD.lib") // Release Ansi CRT-DLL version
         #else

--- a/extern/StormLib/src/StormPort.h
+++ b/extern/StormLib/src/StormPort.h
@@ -341,7 +341,7 @@
   typedef unsigned long long ULONGLONG;
   typedef void         * HANDLE;
   typedef void         * LPOVERLAPPED; // Unsupported on Linux and Mac
-  typedef char           TCHAR;
+  typedef char           char;
   typedef unsigned int   LCID;
   typedef LONG         * PLONG;
   typedef DWORD        * LPDWORD;

--- a/extern/StormLib/src/StormPort.h
+++ b/extern/StormLib/src/StormPort.h
@@ -341,7 +341,7 @@
   typedef unsigned long long ULONGLONG;
   typedef void         * HANDLE;
   typedef void         * LPOVERLAPPED; // Unsupported on Linux and Mac
-  typedef char           char;
+  // typedef char           char;
   typedef unsigned int   LCID;
   typedef LONG         * PLONG;
   typedef DWORD        * LPDWORD;

--- a/extern/StormLib/test/StormTest.cpp
+++ b/extern/StormLib/test/StormTest.cpp
@@ -603,7 +603,7 @@ static void CreateFullPathName(TCHAR * szBuffer, size_t cchBuffer, LPCTSTR szSub
     }
 }
 
-#ifdef _UNICODE
+#if 0
 static void CreateFullPathName(char * szBuffer, size_t cchBuffer, LPCTSTR szSubDir, LPCTSTR szNamePart1, LPCTSTR szNamePart2 = NULL)
 {
     TCHAR szFullPathT[MAX_PATH];
@@ -1791,7 +1791,7 @@ static DWORD CreateNewArchive_V2(TLogHelper * pLogger, LPCTSTR szPlainName, DWOR
 // Creates new archive with UNICODE name. Adds prefix to the name
 static DWORD CreateNewArchiveU(TLogHelper * pLogger, const wchar_t * szPlainName, DWORD dwCreateFlags, DWORD dwMaxFileCount)
 {
-#ifdef _UNICODE
+#if 0
     HANDLE hMpq = NULL;
     TCHAR szMpqName[MAX_PATH+1];
     TCHAR szFullPath[MAX_PATH];

--- a/extern/StormLib/test/StormTest.cpp
+++ b/extern/StormLib/test/StormTest.cpp
@@ -66,22 +66,22 @@ typedef struct _LINE_INFO
 
 #ifdef STORMLIB_WINDOWS
 #define WORK_PATH_ROOT _T("\\Multimedia\\MPQs")
-static const TCHAR szListFileDir[] = { '1', '9', '9', '5', ' ', '-', ' ', 'T', 'e', 's', 't', ' ', 'M', 'P', 'Q', 's', '\\', 'l', 'i', 's', 't', 'f', 'i', 'l', 'e', 's', '-', (TCHAR)0x65B0, (TCHAR)0x5EFA, (TCHAR)0x6587, (TCHAR)0x4EF6, (TCHAR)0x5939, 0 };
+static const char szListFileDir[] = { '1', '9', '9', '5', ' ', '-', ' ', 'T', 'e', 's', 't', ' ', 'M', 'P', 'Q', 's', '\\', 'l', 'i', 's', 't', 'f', 'i', 'l', 'e', 's', '-', (char)0x65B0, (char)0x5EFA, (char)0x6587, (char)0x4EF6, (char)0x5939, 0 };
 #endif
 
 #ifdef STORMLIB_LINUX
 #define WORK_PATH_ROOT "/media/ladik/CascStorages/MPQs"
-static const TCHAR szListFileDir[] = { '1', '9', '9', '5', ' ', '-', ' ', 'T', 'e', 's', 't', ' ', 'M', 'P', 'Q', 's', '\\', 'l', 'i', 's', 't', 'f', 'i', 'l', 'e', 's', '-', (TCHAR)0xe6, (TCHAR)0x96, (TCHAR)0xB0, (TCHAR)0xE5, (TCHAR)0xBB, (TCHAR)0xBA, (TCHAR)0xE6, (TCHAR)0x96, (TCHAR)0x87, (TCHAR)0xE4, (TCHAR)0xBB, (TCHAR)0xB6, (TCHAR)0xE5, (TCHAR)0xA4, (TCHAR)0xB9, 0 };
+static const char szListFileDir[] = { '1', '9', '9', '5', ' ', '-', ' ', 'T', 'e', 's', 't', ' ', 'M', 'P', 'Q', 's', '\\', 'l', 'i', 's', 't', 'f', 'i', 'l', 'e', 's', '-', (char)0xe6, (char)0x96, (char)0xB0, (char)0xE5, (char)0xBB, (char)0xBA, (char)0xE6, (char)0x96, (char)0x87, (char)0xE4, (char)0xBB, (char)0xB6, (char)0xE5, (char)0xA4, (char)0xB9, 0 };
 #endif
 
 #ifdef STORMLIB_MAC
 #define WORK_PATH_ROOT "/home/sam/StormLib/test"
-static const TCHAR szListFileDir[] = { '1', '9', '9', '5', ' ', '-', ' ', 'T', 'e', 's', 't', ' ', 'M', 'P', 'Q', 's', '\\', 'l', 'i', 's', 't', 'f', 'i', 'l', 'e', 's', '-', (TCHAR)0xe6, (TCHAR)0x96, (TCHAR)0xB0, (TCHAR)0xE5, (TCHAR)0xBB, (TCHAR)0xBA, (TCHAR)0xE6, (TCHAR)0x96, (TCHAR)0x87, (TCHAR)0xE4, (TCHAR)0xBB, (TCHAR)0xB6, (TCHAR)0xE5, (TCHAR)0xA4, (TCHAR)0xB9, 0 };
+static const char szListFileDir[] = { '1', '9', '9', '5', ' ', '-', ' ', 'T', 'e', 's', 't', ' ', 'M', 'P', 'Q', 's', '\\', 'l', 'i', 's', 't', 'f', 'i', 'l', 'e', 's', '-', (char)0xe6, (char)0x96, (char)0xB0, (char)0xE5, (char)0xBB, (char)0xBA, (char)0xE6, (char)0x96, (char)0x87, (char)0xE4, (char)0xBB, (char)0xB6, (char)0xE5, (char)0xA4, (char)0xB9, 0 };
 #endif
 
 #ifdef STORMLIB_HAIKU
 #define WORK_PATH_ROOT "~/StormLib/test"
-static const TCHAR szListFileDir[] = { '1', '9', '9', '5', ' ', '-', ' ', 'T', 'e', 's', 't', ' ', 'M', 'P', 'Q', 's', '\\', 'l', 'i', 's', 't', 'f', 'i', 'l', 'e', 's', '-', (TCHAR)0xe6, (TCHAR)0x96, (TCHAR)0xB0, (TCHAR)0xE5, (TCHAR)0xBB, (TCHAR)0xBA, (TCHAR)0xE6, (TCHAR)0x96, (TCHAR)0x87, (TCHAR)0xE4, (TCHAR)0xBB, (TCHAR)0xB6, (TCHAR)0xE5, (TCHAR)0xA4, (TCHAR)0xB9, 0 };
+static const char szListFileDir[] = { '1', '9', '9', '5', ' ', '-', ' ', 'T', 'e', 's', 't', ' ', 'M', 'P', 'Q', 's', '\\', 'l', 'i', 's', 't', 'f', 'i', 'l', 'e', 's', '-', (char)0xe6, (char)0x96, (char)0xB0, (char)0xE5, (char)0xBB, (char)0xBA, (char)0xE6, (char)0x96, (char)0x87, (char)0xE4, (char)0xBB, (char)0xB6, (char)0xE5, (char)0xA4, (char)0xB9, 0 };
 #endif
 
 // Global for the work MPQ
@@ -301,15 +301,15 @@ static LPCTSTR PatchList_HS_6898_enGB[] =
 // Definition of the path separator
 #ifdef STORMLIB_WINDOWS
 static LPCTSTR g_szPathSeparator = _T("\\");
-static const TCHAR PATH_SEPARATOR = _T('\\');       // Path separator for Windows platforms
+static const char PATH_SEPARATOR = _T('\\');       // Path separator for Windows platforms
 #else
 static LPCSTR g_szPathSeparator = "/";
-static const TCHAR PATH_SEPARATOR = '/';            // Path separator for Non-Windows platforms
+static const char PATH_SEPARATOR = '/';            // Path separator for Non-Windows platforms
 #endif
 
 // This must be the directory where our test MPQs are stored.
 // We also expect a subdirectory named
-static TCHAR szMpqDirectory[MAX_PATH+1];
+static char szMpqDirectory[MAX_PATH+1];
 size_t cchMpqDirectory = 0;
 
 template <typename XCHAR>
@@ -496,19 +496,19 @@ static void CopyPathPart(char * szBuffer, LPCSTR szPath)
 
 static bool CopyStringAndVerifyConversion(
     LPCTSTR szFoundFile,
-    TCHAR * szBufferT,
+    char * szBufferT,
     char * szBufferA,
     size_t cchMaxChars)
 {
-    // Convert the TCHAR name to ANSI name
+    // Convert the char name to ANSI name
     StringCopy(szBufferA, cchMaxChars, szFoundFile);
     StringCopy(szBufferT, cchMaxChars, szBufferA);
 
-    // Compare both TCHAR strings
+    // Compare both char strings
     return (_tcsicmp(szBufferT, szFoundFile) == 0) ? true : false;
 }
 
-static size_t ConvertSha1ToText(const unsigned char * sha1_digest, TCHAR * szSha1Text)
+static size_t ConvertSha1ToText(const unsigned char * sha1_digest, char * szSha1Text)
 {
     LPCSTR szTable = "0123456789abcdef";
 
@@ -523,9 +523,9 @@ static size_t ConvertSha1ToText(const unsigned char * sha1_digest, TCHAR * szSha
     return (SHA1_DIGEST_SIZE * 2);
 }
 
-static void CreateFullPathName(TCHAR * szBuffer, size_t cchBuffer, LPCTSTR szSubDir, LPCTSTR szNamePart1, LPCTSTR szNamePart2 = NULL)
+static void CreateFullPathName(char * szBuffer, size_t cchBuffer, LPCTSTR szSubDir, LPCTSTR szNamePart1, LPCTSTR szNamePart2 = NULL)
 {
-    TCHAR * szSaveBuffer = szBuffer;
+    char * szSaveBuffer = szBuffer;
     size_t nPrefixLength = 0;
     size_t nLength;
     DWORD dwProvider = 0;
@@ -606,14 +606,14 @@ static void CreateFullPathName(TCHAR * szBuffer, size_t cchBuffer, LPCTSTR szSub
 #if 0
 static void CreateFullPathName(char * szBuffer, size_t cchBuffer, LPCTSTR szSubDir, LPCTSTR szNamePart1, LPCTSTR szNamePart2 = NULL)
 {
-    TCHAR szFullPathT[MAX_PATH];
+    char szFullPathT[MAX_PATH];
 
     CreateFullPathName(szFullPathT, _countof(szFullPathT), szSubDir, szNamePart1, szNamePart2);
     StringCopy(szBuffer, cchBuffer, szFullPathT);
 }
 #endif
 
-static DWORD CalculateFileSha1(TLogHelper * pLogger, LPCTSTR szFullPath, TCHAR * szFileSha1)
+static DWORD CalculateFileSha1(TLogHelper * pLogger, LPCTSTR szFullPath, char * szFileSha1)
 {
     TFileStream * pStream;
     unsigned char sha1_digest[SHA1_DIGEST_SIZE];
@@ -692,7 +692,7 @@ static HANDLE InitDirectorySearch(LPCTSTR szDirectory)
 
     WIN32_FIND_DATA wf;
     HANDLE hFind;
-    TCHAR szSearchMask[MAX_PATH];
+    char szSearchMask[MAX_PATH];
 
     // Construct the directory mask
     _stprintf(szSearchMask, _T("%s\\*"), szDirectory);
@@ -711,12 +711,12 @@ static HANDLE InitDirectorySearch(LPCTSTR szDirectory)
 #endif
 }
 
-static bool SearchDirectory(HANDLE hFind, TCHAR * szDirEntry, size_t cchDirEntry, bool & IsDirectory)
+static bool SearchDirectory(HANDLE hFind, char * szDirEntry, size_t cchDirEntry, bool & IsDirectory)
 {
 #ifdef STORMLIB_WINDOWS
 
     WIN32_FIND_DATA wf;
-    TCHAR szDirEntryT[MAX_PATH];
+    char szDirEntryT[MAX_PATH];
     char szDirEntryA[MAX_PATH];
 
     __SearchNextEntry:
@@ -766,12 +766,12 @@ static void FreeDirectorySearch(HANDLE hFind)
 #endif
 }
 
-static DWORD FindFilesInternal(FIND_FILE_CALLBACK pfnTest, TCHAR * szDirectory)
+static DWORD FindFilesInternal(FIND_FILE_CALLBACK pfnTest, char * szDirectory)
 {
-    TCHAR * szPlainName;
+    char * szPlainName;
     HANDLE hFind;
     size_t nLength;
-    TCHAR szDirEntry[MAX_PATH];
+    char szDirEntry[MAX_PATH];
     bool IsDirectory = false;
     DWORD dwErrCode = ERROR_SUCCESS;
 
@@ -819,17 +819,17 @@ static DWORD FindFilesInternal(FIND_FILE_CALLBACK pfnTest, TCHAR * szDirectory)
 
 static DWORD FindFiles(FIND_FILE_CALLBACK pfnFindFile, LPCTSTR szSubDirectory)
 {
-    TCHAR szWorkBuff[MAX_PATH];
+    char szWorkBuff[MAX_PATH];
 
     CreateFullPathName(szWorkBuff, _countof(szWorkBuff), szSubDirectory, NULL);
     return FindFilesInternal(pfnFindFile, szWorkBuff);
 }
 
-static DWORD InitializeMpqDirectory(TCHAR * argv[], int argc)
+static DWORD InitializeMpqDirectory(char * argv[], int argc)
 {
     TLogHelper Logger("InitWorkDir");
     TFileStream * pStream;
-    TCHAR szFullPath[MAX_PATH];
+    char szFullPath[MAX_PATH];
     LPCTSTR szWhereFrom = _T("default");
     LPCTSTR szDirName = WORK_PATH_ROOT;
 
@@ -884,9 +884,9 @@ static DWORD InitializeMpqDirectory(TCHAR * argv[], int argc)
 
 static DWORD GetFilePatchCount(TLogHelper * pLogger, HANDLE hMpq, LPCSTR szFileName)
 {
-    TCHAR * szPatchName;
+    char * szPatchName;
     HANDLE hFile;
-    TCHAR szPatchChain[0x400];
+    char szPatchChain[0x400];
     DWORD dwErrCode = ERROR_SUCCESS;
     int nPatchCount = 0;
 
@@ -961,10 +961,10 @@ static DWORD VerifyFilePatchCount(TLogHelper * pLogger, HANDLE hMpq, LPCSTR szFi
     return ERROR_SUCCESS;
 }
 
-static DWORD CreateEmptyFile(TLogHelper * pLogger, LPCTSTR szPlainName, ULONGLONG FileSize, TCHAR * szBuffer)
+static DWORD CreateEmptyFile(TLogHelper * pLogger, LPCTSTR szPlainName, ULONGLONG FileSize, char * szBuffer)
 {
     TFileStream * pStream;
-    TCHAR szFullPath[MAX_PATH];
+    char szFullPath[MAX_PATH];
 
     // Notify the user
     pLogger->PrintProgress(_T("Creating empty file %s ..."), szPlainName);
@@ -1152,7 +1152,7 @@ static DWORD CreateFileCopy(
     TLogHelper * pLogger,
     LPCTSTR szPlainName,
     LPCTSTR szFileCopy,
-    TCHAR * szBuffer = NULL,
+    char * szBuffer = NULL,
     size_t cchBuffer = 0,
     ULONGLONG PreMpqDataSize = 0,
     ULONGLONG UserDataSize = 0)
@@ -1161,8 +1161,8 @@ static DWORD CreateFileCopy(
     TFileStream * pStream2;             // Target file
     ULONGLONG ByteOffset = 0;
     ULONGLONG FileSize = 0;
-    TCHAR szFileName1[MAX_PATH];
-    TCHAR szFileName2[MAX_PATH];
+    char szFileName1[MAX_PATH];
+    char szFileName2[MAX_PATH];
     DWORD dwErrCode = ERROR_SUCCESS;
 
     // Notify the user
@@ -1232,13 +1232,13 @@ static DWORD CreateFileCopy(
 
 static DWORD CreateMasterAndMirrorPaths(
     TLogHelper * pLogger,
-    TCHAR * szMirrorPath,
-    TCHAR * szMasterPath,
+    char * szMirrorPath,
+    char * szMasterPath,
     LPCTSTR szMirrorName,
     LPCTSTR szMasterName,
     bool bCopyMirrorFile)
 {
-    TCHAR szCopyPath[MAX_PATH];
+    char szCopyPath[MAX_PATH];
     DWORD dwErrCode = ERROR_SUCCESS;
 
     // Always delete the mirror file
@@ -1636,7 +1636,7 @@ static DWORD SearchArchive(
     HANDLE hFind;
     DWORD dwFileCount = 0;
     hash_state md5state;
-    TCHAR szListFile[MAX_PATH] = _T("");
+    char szListFile[MAX_PATH] = _T("");
     char szMostPatched[MAX_PATH] = "";
     DWORD dwErrCode = ERROR_SUCCESS;
     bool bIgnoreOpedwErrCodes = (dwSearchFlags & SEARCH_FLAG_IGNORE_ERRORS) ? true : false;
@@ -1727,8 +1727,8 @@ static DWORD SearchArchive(
 static DWORD CreateNewArchive(TLogHelper * pLogger, LPCTSTR szPlainName, DWORD dwCreateFlags, DWORD dwMaxFileCount, HANDLE * phMpq)
 {
     HANDLE hMpq = NULL;
-    TCHAR szMpqName[MAX_PATH];
-    TCHAR szFullPath[MAX_PATH];
+    char szMpqName[MAX_PATH];
+    char szFullPath[MAX_PATH];
 
     // Make sure that the MPQ is deleted
     CreateFullPathName(szFullPath, _countof(szFullPath), NULL, szPlainName);
@@ -1752,8 +1752,8 @@ static DWORD CreateNewArchive_V2(TLogHelper * pLogger, LPCTSTR szPlainName, DWOR
 {
     SFILE_CREATE_MPQ CreateInfo;
     HANDLE hMpq = NULL;
-    TCHAR szMpqName[MAX_PATH];
-    TCHAR szFullPath[MAX_PATH];
+    char szMpqName[MAX_PATH];
+    char szFullPath[MAX_PATH];
 
     // Make sure that the MPQ is deleted
     CreateFullPathName(szFullPath, _countof(szFullPath), NULL, szPlainName);
@@ -1793,8 +1793,8 @@ static DWORD CreateNewArchiveU(TLogHelper * pLogger, const wchar_t * szPlainName
 {
 #if 0
     HANDLE hMpq = NULL;
-    TCHAR szMpqName[MAX_PATH+1];
-    TCHAR szFullPath[MAX_PATH];
+    char szMpqName[MAX_PATH+1];
+    char szFullPath[MAX_PATH];
 
     // Construct the full UNICODE name
     CreateFullPathName(szFullPath, _countof(szFullPath), NULL, _T("StormLibTest_"));
@@ -1869,7 +1869,7 @@ static DWORD OpenExistingArchive(TLogHelper * pLogger, LPCTSTR szFullPath, DWORD
 
 static DWORD OpenPatchArchive(TLogHelper * pLogger, HANDLE hMpq, LPCTSTR szFullPath)
 {
-    TCHAR szPatchName[MAX_PATH];
+    char szPatchName[MAX_PATH];
     DWORD dwErrCode = ERROR_SUCCESS;
 
     pLogger->PrintProgress(_T("Adding patch %s ..."), GetShortPlainName(szFullPath));
@@ -1883,7 +1883,7 @@ static DWORD OpenPatchArchive(TLogHelper * pLogger, HANDLE hMpq, LPCTSTR szFullP
 static DWORD OpenExistingArchiveWithCopy(TLogHelper * pLogger, LPCTSTR szFileName, LPCTSTR szCopyName, HANDLE * phMpq)
 {
     DWORD dwFlags = 0;
-    TCHAR szFullPath[MAX_PATH];
+    char szFullPath[MAX_PATH];
     DWORD dwErrCode = ERROR_SUCCESS;
 
     // We expect MPQ directory to be already prepared by InitializeMpqDirectory
@@ -1920,7 +1920,7 @@ static DWORD OpenExistingArchiveWithCopy(TLogHelper * pLogger, LPCTSTR szFileNam
 static DWORD OpenPatchedArchive(TLogHelper * pLogger, HANDLE * phMpq, LPCTSTR PatchList[])
 {
     HANDLE hMpq = NULL;
-    TCHAR szFullPath[MAX_PATH];
+    char szFullPath[MAX_PATH];
     DWORD dwErrCode = ERROR_SUCCESS;
 
     // The first file is expected to be valid
@@ -2005,7 +2005,7 @@ static DWORD AddLocalFileToMpq(
     DWORD dwCompression = 0,
     bool bMustSucceed = false)
 {
-    TCHAR szFileName[MAX_PATH];
+    char szFileName[MAX_PATH];
     DWORD dwVerifyResult;
 
     // Notify the user
@@ -2210,7 +2210,7 @@ static DWORD TestOnLocalListFile(LPCTSTR szPlainName)
     HANDLE hFind;
     DWORD dwFileSizeHi = 0;
     DWORD dwFileSizeLo = 0;
-    TCHAR szFullPath[MAX_PATH];
+    char szFullPath[MAX_PATH];
     char szFileName1[MAX_PATH];
     char szFileName2[MAX_PATH];
     int nFileCount = 0;
@@ -2282,8 +2282,8 @@ static DWORD TestReadFile_MasterMirror(LPCTSTR szMirrorName, LPCTSTR szMasterNam
     TFileStream * pStream1;                     // Master file
     TFileStream * pStream2;                     // Mirror file
     TLogHelper Logger("OpenMirrorFile", szMirrorName);
-    TCHAR szMirrorPath[MAX_PATH + MAX_PATH];
-    TCHAR szMasterPath[MAX_PATH];
+    char szMirrorPath[MAX_PATH + MAX_PATH];
+    char szMasterPath[MAX_PATH];
     DWORD dwProvider = 0;
     int nIterations = 0x10000;
     DWORD dwErrCode;
@@ -2329,7 +2329,7 @@ static DWORD TestFileStreamOperations(LPCTSTR szPlainName, DWORD dwStreamFlags)
     TLogHelper Logger("FileStreamTest", szPlainName);
     ULONGLONG ByteOffset;
     ULONGLONG FileSize = 0;
-    TCHAR szFullPath[MAX_PATH];
+    char szFullPath[MAX_PATH];
     DWORD dwRequiredFlags = 0;
     BYTE Buffer[0x10];
     DWORD dwErrCode = ERROR_SUCCESS;
@@ -2515,7 +2515,7 @@ static DWORD TestArchive(
     DWORD dwCrc32 = 0;
     DWORD dwExpectedFileCount = 0;
     DWORD dwMpqFlags = 0;
-    TCHAR szFullName[MAX_PATH];
+    char szFullName[MAX_PATH];
     LCID lcFileLocale = 0;
     BYTE ObtainedMD5[MD5_DIGEST_SIZE] = {0};
     bool bIgnoreOpedwErrCodes = false;
@@ -2666,7 +2666,7 @@ static DWORD TestOpenArchive_WillFail(LPCTSTR szPlainName)
 {
     TLogHelper Logger("FailMpqTest", szPlainName);
     HANDLE hMpq = NULL;
-    TCHAR szMpqName[MAX_PATH];
+    char szMpqName[MAX_PATH];
     char szFullPath[MAX_PATH];
 
     // Create the full path name for the archive
@@ -2687,7 +2687,7 @@ static DWORD TestOpenArchive_Corrupt(LPCTSTR szPlainName)
 {
     TLogHelper Logger("OpenCorruptMpqTest", szPlainName);
     HANDLE hMpq = NULL;
-    TCHAR szFullPath[MAX_PATH];
+    char szFullPath[MAX_PATH];
 
     // Copy the archive so we won't fuck up the original one
     CreateFullPathName(szFullPath, _countof(szFullPath), szMpqSubDir, szPlainName);
@@ -2753,7 +2753,7 @@ static DWORD TestOpenArchive_ReadOnly(LPCTSTR szPlainName, bool bReadOnly)
     TLogHelper Logger("ReadOnlyTest", szPlainName);
     LPCTSTR szCopyName;
     HANDLE hMpq = NULL;
-    TCHAR szFullPath[MAX_PATH];
+    char szFullPath[MAX_PATH];
     DWORD dwFlags = bReadOnly ? MPQ_OPEN_READ_ONLY : 0;;
     int nExpectedError;
     DWORD dwErrCode;
@@ -2877,8 +2877,8 @@ static DWORD TestOpenArchive_MasterMirror(LPCTSTR szMirrorName, LPCTSTR szMaster
     HANDLE hFile = NULL;
     HANDLE hMpq = NULL;
     DWORD dwVerifyResult;
-    TCHAR szMirrorPath[MAX_PATH + MAX_PATH];   // Combined name
-    TCHAR szMasterPath[MAX_PATH];              // Original (server) name
+    char szMirrorPath[MAX_PATH + MAX_PATH];   // Combined name
+    char szMasterPath[MAX_PATH];              // Original (server) name
     DWORD dwErrCode;
 
     // Create both paths
@@ -3081,7 +3081,7 @@ static DWORD TestOpenArchive_CompactArchive(LPCTSTR szPlainName, LPCTSTR szCopyN
 	HANDLE hMpq;
     DWORD dwFileCount1 = 0;
     DWORD dwFileCount2 = 0;
-    TCHAR szFullPath[MAX_PATH];
+    char szFullPath[MAX_PATH];
     BYTE FileHash1[MD5_DIGEST_SIZE];
     BYTE FileHash2[MD5_DIGEST_SIZE];
     DWORD dwErrCode;
@@ -3156,9 +3156,9 @@ static DWORD TestOpenArchive_CompactArchive(LPCTSTR szPlainName, LPCTSTR szCopyN
 static DWORD ForEachFile_VerifyFileChecksum(LPCTSTR szFullPath)
 {
     TFileData * pFileData;
-    TCHAR * szExtension;
-    TCHAR szShaFileName[MAX_PATH+1];
-    TCHAR szSha1Text[0x40];
+    char * szExtension;
+    char szShaFileName[MAX_PATH+1];
+    char szSha1Text[0x40];
     char szSha1TextA[0x40];
     DWORD dwErrCode = ERROR_SUCCESS;
 
@@ -3444,7 +3444,7 @@ static DWORD TestCreateArchive_TestGaps(LPCTSTR szPlainName)
     ULONGLONG ByteOffset2 = 0xEEEEEEEE;
     HANDLE hMpq = NULL;
     HANDLE hFile = NULL;
-    TCHAR szFullPath[MAX_PATH];
+    char szFullPath[MAX_PATH];
     DWORD dwErrCode = ERROR_SUCCESS;
 
     // Create new MPQ
@@ -3843,9 +3843,9 @@ static DWORD TestCreateArchive_FileFlagTest(LPCTSTR szPlainName)
 {
     TLogHelper Logger("FileFlagTest", szPlainName);
     HANDLE hMpq = NULL;                 // Handle of created archive
-    TCHAR szFileName1[MAX_PATH];
-    TCHAR szFileName2[MAX_PATH];
-    TCHAR szFullPath[MAX_PATH];
+    char szFileName1[MAX_PATH];
+    char szFileName2[MAX_PATH];
+    char szFullPath[MAX_PATH];
     LPCSTR szMiddleFile = "FileTest_10.exe";
     LCID LocaleIDs[] = {0x000, 0x405, 0x406, 0x407};
     char szArchivedName[MAX_PATH];
@@ -4000,7 +4000,7 @@ static DWORD TestCreateArchive_WaveCompressionsTest(LPCTSTR szPlainName, LPCTSTR
 {
     TLogHelper Logger("CompressionsTest", szPlainName);
     HANDLE hMpq = NULL;                 // Handle of created archive
-    TCHAR szFileName[MAX_PATH];          // Source file to be added
+    char szFileName[MAX_PATH];          // Source file to be added
     char szArchivedName[MAX_PATH];
     DWORD dwCmprCount = sizeof(WaveCompressions) / sizeof(DWORD);
     DWORD dwAddedFiles = 0;
@@ -4152,7 +4152,7 @@ static DWORD TestCreateArchive_BigArchive(LPCTSTR szPlainName)
 {
     TLogHelper Logger("BigMpqTest", szPlainName);
     HANDLE hMpq = NULL;                 // Handle of created archive
-    TCHAR szLocalFileName[MAX_PATH];
+    char szLocalFileName[MAX_PATH];
     char szArchivedName[MAX_PATH];
     DWORD dwMaxFileCount = 0x20;
     DWORD dwAddedCount = 0;
@@ -4207,8 +4207,8 @@ static DWORD TestModifyArchive_ReplaceFile(LPCTSTR szMpqPlainName, LPCTSTR szFil
 {
     TLogHelper Logger("ModifyTest", szMpqPlainName);
     HANDLE hMpq = NULL;
-    TCHAR szFileFullName[MAX_PATH];
-    TCHAR szMpqFullName[MAX_PATH];
+    char szFileFullName[MAX_PATH];
+    char szMpqFullName[MAX_PATH];
     char szArchivedName[MAX_PATH];
     size_t nOffset = 0;
     DWORD dwErrCode;
@@ -4424,7 +4424,7 @@ static const TEST_INFO Patched_Mpqs[] =
 //-----------------------------------------------------------------------------
 // Main
 
-int _tmain(int argc, TCHAR * argv[])
+int _tmain(int argc, char * argv[])
 {
     DWORD dwErrCode = ERROR_SUCCESS;
 

--- a/extern/StormLib/test/TLogHelper.cpp
+++ b/extern/StormLib/test/TLogHelper.cpp
@@ -19,7 +19,7 @@ class TLogHelper
     TLogHelper(const char * szNewMainTitle = NULL, const TCHAR * szNewSubTitle1 = NULL, const TCHAR * szNewSubTitle2 = NULL);
     ~TLogHelper();
 
-#if defined(UNICODE) || defined(UNICODE)
+#if 0
     // TCHAR-based functions. They are only needed on UNICODE builds.
     // On ANSI builds is TCHAR = char, so we don't need them at all
     int  PrintWithClreol(const TCHAR * szFormat, va_list argList, bool bPrintPrefix, bool bPrintLastError, bool bPrintEndOfLine);
@@ -46,7 +46,7 @@ class TLogHelper
 
     protected:
 
-#if defined(UNICODE) || defined(UNICODE)
+#if 0
     TCHAR * CopyFormatCharacter(TCHAR * szBuffer, const TCHAR *& szFormat);
 #endif
     char * CopyFormatCharacter(char * szBuffer, const char *& szFormat);
@@ -129,7 +129,7 @@ TLogHelper::~TLogHelper()
 // TCHAR-based functions. They are only needed on UNICODE builds.
 // On ANSI builds is TCHAR = char, so we don't need them at all
 
-#if defined(UNICODE) || defined(UNICODE)
+#if 0
 int TLogHelper::PrintWithClreol(const TCHAR * szFormat, va_list argList, bool bPrintPrefix, bool bPrintLastError, bool bPrintEndOfLine)
 {
     TCHAR szFormatBuff[0x200];
@@ -383,7 +383,7 @@ DWORD TLogHelper::PrintVerdict(DWORD dwErrCode)
 //-----------------------------------------------------------------------------
 // Protected functions
 
-#ifdef _UNICODE
+#if 0
 TCHAR * TLogHelper::CopyFormatCharacter(TCHAR * szBuffer, const TCHAR *& szFormat)
 {
 //  static LPCTSTR szStringFormat = _T("\"%s\"");

--- a/extern/StormLib/test/TLogHelper.cpp
+++ b/extern/StormLib/test/TLogHelper.cpp
@@ -16,17 +16,17 @@ class TLogHelper
 {
     public:
 
-    TLogHelper(const char * szNewMainTitle = NULL, const TCHAR * szNewSubTitle1 = NULL, const TCHAR * szNewSubTitle2 = NULL);
+    TLogHelper(const char * szNewMainTitle = NULL, const char * szNewSubTitle1 = NULL, const char * szNewSubTitle2 = NULL);
     ~TLogHelper();
 
 #if 0
-    // TCHAR-based functions. They are only needed on UNICODE builds.
-    // On ANSI builds is TCHAR = char, so we don't need them at all
-    int  PrintWithClreol(const TCHAR * szFormat, va_list argList, bool bPrintPrefix, bool bPrintLastError, bool bPrintEndOfLine);
-    void PrintProgress(const TCHAR * szFormat, ...);
-    void PrintMessage(const TCHAR * szFormat, ...);
-    int  PrintErrorVa(const TCHAR * szFormat, ...);
-    int  PrintError(const TCHAR * szFormat, const TCHAR * szFileName = NULL);
+    // char-based functions. They are only needed on UNICODE builds.
+    // On ANSI builds is char = char, so we don't need them at all
+    int  PrintWithClreol(const char * szFormat, va_list argList, bool bPrintPrefix, bool bPrintLastError, bool bPrintEndOfLine);
+    void PrintProgress(const char * szFormat, ...);
+    void PrintMessage(const char * szFormat, ...);
+    int  PrintErrorVa(const char * szFormat, ...);
+    int  PrintError(const char * szFormat, const char * szFileName = NULL);
 #endif  // defined(UNICODE) || defined(UNICODE)
 
     // ANSI functions
@@ -47,14 +47,14 @@ class TLogHelper
     protected:
 
 #if 0
-    TCHAR * CopyFormatCharacter(TCHAR * szBuffer, const TCHAR *& szFormat);
+    char * CopyFormatCharacter(char * szBuffer, const char *& szFormat);
 #endif
     char * CopyFormatCharacter(char * szBuffer, const char *& szFormat);
     int  GetConsoleWidth();
 
     const char  * szMainTitle;                      // Title of the text (usually name)
-    const TCHAR * szSubTitle1;                      // Title of the text (can be name of the tested file)
-    const TCHAR * szSubTitle2;                      // Title of the text (can be name of the tested file)
+    const char * szSubTitle1;                      // Title of the text (can be name of the tested file)
+    const char * szSubTitle2;                      // Title of the text (can be name of the tested file)
     size_t nTextLength;                             // Length of the previous progress message
     bool bMessagePrinted;
 };
@@ -78,9 +78,9 @@ class TLogHelper
 // Constructor and destructor
 
 
-TLogHelper::TLogHelper(const char * szNewMainTitle, const TCHAR * szNewSubTitle1, const TCHAR * szNewSubTitle2)
+TLogHelper::TLogHelper(const char * szNewMainTitle, const char * szNewSubTitle1, const char * szNewSubTitle2)
 {
-    TCHAR szMainTitleT[0x80];
+    char szMainTitleT[0x80];
 
     UserString = "";
     UserCount = 1;
@@ -126,15 +126,15 @@ TLogHelper::~TLogHelper()
 }
 
 //-----------------------------------------------------------------------------
-// TCHAR-based functions. They are only needed on UNICODE builds.
-// On ANSI builds is TCHAR = char, so we don't need them at all
+// char-based functions. They are only needed on UNICODE builds.
+// On ANSI builds is char = char, so we don't need them at all
 
 #if 0
-int TLogHelper::PrintWithClreol(const TCHAR * szFormat, va_list argList, bool bPrintPrefix, bool bPrintLastError, bool bPrintEndOfLine)
+int TLogHelper::PrintWithClreol(const char * szFormat, va_list argList, bool bPrintPrefix, bool bPrintLastError, bool bPrintEndOfLine)
 {
-    TCHAR szFormatBuff[0x200];
-    TCHAR szMessage[0x200];
-    TCHAR * szBuffer = szFormatBuff;
+    char szFormatBuff[0x200];
+    char szMessage[0x200];
+    char * szBuffer = szFormatBuff;
     int nRemainingWidth;
     int nConsoleWidth = GetConsoleWidth();
     int nLength = 0;
@@ -198,7 +198,7 @@ int TLogHelper::PrintWithClreol(const TCHAR * szFormat, va_list argList, bool bP
     return nError;
 }
 
-void TLogHelper::PrintProgress(const TCHAR * szFormat, ...)
+void TLogHelper::PrintProgress(const char * szFormat, ...)
 {
     va_list argList;
 
@@ -207,7 +207,7 @@ void TLogHelper::PrintProgress(const TCHAR * szFormat, ...)
     va_end(argList);
 }
 
-void TLogHelper::PrintMessage(const TCHAR * szFormat, ...)
+void TLogHelper::PrintMessage(const char * szFormat, ...)
 {
     va_list argList;
 
@@ -216,7 +216,7 @@ void TLogHelper::PrintMessage(const TCHAR * szFormat, ...)
     va_end(argList);
 }
 
-int TLogHelper::PrintErrorVa(const TCHAR * szFormat, ...)
+int TLogHelper::PrintErrorVa(const char * szFormat, ...)
 {
     va_list argList;
     int nResult;
@@ -228,7 +228,7 @@ int TLogHelper::PrintErrorVa(const TCHAR * szFormat, ...)
     return nResult;
 }
 
-int TLogHelper::PrintError(const TCHAR * szFormat, const TCHAR * szFileName)
+int TLogHelper::PrintError(const char * szFormat, const char * szFileName)
 {
     return PrintErrorVa(szFormat, szFileName);
 }
@@ -347,7 +347,7 @@ DWORD TLogHelper::PrintVerdict(DWORD dwErrCode)
 {
     LPCTSTR szSaveSubTitle1 = szSubTitle1;
     LPCTSTR szSaveSubTitle2 = szSubTitle2;
-    TCHAR szSaveMainTitle[0x80];
+    char szSaveMainTitle[0x80];
 
     // Set both to NULL so they won't be printed
     StringCopy(szSaveMainTitle, _countof(szSaveMainTitle), szMainTitle);
@@ -384,7 +384,7 @@ DWORD TLogHelper::PrintVerdict(DWORD dwErrCode)
 // Protected functions
 
 #if 0
-TCHAR * TLogHelper::CopyFormatCharacter(TCHAR * szBuffer, const TCHAR *& szFormat)
+char * TLogHelper::CopyFormatCharacter(char * szBuffer, const char *& szFormat)
 {
 //  static LPCTSTR szStringFormat = _T("\"%s\"");
     static LPCTSTR szStringFormat = _T("%s");


### PR DESCRIPTION
LUS was building StormLib without `UNICODE` and `_UNICODE` defined, meaning `TCHAR` was `char`

OTRExporter has `UNICODE` and `_UNICODE` defined (https://github.com/HarbourMasters/OTRExporter/blob/717ae786632e3f3e5f32a12dc0ecd86958593a8b/OTRExporter/CMakeLists.txt#L119-L120), which led to `TCHAR` being `wchar_t`.

To verify this is what was causing the problems with otr generation on windows, I hardcoded all `UNICODE`/`_UNICODE` `#ifdef`/`#ifndef`s in stormlib to `#if 0`/`#if 1`, and hardcoded all `TCHAR`s to `char`

I can't think of another solution given the following constraints:
* LUS expects to use StormLib with `UNICODE`/`_UNICODE` off
* OTRExporter needs to have `UNICODE`/`_UNICODE` on