### PR TITLE
use old `osSendMesg` and `osRecvMesg` implementations

### DIFF
--- a/src/public/libultra/os_mesg.cpp
+++ b/src/public/libultra/os_mesg.cpp
@@ -1,30 +1,17 @@
 #include "libultraship/libultraship.h"
 
-std::map<OSMesgQueue*, std::pair<std::shared_ptr<std::mutex>, std::shared_ptr<std::condition_variable>>>
-    __lusMesgLockMap;
-
 extern "C" {
 
 __OSEventState __osEventStateTab[OS_NUM_EVENTS] = { 0 };
 
-#define MQ_GET_COUNT(mq) ((mq)->validCount)
-#define MQ_IS_EMPTY(mq) (MQ_GET_COUNT(mq) == 0)
-#define MQ_IS_FULL(mq) (MQ_GET_COUNT(mq) >= (mq)->msgCount)
 
-#define MQ_MUTEX(mq) (*__lusMesgLockMap[mq].first)
-#define MQ_CVAR(mq) (*__lusMesgLockMap[mq].second)
 
 void osCreateMesgQueue(OSMesgQueue* mq, OSMesg* msgBuf, int32_t count) {
-
     mq->validCount = 0;
     mq->first = 0;
     mq->msgCount = count;
     mq->msg = msgBuf;
-
-    mq->mtqueue = nullptr;
-    mq->fullqueue = nullptr;
-
-    __lusMesgLockMap[mq] = std::make_pair(std::make_shared<std::mutex>(), std::make_shared<std::condition_variable>());
+    return;
 }
 
 int32_t osSendMesg(OSMesgQueue* mq, OSMesg msg, int32_t flag) {
@@ -40,28 +27,12 @@ int32_t osSendMesg(OSMesgQueue* mq, OSMesg msg, int32_t flag) {
 }
 
 int32_t osJamMesg(OSMesgQueue* mq, OSMesg msg, int32_t flag) {
-
-    // mq is not initialised by osCreateMesgQueue
-    if (!__lusMesgLockMap.contains(mq))
-        return -1;
-
-    std::unique_lock ul(MQ_MUTEX(mq));
-
-    while (MQ_IS_FULL(mq)) {
-        if (flag == OS_MESG_NOBLOCK) {
-            return -1;
-        }
-
-        // Wait for space in the queue.
-        MQ_CVAR(mq).wait(ul);
-    }
-
     mq->first = (mq->first + mq->msgCount - 1) % mq->msgCount;
     mq->msg[mq->first] = msg;
+    if (mq->validCount == 0) {
+        return -1;
+    }
     mq->validCount++;
-
-    // Wake threads waiting on this queue.
-    MQ_CVAR(mq).notify_all();
 
     return 0;
 }

--- a/src/public/libultra/os_mesg.cpp
+++ b/src/public/libultra/os_mesg.cpp
@@ -27,11 +27,12 @@ int32_t osSendMesg(OSMesgQueue* mq, OSMesg msg, int32_t flag) {
 }
 
 int32_t osJamMesg(OSMesgQueue* mq, OSMesg msg, int32_t flag) {
-    mq->first = (mq->first + mq->msgCount - 1) % mq->msgCount;
-    mq->msg[mq->first] = msg;
     if (mq->validCount == 0) {
         return -1;
     }
+
+    mq->first = (mq->first + mq->msgCount - 1) % mq->msgCount;
+    mq->msg[mq->first] = msg;
     mq->validCount++;
 
     return 0;

--- a/src/public/libultra/os_mesg.cpp
+++ b/src/public/libultra/os_mesg.cpp
@@ -4,8 +4,6 @@ extern "C" {
 
 __OSEventState __osEventStateTab[OS_NUM_EVENTS] = { 0 };
 
-
-
 void osCreateMesgQueue(OSMesgQueue* mq, OSMesg* msgBuf, int32_t count) {
     mq->validCount = 0;
     mq->first = 0;


### PR DESCRIPTION
https://github.com/Kenix3/libultraship/pull/493 updated these implementations and caused mutex hangs on soh, this just brings them back to their previous implementations