### PR TITLE
Use map contains checks for gui textures

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -687,11 +687,21 @@ ImTextureID Gui::GetTextureById(int32_t id) {
     return reinterpret_cast<ImTextureID>(id);
 }
 
+bool Gui::HasTextureByName(const std::string& name) {
+    return mGuiTextures.contains(name);
+}
+
 ImTextureID Gui::GetTextureByName(const std::string& name) {
+    if (!Gui::HasTextureByName(name)) {
+        return nullptr;
+    }
     return GetTextureById(mGuiTextures[name].RendererTextureId);
 }
 
 ImVec2 Gui::GetTextureSize(const std::string& name) {
+    if (!Gui::HasTextureByName(name)) {
+        return ImVec2(0, 0);
+    }
     return ImVec2(mGuiTextures[name].Width, mGuiTextures[name].Height);
 }
 

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -76,6 +76,7 @@ class Gui {
     void RemoveGuiWindow(std::shared_ptr<GuiWindow> guiWindow);
     void RemoveGuiWindow(const std::string& name);
     void LoadGuiTexture(const std::string& name, const std::string& path, const ImVec4& tint);
+    bool HasTextureByName(const std::string& name);
     ImTextureID GetTextureByName(const std::string& name);
     ImVec2 GetTextureSize(const std::string& name);
     bool SupportsViewports();


### PR DESCRIPTION
Indexing against a map for a key that doesn't exist will insert a default object constructed to that map.
The gui texture map was being indexed on lookup for texture IDs, and the `texture 0` is generally the main renderer framebuffer texture. This can lead to that texture being displayed into ImGui unexpectedly.

Example of non-existent key returning framebuffer:
<img width="134" alt="image" src="https://github.com/Kenix3/libultraship/assets/13861068/27d53588-758f-425d-a844-cdfe31eb6a5d">


This adds a proper `contains()` check before indexing against the map to avoid inserting a default value into the map, and will return `nullptr` or size 0 in the following functions.