### PR TITLE
Add byteswap support to read framebuffer command

### DIFF
--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -2680,14 +2680,14 @@ typedef union {
     }
 
 // Read the framebuffer's texture to a cpu memory location as RGBA16
-#define gDPReadFB(pkt, src, rgba16buf, ulx, uly, width, height)          \
-    {                                                                    \
-        Gfx *_g0 = (Gfx*)(pkt), *_g1 = (Gfx*)(pkt);                      \
-                                                                         \
-        _g0->words.w0 = _SHIFTL(G_READFB, 24, 8) | _SHIFTL(src, 0, 8);   \
-        _g0->words.w1 = (uintptr_t)rgba16buf;                            \
-        _g1->words.w0 = _SHIFTL(uly, 16, 16) | _SHIFTL(ulx, 0, 16);      \
-        _g1->words.w1 = _SHIFTL(height, 16, 16) | _SHIFTL(width, 0, 16); \
+#define gDPReadFB(pkt, src, rgba16buf, ulx, uly, width, height, bswap)                        \
+    {                                                                                         \
+        Gfx *_g0 = (Gfx*)(pkt), *_g1 = (Gfx*)(pkt);                                           \
+                                                                                              \
+        _g0->words.w0 = _SHIFTL(G_READFB, 24, 8) | _SHIFTL(bswap, 8, 1) | _SHIFTL(src, 0, 8); \
+        _g0->words.w1 = (uintptr_t)rgba16buf;                                                 \
+        _g1->words.w0 = _SHIFTL(uly, 16, 16) | _SHIFTL(ulx, 0, 16);                           \
+        _g1->words.w1 = _SHIFTL(height, 16, 16) | _SHIFTL(width, 0, 16);                      \
     }
 
 #define gDPImageRectangle(pkt, x0, y0, s0, t0, x1, y1, s1, t1, tile, iw, ih) \

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -3306,6 +3306,7 @@ bool gfx_read_fb_handler_custom(Gfx** cmd0) {
     int32_t width, height, ulx, uly;
     uint16_t* rgba16Buffer = (uint16_t*)cmd->words.w1;
     int fbId = C0(0, 8);
+    bool bswap = C0(8, 1);
     ++(*cmd0);
     cmd = *cmd0;
     // Specifying the upper left origin value is unused and unsupported at the renderer level
@@ -3316,6 +3317,16 @@ bool gfx_read_fb_handler_custom(Gfx** cmd0) {
 
     gfx_flush();
     gfx_rapi->read_framebuffer_to_cpu(fbId, width, height, rgba16Buffer);
+
+#ifndef IS_BIGENDIAN
+    // byteswap the output to BE
+    if (bswap) {
+        for (size_t i = 0; i < width * height; i++) {
+            rgba16Buffer[i] = BE16SWAP(rgba16Buffer[i]);
+        }
+    }
+#endif
+
     return false;
 }
 


### PR DESCRIPTION
The read framebuffer command works great for getting framebuffer data back as RGBA16 for things that read the pixel data as u16.

However, when sending the resulting RGBA16 buffer back into F3D as a texture load, F3D assumes BigEndian and reads from the buffer as u8. For LittleEndian this means that colors would be incorrect.

This PR adds a flag to the command handler to force the buffer output into BigEndian when the data needs to be used by F3D at a later point.