### PR TITLE
update `GameOverlay` to work when no external fonts have been loaded

### DIFF
--- a/src/window/gui/GameOverlay.cpp
+++ b/src/window/gui/GameOverlay.cpp
@@ -25,12 +25,12 @@ void GameOverlay::LoadFont(const std::string& name, const std::string& path, flo
     initData->ResourceVersion = 0;
     std::shared_ptr<Font> font = std::static_pointer_cast<Font>(
         Context::GetInstance()->GetResourceManager()->LoadResource(path, false, initData));
-    
+
     if (font == nullptr) {
         SPDLOG_ERROR("Failed to load font: {}", name);
-        return;   
+        return;
     }
-        
+
     mFonts[name] = io.Fonts->AddFontFromMemoryTTF(font->Data, font->DataSize, fontSize);
 }
 

--- a/src/window/gui/GameOverlay.h
+++ b/src/window/gui/GameOverlay.h
@@ -12,6 +12,10 @@
 
 namespace LUS {
 
+#ifndef CVAR_GAME_OVERLAY_FONT
+#define CVAR_GAME_OVERLAY_FONT "gOverlayFont"
+#endif
+
 enum class OverlayType { TEXT, IMAGE, NOTIFICATION };
 
 struct Overlay {
@@ -27,6 +31,8 @@ class GameOverlay {
     ~GameOverlay();
 
     void Init();
+    void LoadFont(const std::string& name, const std::string& path, float fontSize);
+    void SetCurrentFont(const std::string& name);
     void Draw();
     void DrawSettings();
     float GetStringWidth(const char* text);
@@ -47,6 +53,5 @@ class GameOverlay {
     bool mNeedsCleanup = false;
 
     void CleanupNotifications();
-    void LoadFont(const std::string& name, const std::string& path, float fontSize);
 };
 } // namespace LUS


### PR DESCRIPTION
Resolves https://github.com/Kenix3/libultraship/issues/481

see https://github.com/HarbourMasters/Shipwright/pull/4067 to see how this can be used