### PR TITLE
Reapply viewport and scissor when resetting back to the main framebuffer

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -3288,6 +3288,11 @@ bool gfx_reset_fb_handler_custom(Gfx** cmd0) {
     fbActive = 0;
     gfx_rapi->start_draw_to_framebuffer(game_renders_to_framebuffer ? game_framebuffer : 0,
                                         (float)gfx_current_dimensions.height / gfx_native_dimensions.height);
+    // Force viewport and scissor to reapply against the main framebuffer, in case a previous smaller
+    // framebuffer truncated the values
+    g_rdp.viewport_or_scissor_changed = true;
+    rendering_state.viewport = {};
+    rendering_state.scissor = {};
     return false;
 }
 


### PR DESCRIPTION
When changing to another framebuffer, especially one smaller than the main framebuffer, if the viewport/scissor is ever changed the rendering API may truncate the values to align with the smaller framebuffer. This can cause unintended clipping when switching back to the larger main framebuffer.

Setting `g_rdp.viewport_or_scissor_changed` to true and wiping out the current rendering state allows the next triangle draw to reapply the original viewport/scissor values again based on the main framebuffer size.

If more ports in the future do different things with switching framebuffers, we may want to consider tracking viewport values per framebuffer so that we can re-apply as needed.