### PR TITLE
check for null controller mapping before assigning

### DIFF
--- a/src/controller/deviceindex/ShipDeviceIndexMappingManager.cpp
+++ b/src/controller/deviceindex/ShipDeviceIndexMappingManager.cpp
@@ -626,7 +626,9 @@ ShipDeviceIndexMappingManager::GetAllDeviceIndexMappingsFromConfig() {
     std::string mappingIdString;
     while (getline(mappingIdsStringStream, mappingIdString, ',')) {
         auto mapping = CreateDeviceIndexMappingFromConfig(mappingIdString);
-        mappings[mapping->GetShipDeviceIndex()] = mapping;
+        if (mapping != nullptr) {
+            mappings[mapping->GetShipDeviceIndex()] = mapping;
+        }
     }
 
     return mappings;


### PR DESCRIPTION
Since `CreateDeviceIndexMappingFromConfig` can return `null`, we need to check for null controller mapping before assigning.

This was exposed due to namespace changes, and the cvars from an old json had `LUSDeviceIndexToSDLDeviceIndexMapping` instead of `ShipXXX`, causing it to return null.