### PR TITLE
Adjust frame buffer copy to handle all viewport scenarios

### DIFF
--- a/src/graphic/Fast3D/gfx_gx2.cpp
+++ b/src/graphic/Fast3D/gfx_gx2.cpp
@@ -752,7 +752,8 @@ void gfx_gx2_select_texture_fb(int fb) {
     GX2SetPixelSampler(&buffer->sampler, location);
 }
 
-void gfx_gx2_copy_framebuffer(int fb_dst_id, int fb_src_id) {
+void gfx_gx2_copy_framebuffer(int fb_dst_id, int fb_src_id, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0,
+                              int dstY0, int dstX1, int dstY1) {
     // TODO: Implement framebuffer texture copy
 }
 

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -1024,57 +1024,51 @@ void gfx_opengl_select_texture_fb(int fb_id) {
     glBindTexture(GL_TEXTURE_2D, framebuffers[fb_id].clrbuf);
 }
 
-void gfx_opengl_copy_framebuffer(int fb_dst_id, int fb_src_id) {
+void gfx_opengl_copy_framebuffer(int fb_dst_id, int fb_src_id, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0,
+                                 int dstY0, int dstX1, int dstY1) {
     if (fb_dst_id >= (int)framebuffers.size() || fb_src_id >= (int)framebuffers.size()) {
         return;
     }
 
-    Framebuffer& src = framebuffers[fb_src_id];
+    Framebuffer src = framebuffers[fb_src_id];
     const Framebuffer& dst = framebuffers[fb_dst_id];
 
-    // Skip copying framebuffers that don't have the same width
-    if (src.width != dst.width) {
-        return;
+    // Adjust y values for non-inverted source frame buffers because opengl uses bottom left for origin
+    if (!src.invert_y) {
+        int temp = srcY1 - srcY0;
+        srcY1 = src.height - srcY0;
+        srcY0 = srcY1 - temp;
     }
 
-    int srcX0, srcY0, srcX1, srcY1;
-    int dstX0, dstY0, dstX1, dstY1;
-
-    dstX0 = dstY0 = 0;
-    dstX1 = dst.width;
-    dstY1 = dst.height;
-
-    srcX0 = 0;
-    srcY0 = 0;
-    srcX1 = src.width;
-    srcY1 = src.height;
-
-    // Account for source framebuffer having the menu bar open
-    if (src.height >= dst.height) {
-        srcY1 -= src.height - dst.height;
-    }
-
-    // flip vertically as openGLs origin is in the bottom left when compared to Fast3D
+    // Flip the y values
     if (src.invert_y != dst.invert_y) {
-        std::swap(dstY0, dstY1);
+        std::swap(srcY0, srcY1);
     }
 
     // Disabled for blit
     glDisable(GL_SCISSOR_TEST);
 
     // For msaa enabled buffers we can't perform a scaled blit to a simple sample buffer
-    // First do an unscaled blit to main buffer to resolve the sample data
+    // First do an unscaled blit to a msaa resolved buffer
     if (src.height != dst.height && src.width != dst.width && src.msaa_level > 1) {
-        // Since frambuffer 0 is considered the final single sample resolve for the MSAA buffer,
-        // and is only needed at the end of a frame, we can temporarily use it here without causing issues
+        // Start with the main buffer (0) as the msaa resolved buffer
+        int fb_resolve_id = 0;
+        Framebuffer fb_resolve = framebuffers[fb_resolve_id];
+
+        // If the size doesn't match our source, then we need to use our separate color msaa resolved buffer (2)
+        if (fb_resolve.height != src.height || fb_resolve.width != src.width) {
+            fb_resolve_id = 2;
+            fb_resolve = framebuffers[fb_resolve_id];
+        }
+
         glBindFramebuffer(GL_READ_FRAMEBUFFER, src.fbo);
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fb_resolve.fbo);
 
         glBlitFramebuffer(0, 0, src.width, src.height, 0, 0, src.width, src.height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 
-        // Switch source buffer to the single sample
-        fb_src_id = 0;
-        src = framebuffers[0];
+        // Switch source buffer to the resolved sample
+        fb_src_id = fb_resolve_id;
+        src = fb_resolve;
     }
 
     glBindFramebuffer(GL_READ_FRAMEBUFFER, src.fbo);

--- a/src/graphic/Fast3D/gfx_rendering_api.h
+++ b/src/graphic/Fast3D/gfx_rendering_api.h
@@ -58,7 +58,8 @@ struct GfxRenderingAPI {
                                           bool opengl_invert_y, bool render_target, bool has_depth_buffer,
                                           bool can_extract_depth);
     void (*start_draw_to_framebuffer)(int fb_id, float noise_scale);
-    void (*copy_framebuffer)(int fb_dst_id, int fb_src_id);
+    void (*copy_framebuffer)(int fb_dst_id, int fb_src_id, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0,
+                             int dstY0, int dstX1, int dstY1);
     void (*clear_framebuffer)(void);
     void (*resolve_msaa_color_buffer)(int fb_id_target, int fb_id_source);
     std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff> (*get_pixel_depth)(


### PR DESCRIPTION
The frame buffer copy logic currently was only equipped to handle the main frame buffer and the main MSAA buffer, and only with/without the menu bar being open. I had a hacky check for the menu bar handling. The problem is that this logic fell apart if any ImGui windows were docked to the sides of the viewport, or the internal resolution multiplier/custom aspect ratio enhancements were active.

In this PR I have reworked the copy handling so that Fast3D will get the appropriate origin, width, and height values for the source buffer and pass that to each renderer to use for their blit/copy operations. Extra care is taken for OpenGL's different interpretation of the origin value and buffers being y-inverted.

Now, the frame buffer copy logic will handle all possible scenarios of custom aspect ratios, any combination of docked windows, and any level of MSAA.