### PR TITLE
Fix FPS deviation in DirectX

### DIFF
--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -701,13 +701,12 @@ static void gfx_dxgi_swap_buffers_begin(void) {
             li.QuadPart = -left;
             SetWaitableTimer(dxgi.timer, &li, 0, nullptr, nullptr, false);
             WaitForSingleObject(dxgi.timer, INFINITE);
-
-            do {
-                YieldProcessor();
-                QueryPerformanceCounter(&t);
-                t.QuadPart = qpc_to_100ns(t.QuadPart);
-            } while (t.QuadPart < next);
         }
+        do {
+            YieldProcessor();
+            QueryPerformanceCounter(&t);
+            t.QuadPart = qpc_to_100ns(t.QuadPart);
+        } while (t.QuadPart < next);
     }
     QueryPerformanceCounter(&t);
     dxgi.previous_present_time = t;


### PR DESCRIPTION
Bracket at the wrong place caused that some frames didn't wait until it was their turn. This had the result of trying to output more frames per second than asked for. Which then could cause the game to speed up or stutter. This was especially noticable on high FPS settings.