### PR TITLE
Add opcode for reading a framebuffer texture to a cpu buffer

### DIFF
--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -187,6 +187,7 @@
 #define G_COPYFB 0x3b
 #define G_IMAGERECT 0x3c
 #define G_DL_INDEX 0x3d
+#define G_READFB 0x3e
 #define G_SETINTENSITY 0x40
 
 /*
@@ -2675,6 +2676,16 @@ typedef union {
                                                                                                                      \
         _g->words.w0 = _SHIFTL(G_COPYFB, 24, 8) | _SHIFTL(dst, 11, 11) | _SHIFTL(src, 0, 11) | _SHIFTL(once, 22, 1); \
         _g->words.w1 = (uintptr_t)copiedPtr;                                                                         \
+    }
+
+#define gDPReadFB(pkt, src, buf, ulx, uly, width, height)                \
+    {                                                                    \
+        Gfx *_g0 = (Gfx*)(pkt), *_g1 = (Gfx*)(pkt);                      \
+                                                                         \
+        _g0->words.w0 = _SHIFTL(G_READFB, 24, 8) | _SHIFTL(src, 0, 8);   \
+        _g0->words.w1 = (uintptr_t)buf;                                  \
+        _g1->words.w0 = _SHIFTL(uly, 16, 16) | _SHIFTL(ulx, 0, 16);      \
+        _g1->words.w1 = _SHIFTL(height, 16, 16) | _SHIFTL(width, 0, 16); \
     }
 
 #define gDPImageRectangle(pkt, x0, y0, s0, t0, x1, y1, s1, t1, tile, iw, ih) \

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -2670,6 +2670,7 @@ typedef union {
         _g->words.w1 = 0;                         \
     }
 
+// Copy a framebuffer's texture to another framebuffer's in the GPU
 #define gDPCopyFB(pkt, dst, src, once, copiedPtr)                                                                    \
     {                                                                                                                \
         Gfx* _g = (Gfx*)(pkt);                                                                                       \
@@ -2678,12 +2679,13 @@ typedef union {
         _g->words.w1 = (uintptr_t)copiedPtr;                                                                         \
     }
 
-#define gDPReadFB(pkt, src, buf, ulx, uly, width, height)                \
+// Read the framebuffer's texture to a cpu memory location as RGBA16
+#define gDPReadFB(pkt, src, rgba16buf, ulx, uly, width, height)          \
     {                                                                    \
         Gfx *_g0 = (Gfx*)(pkt), *_g1 = (Gfx*)(pkt);                      \
                                                                          \
         _g0->words.w0 = _SHIFTL(G_READFB, 24, 8) | _SHIFTL(src, 0, 8);   \
-        _g0->words.w1 = (uintptr_t)buf;                                  \
+        _g0->words.w1 = (uintptr_t)rgba16buf;                            \
         _g1->words.w0 = _SHIFTL(uly, 16, 16) | _SHIFTL(ulx, 0, 16);      \
         _g1->words.w1 = _SHIFTL(height, 16, 16) | _SHIFTL(width, 0, 16); \
     }

--- a/src/graphic/Fast3D/gfx_direct3d11.cpp
+++ b/src/graphic/Fast3D/gfx_direct3d11.cpp
@@ -1030,7 +1030,7 @@ void gfx_d3d11_copy_framebuffer(int fb_dst_id, int fb_src_id, int srcX0, int src
     }
 }
 
-void gfx_d3d11_read_framebuffer_to_cpu(int fb_id, uint32_t width, uint32_t height, void* rgb_buf) {
+void gfx_d3d11_read_framebuffer_to_cpu(int fb_id, uint32_t width, uint32_t height, uint16_t* rgba16_buf) {
     if (fb_id >= (int)d3d.framebuffers.size()) {
         return;
     }
@@ -1085,7 +1085,7 @@ void gfx_d3d11_read_framebuffer_to_cpu(int fb_id, uint32_t width, uint32_t heigh
             uint8_t b = ((((pixel >> 16) & 0xFF) + 4) * 0x1F) / 0xFF;
             uint8_t a = ((pixel >> 24) & 0xFF) ? 1 : 0;
 
-            ((uint16_t*)rgb_buf)[i + (j * width)] = (r << 11) | (g << 6) | (b << 1) | a;
+            rgba16_buf[i + (j * width)] = (r << 11) | (g << 6) | (b << 1) | a;
         }
     }
 

--- a/src/graphic/Fast3D/gfx_gx2.cpp
+++ b/src/graphic/Fast3D/gfx_gx2.cpp
@@ -757,6 +757,10 @@ void gfx_gx2_copy_framebuffer(int fb_dst_id, int fb_src_id, int srcX0, int srcY0
     // TODO: Implement framebuffer texture copy
 }
 
+void gfx_gx2_read_framebuffer_to_cpu(int fb_id, uint32_t width, uint32_t height, void* rgb_buf) {
+    // TODO: Implement framebuffer copy to CPU
+}
+
 static std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff>
 gfx_gx2_get_pixel_depth(int fb_id, const std::set<std::pair<float, float>>& coordinates) {
     struct Framebuffer* buffer = (struct Framebuffer*)fb_id;
@@ -862,6 +866,7 @@ struct GfxRenderingAPI gfx_gx2_api = { gfx_gx2_get_name,
                                        gfx_gx2_start_draw_to_framebuffer,
                                        gfx_gx2_copy_framebuffer,
                                        gfx_gx2_clear_framebuffer,
+                                       gfx_gx2_read_framebuffer_to_cpu,
                                        gfx_gx2_resolve_msaa_color_buffer,
                                        gfx_gx2_get_pixel_depth,
                                        gfx_gx2_get_framebuffer_texture_id,

--- a/src/graphic/Fast3D/gfx_gx2.cpp
+++ b/src/graphic/Fast3D/gfx_gx2.cpp
@@ -757,7 +757,7 @@ void gfx_gx2_copy_framebuffer(int fb_dst_id, int fb_src_id, int srcX0, int srcY0
     // TODO: Implement framebuffer texture copy
 }
 
-void gfx_gx2_read_framebuffer_to_cpu(int fb_id, uint32_t width, uint32_t height, void* rgb_buf) {
+void gfx_gx2_read_framebuffer_to_cpu(int fb_id, uint32_t width, uint32_t height, uint16_t* rgba16_buf) {
     // TODO: Implement framebuffer copy to CPU
 }
 

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -1090,13 +1090,13 @@ void gfx_opengl_copy_framebuffer(int fb_dst_id, int fb_src_id, int srcX0, int sr
     glEnable(GL_SCISSOR_TEST);
 }
 
-void gfx_opengl_read_framebuffer_to_cpu(int fb_id, uint32_t width, uint32_t height, void* rgb_buf) {
+void gfx_opengl_read_framebuffer_to_cpu(int fb_id, uint32_t width, uint32_t height, uint16_t* rgba16_buf) {
     if (fb_id >= (int)framebuffers.size()) {
         return;
     }
 
     glBindFramebuffer(GL_FRAMEBUFFER, framebuffers[fb_id].fbo);
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_SHORT_5_5_5_1, rgb_buf);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_SHORT_5_5_5_1, (void*)rgba16_buf);
     glBindFramebuffer(GL_FRAMEBUFFER, framebuffers[current_framebuffer].fbo);
 }
 

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -1090,6 +1090,16 @@ void gfx_opengl_copy_framebuffer(int fb_dst_id, int fb_src_id, int srcX0, int sr
     glEnable(GL_SCISSOR_TEST);
 }
 
+void gfx_opengl_read_framebuffer_to_cpu(int fb_id, uint32_t width, uint32_t height, void* rgb_buf) {
+    if (fb_id >= (int)framebuffers.size()) {
+        return;
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, framebuffers[fb_id].fbo);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_SHORT_5_5_5_1, rgb_buf);
+    glBindFramebuffer(GL_FRAMEBUFFER, framebuffers[current_framebuffer].fbo);
+}
+
 static std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff>
 gfx_opengl_get_pixel_depth(int fb_id, const std::set<std::pair<float, float>>& coordinates) {
     std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff> res;
@@ -1196,6 +1206,7 @@ struct GfxRenderingAPI gfx_opengl_api = { gfx_opengl_get_name,
                                           gfx_opengl_start_draw_to_framebuffer,
                                           gfx_opengl_copy_framebuffer,
                                           gfx_opengl_clear_framebuffer,
+                                          gfx_opengl_read_framebuffer_to_cpu,
                                           gfx_opengl_resolve_msaa_color_buffer,
                                           gfx_opengl_get_pixel_depth,
                                           gfx_opengl_get_framebuffer_texture_id,

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -3304,17 +3304,18 @@ bool gfx_read_fb_handler_custom(Gfx** cmd0) {
     Gfx* cmd = *cmd0;
 
     int32_t width, height, ulx, uly;
-    void* rgbBuffer = (void*)cmd->words.w1;
+    uint16_t* rgba16Buffer = (uint16_t*)cmd->words.w1;
     int fbId = C0(0, 8);
     ++(*cmd0);
     cmd = *cmd0;
+    // Specifying the upper left origin value is unused and unsupported at the renderer level
     ulx = C0(0, 16);
     uly = C0(16, 16);
     width = C1(0, 16);
     height = C1(16, 16);
 
     gfx_flush();
-    gfx_rapi->read_framebuffer_to_cpu(fbId, width, height, rgbBuffer);
+    gfx_rapi->read_framebuffer_to_cpu(fbId, width, height, rgba16Buffer);
     return false;
 }
 

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2359,8 +2359,10 @@ static void gfx_dp_image_rectangle(int32_t tile, int32_t w, int32_t h, int32_t u
     g_rdp.texture_tile[tile].cmt = 0;
     g_rdp.texture_tile[tile].shifts = 0;
     g_rdp.texture_tile[tile].shiftt = 0;
-    g_rdp.texture_tile[tile].uls = 0;
-    g_rdp.texture_tile[tile].ult = 0;
+    g_rdp.texture_tile[tile].uls = 0 * 4;
+    g_rdp.texture_tile[tile].ult = 0 * 4;
+    g_rdp.texture_tile[tile].lrs = w * 4;
+    g_rdp.texture_tile[tile].lrt = h * 4;
     g_rdp.texture_tile[tile].line_size_bytes = w << (g_rdp.texture_tile[tile].siz >> 1);
 
     auto& loadtex = g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index];
@@ -3298,6 +3300,24 @@ bool gfx_copy_fb_handler_custom(Gfx** cmd0) {
     return false;
 }
 
+bool gfx_read_fb_handler_custom(Gfx** cmd0) {
+    Gfx* cmd = *cmd0;
+
+    int32_t width, height, ulx, uly;
+    void* rgbBuffer = (void*)cmd->words.w1;
+    int fbId = C0(0, 8);
+    ++(*cmd0);
+    cmd = *cmd0;
+    ulx = C0(0, 16);
+    uly = C0(16, 16);
+    width = C1(0, 16);
+    height = C1(16, 16);
+
+    gfx_flush();
+    gfx_rapi->read_framebuffer_to_cpu(fbId, width, height, rgbBuffer);
+    return false;
+}
+
 bool gfx_set_timg_fb_handler_custom(Gfx** cmd0) {
     Gfx* cmd = *cmd0;
 
@@ -3611,6 +3631,7 @@ const static std::unordered_map<uint32_t, GfxOpcodeHandlerFunc> otrHandlers = {
     { G_SETGRAYSCALE, gfx_set_grayscale_handler_custom },            // G_SETGRAYSCALE (0x39)
     { G_EXTRAGEOMETRYMODE, gfx_extra_geometry_mode_handler_custom }, // G_EXTRAGEOMETRYMODE (0x3a)
     { G_COPYFB, gfx_copy_fb_handler_custom },                        // G_COPYFB (0x3b)
+    { G_READFB, gfx_read_fb_handler_custom },                        // G_READFB (0x3e)
     { G_IMAGERECT, gfx_image_rect_handler_custom },                  // G_IMAGERECT (0x3c)
     { G_SETINTENSITY, gfx_set_intensity_handler_custom },            // G_SETINTENSITY (0x40)
 };

--- a/src/graphic/Fast3D/gfx_pc.h
+++ b/src/graphic/Fast3D/gfx_pc.h
@@ -222,7 +222,8 @@ void gfx_set_target_fps(int);
 void gfx_set_maximum_frame_latency(int latency);
 void gfx_texture_cache_delete(const uint8_t* orig_addr);
 extern "C" void gfx_texture_cache_clear();
-extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height);
+extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height,
+                                      uint8_t resize);
 void gfx_get_pixel_depth_prepare(float x, float y);
 uint16_t gfx_get_pixel_depth(float x, float y);
 void gfx_push_current_dir(char* path);

--- a/src/graphic/Fast3D/gfx_rendering_api.h
+++ b/src/graphic/Fast3D/gfx_rendering_api.h
@@ -61,7 +61,7 @@ struct GfxRenderingAPI {
     void (*copy_framebuffer)(int fb_dst_id, int fb_src_id, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0,
                              int dstY0, int dstX1, int dstY1);
     void (*clear_framebuffer)(void);
-    void (*read_framebuffer_to_cpu)(int fb_id, uint32_t width, uint32_t height, void* rgb_buf);
+    void (*read_framebuffer_to_cpu)(int fb_id, uint32_t width, uint32_t height, uint16_t* rgba16_buf);
     void (*resolve_msaa_color_buffer)(int fb_id_target, int fb_id_source);
     std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff> (*get_pixel_depth)(
         int fb_id, const std::set<std::pair<float, float>>& coordinates);

--- a/src/graphic/Fast3D/gfx_rendering_api.h
+++ b/src/graphic/Fast3D/gfx_rendering_api.h
@@ -61,6 +61,7 @@ struct GfxRenderingAPI {
     void (*copy_framebuffer)(int fb_dst_id, int fb_src_id, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0,
                              int dstY0, int dstX1, int dstY1);
     void (*clear_framebuffer)(void);
+    void (*read_framebuffer_to_cpu)(int fb_id, uint32_t width, uint32_t height, void* rgb_buf);
     void (*resolve_msaa_color_buffer)(int fb_id_target, int fb_id_source);
     std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff> (*get_pixel_depth)(
         int fb_id, const std::set<std::pair<float, float>>& coordinates);


### PR DESCRIPTION
This PR adds an opcode to instruct the render to copy/write a framebuffer's texture into a CPU buffer.
Currently this only supports and expects the buffer to be sized correctly as `uint16*` and will convert the texture data to RGBA16 (RGB components at 5 bytes, Alpha at 1 byte).

OpenGL conveniently supports being able to read pixel data into another format, so we get the conversion for free.
Metal required a shader/kernel function that performs the conversion and transfer to cpu, which is threaded using the thread group.
DirectX requires copying the texture to a staging texture, then mapping into to a CPU readable resource, then we can copy to buffers and perform the conversion externally from the GPU.

Metal additionally required that I force the command buffers to queue in the order that framebuffers are drawn to, so that the read operation is performed after we've actually drawn to the framebuffer that we want to read.

---

This is all to support getting the framebuffer data to the CPU for MM picto box. The picto box only deals with a framebuffer size of 320x240, so I've added the ability to control wether framebuffers should resize/scale based on the windows dimensions. The resize flag will prevent scaling the underlying texture as well as control the scissor box/viewport box at the renderer level.