### PR TITLE
Fix crash on texture load with missing/empty resources

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -232,6 +232,11 @@ void Gui::ImGuiBackendInit() {
 void Gui::LoadTextureFromRawImage(const std::string& name, const std::string& path) {
     const auto res = Context::GetInstance()->GetResourceManager()->GetArchiveManager()->LoadFileRaw(path);
 
+    if (!res || !res->Buffer || res->Buffer->empty()) {
+        SPDLOG_ERROR("Failed to load resource or buffer is empty");
+        return;
+    }
+
     GuiTexture asset;
     asset.Width = 0;
     asset.Height = 0;

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -232,8 +232,12 @@ void Gui::ImGuiBackendInit() {
 void Gui::LoadTextureFromRawImage(const std::string& name, const std::string& path) {
     const auto res = Context::GetInstance()->GetResourceManager()->GetArchiveManager()->LoadFileRaw(path);
 
-    if (!res || !res->Buffer || res->Buffer->empty()) {
-        SPDLOG_ERROR("Failed to load resource or buffer is empty");
+    if (!res) {
+        SPDLOG_ERROR("Failed to load resource");
+        return;
+    }
+    if (!res->Buffer || res->Buffer->empty()) {
+        SPDLOG_ERROR("Buffer is null or empty");
         return;
     }
 


### PR DESCRIPTION
Ran into a crash when the game tried to load textures from resources that were either missing or had empty data. Added quick checks to exit early in `Gui::LoadTextureFromRawImage` if the resource or its buffer is null or empty. This stops the crash and logs an error instead. Per Archez, I needed to regenerate my soh.otr via the cmake target. The recent input viewer changes add some new images that use this method, but these new checks should help avoid similar issues in the future. 

[crash log.txt](https://github.com/Kenix3/libultraship/files/14324272/crash.log.txt)
