### PR TITLE
Support different native resolutions for fast3d

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -187,6 +187,8 @@ set(Source_Files__Public__Bridge
     ${CMAKE_CURRENT_SOURCE_DIR}/public/bridge/windowbridge.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/public/bridge/audiobridge.h
     ${CMAKE_CURRENT_SOURCE_DIR}/public/bridge/audiobridge.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/public/bridge/gfxbridge.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/public/bridge/gfxbridge.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/public/bridge/gfxdebuggerbridge.h
     ${CMAKE_CURRENT_SOURCE_DIR}/public/bridge/gfxdebuggerbridge.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/public/bridge/controllerbridge.h

--- a/src/graphic/Fast3D/gfx_pc.h
+++ b/src/graphic/Fast3D/gfx_pc.h
@@ -199,6 +199,9 @@ extern GfxExecStack g_exec_stack;
 
 extern "C" {
 
+extern struct XYWidthHeight
+    gfx_native_dimensions; // The dimensions of the VI mode for the console (typically SCREEN_WIDTH, SCREEN_HEIGHT)
+
 extern struct GfxDimensions gfx_current_window_dimensions; // The dimensions of the window
 extern struct GfxDimensions
     gfx_current_dimensions; // The dimensions of the draw area the game draws to, before scaling (if applicable)
@@ -219,7 +222,7 @@ void gfx_set_target_fps(int);
 void gfx_set_maximum_frame_latency(int latency);
 void gfx_texture_cache_delete(const uint8_t* orig_addr);
 extern "C" void gfx_texture_cache_clear();
-extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height);
+extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height);
 void gfx_get_pixel_depth_prepare(float x, float y);
 uint16_t gfx_get_pixel_depth(float x, float y);
 void gfx_push_current_dir(char* path);

--- a/src/public/bridge/gfxbridge.cpp
+++ b/src/public/bridge/gfxbridge.cpp
@@ -1,0 +1,10 @@
+#include "gfxbridge.h"
+
+#include "graphic/Fast3D/gfx_pc.h"
+
+// Set the dimensions for the VI mode that the console would be using
+// (Usually 320x240 for lo-res and 640x480 for hi-res)
+extern "C" void gfx_set_native_dimensions(uint32_t width, uint32_t height) {
+    gfx_native_dimensions.width = width;
+    gfx_native_dimensions.height = height;
+}

--- a/src/public/bridge/gfxbridge.cpp
+++ b/src/public/bridge/gfxbridge.cpp
@@ -4,7 +4,7 @@
 
 // Set the dimensions for the VI mode that the console would be using
 // (Usually 320x240 for lo-res and 640x480 for hi-res)
-extern "C" void gfx_set_native_dimensions(uint32_t width, uint32_t height) {
+extern "C" void Gfx_SetNativeDimensions(uint32_t width, uint32_t height) {
     gfx_native_dimensions.width = width;
     gfx_native_dimensions.height = height;
 }

--- a/src/public/bridge/gfxbridge.cpp
+++ b/src/public/bridge/gfxbridge.cpp
@@ -4,7 +4,7 @@
 
 // Set the dimensions for the VI mode that the console would be using
 // (Usually 320x240 for lo-res and 640x480 for hi-res)
-extern "C" void Gfx_SetNativeDimensions(uint32_t width, uint32_t height) {
+extern "C" void GfxSetNativeDimensions(uint32_t width, uint32_t height) {
     gfx_native_dimensions.width = width;
     gfx_native_dimensions.height = height;
 }

--- a/src/public/bridge/gfxbridge.h
+++ b/src/public/bridge/gfxbridge.h
@@ -1,6 +1,8 @@
 #ifndef GFX_BRIDGE_H
 #define GFX_BRIDGE_H
 
+#include "stdint.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -10,6 +12,8 @@ typedef enum UcodeHandlers {
     ucode_s2dex,
     ucode_max,
 } UcodeHandlers;
+
+void gfx_set_native_dimensions(uint32_t width, uint32_t height);
 
 #ifdef __cplusplus
 }

--- a/src/public/bridge/gfxbridge.h
+++ b/src/public/bridge/gfxbridge.h
@@ -13,7 +13,7 @@ typedef enum UcodeHandlers {
     ucode_max,
 } UcodeHandlers;
 
-void Gfx_SetNativeDimensions(uint32_t width, uint32_t height);
+void GfxSetNativeDimensions(uint32_t width, uint32_t height);
 
 #ifdef __cplusplus
 }

--- a/src/public/bridge/gfxbridge.h
+++ b/src/public/bridge/gfxbridge.h
@@ -13,7 +13,7 @@ typedef enum UcodeHandlers {
     ucode_max,
 } UcodeHandlers;
 
-void gfx_set_native_dimensions(uint32_t width, uint32_t height);
+void Gfx_SetNativeDimensions(uint32_t width, uint32_t height);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds a new dimensions variable that is meant to represent the native resolution of the console. A setter is provided for ports to update the resolution (like HIRES mode in MM for the bombers notebook) via `gfx_set_native_dimensions()`

Fast3D is updated to replace its usage of `SCREEN_WIDTH` and `SCREEN_HEIGHT` to instead use `gfx_native_dimensions`. The custom created framebuffers now need to be provided the native dimensions for the "full screen" so that partial sized framebuffers will be scaled by the right proportion.

I've settled on `native` to mean the "console" size, but if there is a different name that we would prefer, let me know.

This will require Ports to update their use of `gfx_create_framebuffers()`

Closes #414 