### PR TITLE
OpenGL: Check max supported msaa level

### DIFF
--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -87,6 +87,7 @@ static size_t current_framebuffer;
 static float current_noise_scale;
 static FilteringMode current_filter_mode = FILTER_THREE_POINT;
 
+GLint max_msaa_level = 1;
 GLuint pixel_depth_rb, pixel_depth_fb;
 size_t pixel_depth_rb_size;
 
@@ -877,6 +878,8 @@ static void gfx_opengl_init(void) {
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
     pixel_depth_rb_size = 1;
+
+    glGetIntegerv(GL_MAX_SAMPLES, &max_msaa_level);
 }
 
 static void gfx_opengl_on_resize(void) {
@@ -932,6 +935,7 @@ static void gfx_opengl_update_framebuffer_parameters(int fb_id, uint32_t width, 
 
     width = max(width, 1U);
     height = max(height, 1U);
+    msaa_level = min(msaa_level, (uint32_t)max_msaa_level);
 
     glBindFramebuffer(GL_FRAMEBUFFER, fb.fbo);
 


### PR DESCRIPTION
In the DirectX and Metal renderer APIs, we are performing MSAA support checks and overriding the passed in MSAA level for framebuffers so that those are created/work as expected for the running machine. Opengl was lacking this. As an example, on Mac (M1) the max supported MSAA level is 4, so selecting anything above 4 in the UI would lead to unresolved/black frame buffers.

This adds a call to read `GL_MAX_SAMPLES` on init and then performs a min check in the `update_framebuffer_parameters` callback.

Tested on my Mac (max level 4), and Windows (max level 32).