### PR TITLE
Fix: Metal scissor box width calculation

### DIFF
--- a/src/graphic/Fast3D/gfx_metal.cpp
+++ b/src/graphic/Fast3D/gfx_metal.cpp
@@ -522,7 +522,7 @@ static void gfx_metal_set_scissor(int x, int y, int width, int height) {
     // clamp to viewport size as metal does not support larger values than viewport size
     fb.scissor_rect.x = std::max(0, std::min<int>(x, tex.width));
     fb.scissor_rect.y = std::max(0, std::min<int>(mctx.render_target_height - y - height, tex.height));
-    fb.scissor_rect.width = std::max(0, std::min<int>(x + width, tex.width));
+    fb.scissor_rect.width = std::max(0, std::min<int>(width, tex.width));
     fb.scissor_rect.height = std::max(0, std::min<int>(height, tex.height));
 
     fb.command_encoder->setScissorRect(fb.scissor_rect);


### PR DESCRIPTION
The scissor box for Metal was adding the x origin to the width as the width value, but should have just been using width by itself. This was causing the overall width to be larger than the viewport which is illegal (was tripping debug validation asserts).