### PR TITLE
Fix right stick showing up as left stick in controller mapping window

### DIFF
--- a/src/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAnyMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAnyMapping.cpp
@@ -23,10 +23,10 @@ std::string SDLAxisDirectionToAnyMapping::GetPhysicalInputName() {
             return StringHelper::Sprintf(UsesGameCubeLayout() ? "Analog Stick %s" : "Left Stick %s",
                                          mAxisDirection == NEGATIVE ? ICON_FA_ARROW_UP : ICON_FA_ARROW_DOWN);
         case SDL_CONTROLLER_AXIS_RIGHTX:
-            return StringHelper::Sprintf(UsesGameCubeLayout() ? "C Stick %s" : "Left Stick %s",
+            return StringHelper::Sprintf(UsesGameCubeLayout() ? "C Stick %s" : "Right Stick %s",
                                          mAxisDirection == NEGATIVE ? ICON_FA_ARROW_LEFT : ICON_FA_ARROW_RIGHT);
         case SDL_CONTROLLER_AXIS_RIGHTY:
-            return StringHelper::Sprintf(UsesGameCubeLayout() ? "C Stick %s" : "Left Stick %s",
+            return StringHelper::Sprintf(UsesGameCubeLayout() ? "C Stick %s" : "Right Stick %s",
                                          mAxisDirection == NEGATIVE ? ICON_FA_ARROW_UP : ICON_FA_ARROW_DOWN);
         case SDL_CONTROLLER_AXIS_TRIGGERLEFT:
             if (UsesPlaystationLayout()) {


### PR DESCRIPTION
Fix for what appears to be a copy-paste error causing the right stick to show up as "Left Stick" in the controller mapping window, even though actual right stick functionality is not impaired.a

Before:
![image](https://github.com/Kenix3/libultraship/assets/7520947/f7979627-6a97-4466-9969-26dd0f367730)

After:
![image](https://github.com/Kenix3/libultraship/assets/7520947/775e9bb9-0d80-418b-9b45-6ee300236e52)
