### PR TITLE
Fix: Include texture size for cache key

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -572,7 +572,7 @@ static std::string gfx_get_base_texture_path(const std::string& path) {
 
 void gfx_texture_cache_delete(const uint8_t* orig_addr) {
     while (gfx_texture_cache.map.bucket_count() > 0) {
-        TextureCacheKey key = { orig_addr, { 0 }, 0, 0 }; // bucket index only depends on the address
+        TextureCacheKey key = { orig_addr, { 0 }, 0, 0, 0 }; // bucket index only depends on the address
         size_t bucket = gfx_texture_cache.map.bucket(key);
         bool again = false;
         for (auto it = gfx_texture_cache.map.begin(bucket); it != gfx_texture_cache.map.end(bucket); ++it) {
@@ -968,6 +968,7 @@ static void import_texture(int i, int tile, bool importReplacement) {
     uint32_t texFlags = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].tex_flags;
     uint32_t tmem_index = rdp.texture_tile[tile].tmem_index;
     uint8_t palette_index = rdp.texture_tile[tile].palette;
+    uint32_t orig_size_bytes = rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].orig_size_bytes;
 
     const RawTexMetadata* metadata = &rdp.loaded_texture[rdp.texture_tile[tile].tmem_index].raw_tex_metadata;
     const uint8_t* orig_addr =
@@ -978,9 +979,9 @@ static void import_texture(int i, int tile, bool importReplacement) {
 
     TextureCacheKey key;
     if (fmt == G_IM_FMT_CI) {
-        key = { orig_addr, { rdp.palettes[0], rdp.palettes[1] }, fmt, siz, palette_index };
+        key = { orig_addr, { rdp.palettes[0], rdp.palettes[1] }, fmt, siz, palette_index, orig_size_bytes };
     } else {
-        key = { orig_addr, {}, fmt, siz, palette_index };
+        key = { orig_addr, {}, fmt, siz, palette_index, orig_size_bytes };
     }
 
     if (gfx_texture_cache_lookup(i, key)) {
@@ -1052,7 +1053,7 @@ static void import_texture_mask(int i, int tile) {
         return;
     }
 
-    TextureCacheKey key = { orig_addr, {}, 0, 0, 0 };
+    TextureCacheKey key = { orig_addr, {}, 0, 0, 0, 0 };
 
     if (gfx_texture_cache_lookup(i, key)) {
         return;

--- a/src/graphic/Fast3D/gfx_pc.h
+++ b/src/graphic/Fast3D/gfx_pc.h
@@ -36,6 +36,7 @@ struct TextureCacheKey {
     const uint8_t* palette_addrs[2];
     uint8_t fmt, siz;
     uint8_t palette_index;
+    uint32_t size_bytes;
 
     bool operator==(const TextureCacheKey&) const noexcept = default;
 


### PR DESCRIPTION
This adds the original texture lookup size to the texture cache key so that unique cache records can be made for the same texture resource being loaded with different height/width values.

The use case is in SoH, there are two DLs that load the same texture. The first DL loads the texture as 8x8 which then gets cached. The second DL loads the texture as 16x16, but a cache hit is found so the texture loaded from the first DL is used. This cache record doesn't have 16x16 worth of data leading to rendering issues.

By having the cache key include the original size bytes, we effectively track the loaded height/width and can prevent the rendering bug.

https://github.com/HarbourMasters/Shipwright/issues/4000