### PR TITLE
Safely check ucode handlers for out of range or missing opcode

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -3687,8 +3687,15 @@ static void gfx_step() {
         if (rdpHandlers.at(opcode)(&cmd)) {
             return;
         }
-    } else if (ucode_handlers[ucode_handler_index]->at(opcode)(&cmd)) {
-        return;
+    } else if (ucode_handler_index < ucode_handlers.size()) {
+        if (ucode_handlers[ucode_handler_index]->contains(opcode)) {
+            if (ucode_handlers[ucode_handler_index]->at(opcode)(&cmd)) {
+                return;
+            }
+        }
+    } else {
+        // Loaded ucode is out of range of the supported ucode_handlers
+        assert(true);
     }
 
     ++cmd;

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -3664,6 +3664,8 @@ const static std::array<const std::unordered_map<uint32_t, GfxOpcodeHandlerFunc>
 // TODO, implement a system where we can get the current opcode handler by writing to the GWords. If the powers that be
 // are OK with that...
 static void gfx_set_ucode_handler(UcodeHandlers ucode) {
+    // Loaded ucode must be in range of the supported ucode_handlers
+    assert(ucode < ucode_max);
     ucode_handler_index = ucode;
 }
 
@@ -3692,10 +3694,9 @@ static void gfx_step() {
             if (ucode_handlers[ucode_handler_index]->at(opcode)(&cmd)) {
                 return;
             }
+        } else {
+            SPDLOG_WARN("Unhandled OP code: {}, for loaded ucode: {}", opcode, ucode_handler_index);
         }
-    } else {
-        // Loaded ucode is out of range of the supported ucode_handlers
-        assert(true);
     }
 
     ++cmd;

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -3695,7 +3695,7 @@ static void gfx_step() {
                 return;
             }
         } else {
-            SPDLOG_WARN("Unhandled OP code: {}, for loaded ucode: {}", opcode, ucode_handler_index);
+            SPDLOG_WARN("Unhandled OP code: {}, for loaded ucode: {}", opcode, (uint32_t)ucode_handler_index);
         }
     }
 


### PR DESCRIPTION
The execution of the ucode handlers would crash if a bad ucode index was loaded, or the opcode has no handler.

This first adds a bounds check for the index being within the array size of ucode_handlers, and if it isn't, trip a debug `assert` as the call to `G_LOAD_UCODE` was incorrect. Alternatively, we could move the `assert` to be inside `gfx_set_ucode_handler`.

The second is to add a `contains` check for the opcode on the specific ucode handler before accessing the map. If the opcode is not recognized, it silently skips over it. I'm not sure if we would also want a debug `assert` here, or maybe logging, thoughts?