### PR TITLE
Restore window before closing

### DIFF
--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -301,6 +301,11 @@ void GetMonitorHzPeriod(std::tuple<HMONITOR, RECT, BOOL> Monitor, double& Freque
     }
 }
 
+static void gfx_dxgi_close() {
+    ShowWindow(dxgi.h_wnd, SW_RESTORE); // Restore window before closing, so normal window pos and size is saved
+    dxgi.is_running = false;
+}
+
 static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_param, LPARAM l_param) {
     char fileName[256];
     Ship::WindowEvent event_impl;
@@ -329,7 +334,7 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
             }
             break;
         case WM_CLOSE:
-            dxgi.is_running = false;
+            gfx_dxgi_close();
             break;
         case WM_DPICHANGED: {
             RECT* const prcNewWindow = (RECT*)l_param;
@@ -344,7 +349,7 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
         case WM_ENDSESSION:
             // This hopefully gives the game a chance to shut down, before windows kills it.
             if (w_param == TRUE) {
-                dxgi.is_running = false;
+                gfx_dxgi_close();
             }
             break;
         case WM_ACTIVATEAPP:
@@ -479,10 +484,6 @@ void gfx_dxgi_init(const char* game_name, const char* gfx_api_name, bool start_i
     }
 
     DragAcceptFiles(dxgi.h_wnd, TRUE);
-}
-
-static void gfx_dxgi_close() {
-    dxgi.is_running = false;
 }
 
 static void gfx_dxgi_set_fullscreen_changed_callback(void (*on_fullscreen_changed)(bool is_now_fullscreen)) {

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -302,7 +302,7 @@ void GetMonitorHzPeriod(std::tuple<HMONITOR, RECT, BOOL> Monitor, double& Freque
 }
 
 static void gfx_dxgi_close() {
-    ShowWindow(dxgi.h_wnd, SW_RESTORE); // Restore window before closing, so normal window pos and size is saved
+    ShowWindow(dxgi.h_wnd, SW_NORMAL); // Restore window before closing, so normal window pos and size is saved
     dxgi.is_running = false;
 }
 

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -540,12 +540,17 @@ static void gfx_sdl_handle_single_event(SDL_Event& event) {
             break;
 #endif
         case SDL_WINDOWEVENT:
-            if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
-                SDL_GL_GetDrawableSize(wnd, &window_width, &window_height);
-            } else if (event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == SDL_GetWindowID(wnd)) {
-                // We listen specifically for main window close because closing main window
-                // on macOS does not trigger SDL_Quit.
-                gfx_sdl_close();
+            switch (event.window.event) {
+                case SDL_WINDOWEVENT_SIZE_CHANGED:
+                    SDL_GL_GetDrawableSize(wnd, &window_width, &window_height);
+                    break;
+                case SDL_WINDOWEVENT_CLOSE:
+                    if (event.window.windowID == SDL_GetWindowID(wnd)) {
+                        // We listen specifically for main window close because closing main window
+                        // on macOS does not trigger SDL_Quit.
+                        gfx_sdl_close();
+                    }
+                    break;
             }
             break;
         case SDL_DROPFILE:


### PR DESCRIPTION
This looks a bit funny, but prevents saving the size of a maximized or minimized window. The window is always restored to it's normal state before closing down (maximized and minimized state is NOT saved.)

The only thing that doesn't really work is when going fullscreen while the window is maximized and the game is closed while still in fullscreen. It still starts in fullscreen, but the maximized size is restored (without it being actually maximized) when going windowed.

Also quitting should always call gfx_dxgi_close() or gfx_dxgi_close() now, no matter how you quit (except outright killing the process I guess).

Test-PR: https://github.com/HarbourMasters/Shipwright/pull/4395