### PR TITLE
mac test 1

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -112,7 +112,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     find_package(GLEW REQUIRED)
     target_link_libraries(ImGui PUBLIC opengl32 GLEW::GLEW)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    find_package(GLEW REQUIRED)
     target_link_libraries(ImGui PUBLIC ${OPENGL_opengl_LIBRARY} GLEW::GLEW)
     set_target_properties(ImGui PROPERTIES
         XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES 

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -112,7 +112,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     find_package(GLEW REQUIRED)
     target_link_libraries(ImGui PUBLIC opengl32 GLEW::GLEW)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    target_link_libraries(ImGui PUBLIC ${OPENGL_opengl_LIBRARY} GLEW::GLEW)
+    target_link_libraries(ImGui PUBLIC ${OPENGL_opengl_LIBRARY})
     set_target_properties(ImGui PROPERTIES
         XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES 
     )


### PR DESCRIPTION
Experimental PR to try to find out why removing GLEW linking on Mac OS breaks SDL audio backend compilation.