### PR TITLE
Remove the last remains of GLEW in other platforms.

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -109,11 +109,9 @@ else()
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    find_package(GLEW REQUIRED)
-    target_link_libraries(ImGui PUBLIC opengl32 GLEW::GLEW)
+    target_link_libraries(ImGui PUBLIC opengl32)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    find_package(GLEW REQUIRED)
-    target_link_libraries(ImGui PUBLIC ${OPENGL_opengl_LIBRARY} GLEW::GLEW)
+    target_link_libraries(ImGui PUBLIC ${OPENGL_opengl_LIBRARY})
     set_target_properties(ImGui PROPERTIES
         XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES 
     )

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -19,18 +19,10 @@
 #define FOR_WINDOWS 0
 #endif
 
-#ifdef _MSC_VER
-#include <SDL2/SDL.h>
-// #define GL_GLEXT_PROTOTYPES 1
-#include <GL/glew.h>
-#elif FOR_WINDOWS
-#include <GL/glew.h>
+#ifdef FOR_WINDOWS
 #include "SDL.h"
 #define GL_GLEXT_PROTOTYPES 1
 #include "SDL_opengl.h"
-#elif __APPLE__
-#include <SDL2/SDL.h>
-#include <GL/glew.h>
 #elif __SWITCH__
 #include <SDL2/SDL.h>
 #include <glad/glad.h>
@@ -846,10 +838,6 @@ static void gfx_opengl_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_
 }
 
 static void gfx_opengl_init(void) {
-#if !defined(__SWITCH__) && !defined(__linux__)
-    glewInit();
-#endif
-
     glGenBuffers(1, &opengl_vbo);
     glBindBuffer(GL_ARRAY_BUFFER, opengl_vbo);
 

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -16,15 +16,11 @@
 #define FOR_WINDOWS 0
 #endif
 
-#if FOR_WINDOWS
-#include <GL/glew.h>
-#include "SDL.h"
-#define GL_GLEXT_PROTOTYPES 1
-#include "SDL_opengl.h"
-#elif __APPLE__
-#include <SDL.h>
+#ifdef __APPLE__
 #include "gfx_metal.h"
-#elif __SWITCH__
+#endif
+
+#ifdef __SWITCH__
 #include <SDL2/SDL.h>
 #include <switch.h>
 #include <glad/glad.h>


### PR DESCRIPTION
This is a follow-up to removing the remains of the unused GLEW dependency on GNU/Linux:

https://github.com/Kenix3/libultraship/commit/bd20dd4470462420a55d9a3d999868c2110add5d

The situation on these remaining systems is the same it was on GNU/Linix: GLEW headers were used for providing GL functions that should be provided by the SDL2 headers instead, since SDL2 is already a dependency.
