### PR TITLE
Remove math related to macros

### DIFF
--- a/include/libultraship/libultra/convert.h
+++ b/include/libultraship/libultra/convert.h
@@ -9,10 +9,10 @@
 #define OS_CYCLES_TO_NSEC(c) (((u64)(c) * (1000000000LL / 15625000LL)) / (OS_CPU_COUNTER / 15625000LL))
 #define OS_CYCLES_TO_USEC(c) (((u64)(c) * (1000000LL / 15625LL)) / (OS_CPU_COUNTER / 15625LL))
 
-#define OS_K0_TO_PHYSICAL(x) (u32)(((char*)(x)-0x80000000))
-#define OS_K1_TO_PHYSICAL(x) (0) //(u32)(((char*)(x)-0xA0000000))
+#define OS_K0_TO_PHYSICAL(x) (x)
+#define OS_K1_TO_PHYSICAL(x) (x)
 
-#define OS_PHYSICAL_TO_K0(x) (void*)(((u32)(x) + 0x80000000))
-#define OS_PHYSICAL_TO_K1(x) (void*)(((u32)(x) + 0xA0000000))
+#define OS_PHYSICAL_TO_K0(x) (x)
+#define OS_PHYSICAL_TO_K1(x) (x)
 
 #endif


### PR DESCRIPTION
When including only this header the game will crash due to a u32 cast. These macros don't do anything on PC so just remove their logic.