### PR TITLE
Remove GLEW remains on other platforms.

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -111,8 +111,7 @@ endif()
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     target_link_libraries(ImGui PUBLIC opengl32)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    find_package(GLEW REQUIRED)
-    target_link_libraries(ImGui PUBLIC ${OPENGL_opengl_LIBRARY} GLEW::GLEW)
+    target_link_libraries(ImGui PUBLIC ${OPENGL_opengl_LIBRARY})
     set_target_properties(ImGui PROPERTIES
         XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES 
     )

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -109,7 +109,6 @@ else()
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    find_package(GLEW REQUIRED)
     target_link_libraries(ImGui PUBLIC opengl32)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     find_package(GLEW REQUIRED)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -110,7 +110,7 @@ endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     find_package(GLEW REQUIRED)
-    target_link_libraries(ImGui PUBLIC opengl32 GLEW::GLEW)
+    target_link_libraries(ImGui PUBLIC opengl32)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     find_package(GLEW REQUIRED)
     target_link_libraries(ImGui PUBLIC ${OPENGL_opengl_LIBRARY} GLEW::GLEW)

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -29,7 +29,8 @@
 #include "SDL_opengl.h"
 #elif __APPLE__
 #include <SDL2/SDL.h>
-#include <GL/glew.h>
+#define GL_GLEXT_PROTOTYPES 1
+#include <SDL2/SDL_opengl.h>
 #elif __SWITCH__
 #include <SDL2/SDL.h>
 #include <glad/glad.h>

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -21,10 +21,9 @@
 
 #ifdef _MSC_VER
 #include <SDL2/SDL.h>
-// #define GL_GLEXT_PROTOTYPES 1
-#include <GL/glew.h>
+#define GL_GLEXT_PROTOTYPES 1
+#include <SDL2/SDL_opengl.h>
 #elif FOR_WINDOWS
-#include <GL/glew.h>
 #include "SDL.h"
 #define GL_GLEXT_PROTOTYPES 1
 #include "SDL_opengl.h"
@@ -846,10 +845,6 @@ static void gfx_opengl_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_
 }
 
 static void gfx_opengl_init(void) {
-#if !defined(__SWITCH__) && !defined(__linux__)
-    glewInit();
-#endif
-
     glGenBuffers(1, &opengl_vbo);
     glBindBuffer(GL_ARRAY_BUFFER, opengl_vbo);
 

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -17,7 +17,6 @@
 #endif
 
 #if FOR_WINDOWS
-#include <GL/glew.h>
 #include "SDL.h"
 #define GL_GLEXT_PROTOTYPES 1
 #include "SDL_opengl.h"


### PR DESCRIPTION
This is a follow-up to removing the remains of the unused GLEW dependency on GNU/Linux:

https://github.com/Kenix3/libultraship/commit/bd20dd4470462420a55d9a3d999868c2110add5d

The situation on these remaining systems is the same it was on GNU/Linix: GLEW headers were used for providing GL functions that should be provided by the SDL2 headers instead, since SDL2 is already a dependency.