### PR TITLE
Fix: opengles cmake check

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -118,7 +118,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES 
     )
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    if (DEFINED USE_OPENGLES)
+    if (USE_OPENGLES)
         target_link_libraries(ImGui PUBLIC ${OPENGL_GLESv2_LIBRARY})
         add_compile_definitions(IMGUI_IMPL_OPENGL_ES3)
     else()


### PR DESCRIPTION
In the cmake list `option(USE_OPENGLES "Enable GLES3" OFF)` is used to define and default the value of `USE_OPENGLES` in the cmake lists.

Then later a check for `if(DEFINED USE_OPENGLES)` was being used. This always evaluates to true because the value is defined even if its "OFF", which was leading to opengles being used for all linux platforms.

This PR fixes that by actually checking the value of the variable.