### PR TITLE
revert HighDPI

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -295,13 +295,8 @@ void Gui::Update(WindowEvent event) {
         case WindowBackend::SDL_METAL:
             ImGui_ImplSDL2_ProcessEvent(static_cast<const SDL_Event*>(event.Sdl.Event));
 
-#ifdef __SWITCH__
-            // Switch doesn't support SDL_WINDOWEVENT_DISPLAY_CHANGED
-            if (mDpiInit) {
-#else
             if (static_cast<const SDL_Event*>(event.Sdl.Event)->window.event == SDL_WINDOWEVENT_DISPLAY_CHANGED ||
                 mDpiInit) {
-#endif
                 int display = 0;
                 if (Context::GetInstance()->GetWindow()->GetWindowBackend() == WindowBackend::SDL_OPENGL) {
                     display = SDL_GetWindowDisplayIndex(static_cast<SDL_Window*>(mImpl.Opengl.Window));

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -65,10 +65,6 @@ IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARA
 
 #endif
 
-#ifndef USER_DEFAULT_SCREEN_DPI
-#define USER_DEFAULT_SCREEN_DPI 96
-#endif
-
 namespace LUS {
 #define TOGGLE_BTN ImGuiKey_F1
 #define TOGGLE_PAD_BTN ImGuiKey_GamepadBack
@@ -283,8 +279,6 @@ void Gui::Update(WindowEvent event) {
         mNeedsConsoleVariableSave = false;
     }
 
-    float dpiScale = 0;
-
     switch (Context::GetInstance()->GetWindow()->GetWindowBackend()) {
 #ifdef __WIIU__
         case WindowBackend::GX2:
@@ -294,21 +288,6 @@ void Gui::Update(WindowEvent event) {
         case WindowBackend::SDL_OPENGL:
         case WindowBackend::SDL_METAL:
             ImGui_ImplSDL2_ProcessEvent(static_cast<const SDL_Event*>(event.Sdl.Event));
-
-            if (static_cast<const SDL_Event*>(event.Sdl.Event)->window.event == SDL_WINDOWEVENT_DISPLAY_CHANGED ||
-                mDpiInit) {
-                int display = 0;
-                if (Context::GetInstance()->GetWindow()->GetWindowBackend() == WindowBackend::SDL_OPENGL) {
-                    display = SDL_GetWindowDisplayIndex(static_cast<SDL_Window*>(mImpl.Opengl.Window));
-                } else {
-                    display = SDL_GetWindowDisplayIndex(static_cast<SDL_Window*>(mImpl.Metal.Window));
-                }
-
-                float dpi;
-                if (SDL_GetDisplayDPI(display, &dpi, nullptr, nullptr) == 0) {
-                    dpiScale = dpi / USER_DEFAULT_SCREEN_DPI;
-                }
-            }
 
 #ifdef __SWITCH__
             LUS::Switch::ImGuiProcessEvent(mImGuiIo->WantTextInput);
@@ -322,29 +301,10 @@ void Gui::Update(WindowEvent event) {
         case WindowBackend::DX11:
             ImGui_ImplWin32_WndProcHandler(static_cast<HWND>(event.Win32.Handle), event.Win32.Msg, event.Win32.Param1,
                                            event.Win32.Param2);
-
-            if (event.Win32.Msg == WM_DPICHANGED || mDpiInit) {
-                HMONITOR monitor = MonitorFromWindow(static_cast<HWND>(event.Win32.Handle), MONITOR_DEFAULTTONEAREST);
-                dpiScale = (float)ImGui_ImplWin32_GetDpiScaleForMonitor(monitor);
-            }
             break;
 #endif
         default:
             break;
-    }
-
-    if (dpiScale > 0) {
-        if (mDpiInit) {
-            mLastDpiScale = 1.f;
-            mDpiInit = false;
-        }
-
-        float diff = dpiScale / mLastDpiScale;
-        mLastDpiScale = dpiScale;
-
-        ImGui::GetStyle().ScaleAllSizes(diff);
-        ImFont* font = ImGui::GetFont();
-        font->Scale *= diff;
     }
 }
 
@@ -362,23 +322,11 @@ void Gui::UnblockImGuiGamepadNavigation() {
     }
 }
 
-float Gui::GetCurrentDpiScale() {
-    if (mLastDpiScale <= 0) {
-        return 1.f;
-    }
-
-    return mLastDpiScale;
-}
-
 void Gui::DrawMenu() {
     LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console")->Update();
     ImGuiBackendNewFrame();
     ImGuiWMNewFrame();
     ImGui::NewFrame();
-
-    if (mLastDpiScale == 0) {
-        mDpiInit = true;
-    }
 
     const std::shared_ptr<Window> wnd = Context::GetInstance()->GetWindow();
     const std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -92,7 +92,6 @@ class Gui {
     bool ImGuiGamepadNavigationEnabled();
     void BlockImGuiGamepadNavigation();
     void UnblockImGuiGamepadNavigation();
-    float GetCurrentDpiScale();
 
   protected:
     void ImGuiWMInit();
@@ -112,9 +111,6 @@ class Gui {
     std::shared_ptr<GuiMenuBar> mMenuBar;
     std::map<std::string, GuiTextureMetadata> mGuiTextures;
     std::map<std::string, std::shared_ptr<GuiWindow>> mGuiWindows;
-
-    bool mDpiInit = false;
-    float mLastDpiScale = 0;
 };
 } // namespace LUS
 


### PR DESCRIPTION
## Reverts
* https://github.com/Kenix3/libultraship/pull/501
* https://github.com/Kenix3/libultraship/pull/467

## Reasons

### Blocking reasons
* Mac is double scaled
* `USER_DEFAULT_SCREEN_DPI` being `96` is a windows-ism - causes blurry text on Linux
* Multiple viewports are not accounted for (dragging the check tracker window off onto a monitor with a different DPI)
  * I don't know a seamless way to handle this, but we should at least test/document any issues we find

### Non-blocking reasons
* SoH will need a full UI audit to ensure all controls still work

## Landing the reverted changes
* Write up a testing plan
  * For each thing we test
    * What behavior is expected
    * What behavior is experienced
* Go through testing results
  * For all places where expected behavior doesn't match experienced behavior
    * Figure out if a fix can/should happen on the LUS side
      * If so, decide if the fix is required or if it can be documented as a known issue
      * If not, document by creating an issue on on port repo where the unexpected behavior was experienced.