### PR TITLE
fix linux zenity otr generation

### DIFF
--- a/extern/ZAPDUtils/Utils/DiskFile.h
+++ b/extern/ZAPDUtils/Utils/DiskFile.h
@@ -66,8 +66,9 @@ public:
 
 	static void WriteAllBytes(const std::string& filePath, const std::vector<char>& data)
 	{
-		if (!Directory::Exists(Path::GetDirectoryName(filePath)))
+		if (!Directory::Exists(Path::GetDirectoryName(filePath))) {
 			Directory::MakeDirectory(Path::GetDirectoryName(filePath).string());
+		}
 
 		std::ofstream file(filePath, std::ios::binary);
 		file.write((char*)data.data(), data.size());
@@ -81,8 +82,8 @@ public:
 
 	static void WriteAllText(const fs::path& filePath, const std::string& text)
 	{
-        if (!std::filesystem::exists(filePath.parent_path())) {
-                std::filesystem::create_directories(filePath.parent_path());
+		if (!Directory::Exists(Path::GetDirectoryName(filePath))) {
+			Directory::MakeDirectory(Path::GetDirectoryName(filePath).string());
 		}
         std::ofstream file(filePath, std::ios::out);
 		file.write(text.c_str(), text.size());


### PR DESCRIPTION
this broke in https://github.com/Kenix3/libultraship/pull/461 (progress bar would go all the way to 100% but no `.otr` file would be generated)

i looked through the changes and these https://github.com/louist103/libultraship/commit/8935a1e3f8acefc52a9b7f8ed3683c3e40d97176 https://github.com/louist103/libultraship/commit/95e9c34c70a33e3e256f263e022b98e1c0fe0c6b seemed like the most likely candidate for the code changes that broke it. i'm not sure why exactly directly using `std::filesystem` was causing problems but since `WriteAllBytes` already had a pattern for this i figured just using that same pattern in `WriteAllText` might fix the issue i was encountering. after testing in https://github.com/HarbourMasters/Shipwright/pull/4042 i can verify it does.