### PR TITLE
Fix compute shader on Feature Level 10_0

### DIFF
--- a/src/graphic/Fast3D/gfx_direct3d11.cpp
+++ b/src/graphic/Fast3D/gfx_direct3d11.cpp
@@ -1169,7 +1169,10 @@ gfx_d3d11_get_pixel_depth(int fb_id, const std::set<std::pair<float, float>>& co
     }
 
     // ImGui overwrites these values, so we cannot set them once at init
-    d3d.context->CSSetShader(fb.msaa_level > 1 ? d3d.compute_shader_msaa.Get() : d3d.compute_shader.Get(), nullptr, 0);
+    d3d.context->CSSetShader(fb.msaa_level > 1 && d3d.feature_level >= D3D_FEATURE_LEVEL_10_1
+                                 ? d3d.compute_shader_msaa.Get()
+                                 : d3d.compute_shader.Get(),
+                             nullptr, 0);
     d3d.context->CSSetUnorderedAccessViews(0, 1, d3d.depth_value_output_uav.GetAddressOf(), nullptr);
 
     ThrowIfFailed(d3d.context->Map(d3d.coord_buffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &ms));


### PR DESCRIPTION
* Missed a condition, so compute shaders where disabled altogether if you tried to use MSAA on feature level 10_0 (Fixes an error in #375).
* Reduced the number of checks by simply setting the msaa_level variable to 1 if Feature Level is lower than 10_1.

This still doesn't fix the fact, that the GPU has to support Compute Shaders v4.0 (no MSAA) or v4.1 (MSAA) or it will still crash. This support is an optional feature on DX10.x GPUs.