### PR TITLE
Fix loading raw images to the gui

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -229,13 +229,10 @@ void Gui::ImGuiBackendInit() {
     }
 }
 
-void Gui::LoadTexture(const std::string& name, const std::string& path) {
-    // TODO: Nothing ever unloads the texture from Fast3D here.
-    GfxRenderingAPI* api = gfx_get_current_rendering_api();
-    const auto res = Context::GetInstance()->GetResourceManager()->LoadFile(path);
+void Gui::LoadTextureFromRawImage(const std::string& name, const std::string& path) {
+    const auto res = Context::GetInstance()->GetResourceManager()->GetArchiveManager()->LoadFileRaw(path);
 
     GuiTexture asset;
-    asset.RendererTextureId = api->new_texture();
     asset.Width = 0;
     asset.Height = 0;
     uint8_t* imgData = stbi_load_from_memory(reinterpret_cast<const stbi_uc*>(res->Buffer->data()), res->Buffer->size(),
@@ -246,6 +243,10 @@ void Gui::LoadTexture(const std::string& name, const std::string& path) {
         return;
     }
 
+    GfxRenderingAPI* api = gfx_get_current_rendering_api();
+
+    // TODO: Nothing ever unloads the texture from Fast3D here.
+    asset.RendererTextureId = api->new_texture();
     api->select_texture(0, asset.RendererTextureId);
     api->set_sampler_parameters(0, false, 0, 0);
     api->upload_texture(imgData, asset.Width, asset.Height);

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -83,7 +83,7 @@ class Gui {
     std::shared_ptr<GameOverlay> GetGameOverlay();
     void SetMenuBar(std::shared_ptr<GuiMenuBar> menuBar);
     std::shared_ptr<GuiMenuBar> GetMenuBar();
-    void LoadTexture(const std::string& name, const std::string& path);
+    void LoadTextureFromRawImage(const std::string& name, const std::string& path);
     bool ImGuiGamepadNavigationEnabled();
     void BlockImGuiGamepadNavigation();
     void UnblockImGuiGamepadNavigation();


### PR DESCRIPTION
After the archive changes, the function to load raw images for ImGui (like `.png` files in the archive) broke.

What was happening is that `LoadFile` sees the file as binary, and attempts to read an "OTR header" from it when creating the resource. When it does this, it truncates the original file buffer to "skip" the header. The problem is raw files like png obviously dont have a OTR header.

This stripped buffer was being passed into `stbi_load_from_memory` which would fail to detect the image type (because the png header is now corrupted).

To resolve this I have renamed this function and have it use `LoadFileRaw` so we get the whole png file, which then works like before with `stbi_`.

---

I also moved some things around so that we aren't creating the renderer texture until after we confirmed that `stbi_load_from_memory` succeeded.