### PR TITLE
Fix gfx debugger with branch calls

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2935,7 +2935,7 @@ bool gfx_dl_otr_filepath_handler_custom(F3DGfx** cmd0) {
     } else {
         if (nDL != nullptr) {
             (*cmd0) = nDL;
-            g_exec_stack.branch(*cmd0);
+            g_exec_stack.branch(cmd);
             return true; // shortcut cmd increment
         } else {
             assert(0 && "???");
@@ -2965,7 +2965,7 @@ bool gfx_dl_handler_common(F3DGfx** cmd0) {
         }
     } else {
         (*cmd0) = subGFX;
-        g_exec_stack.branch(*cmd0);
+        g_exec_stack.branch(cmd);
         return true; // shortcut cmd increment
     }
     return false;
@@ -3008,7 +3008,7 @@ bool gfx_dl_index_handler(F3DGfx** cmd0) {
         }
     } else {
         (*cmd0) = subGFX;
-        g_exec_stack.branch(*cmd0);
+        g_exec_stack.branch(cmd);
         return true; // shortcut cmd increment
     }
     return false;
@@ -3023,6 +3023,7 @@ bool gfx_pushcd_handler_custom(F3DGfx** cmd0) {
 // TODO handle special OTR opcodes later...
 bool gfx_branch_z_otr_handler_f3dex2(F3DGfx** cmd0) {
     // Push return address
+    F3DGfx* cmd = (*cmd0);
 
     uint8_t vbidx = (uint8_t)((*cmd0)->words.w0 & 0x00000FFF);
     uint32_t zval = (uint32_t)((*cmd0)->words.w1);
@@ -3036,7 +3037,8 @@ bool gfx_branch_z_otr_handler_f3dex2(F3DGfx** cmd0) {
 
         if (gfx != 0) {
             (*cmd0) = gfx;
-            return true;
+            g_exec_stack.branch(cmd);
+            return true; // shortcut cmd increment
         }
     }
     return false;

--- a/src/window/gui/GfxDebuggerWindow.cpp
+++ b/src/window/gui/GfxDebuggerWindow.cpp
@@ -95,7 +95,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
 
             gfxd_input_buffer(input.data(), sizeof(uint32_t) * size * 2);
             gfxd_endian(gfxd_endian_host, sizeof(uint32_t));
-            char buff[256] = { 0 };
+            char buff[512] = { 0 };
             gfxd_output_buffer(buff, sizeof(buff));
             gfxd_enable(gfxd_emit_dec_color);
             gfxd_target(gfxd_f3dex2);


### PR DESCRIPTION
In #503 I fixed an actual issue with DL Branch causing infinite render loops. In that commit I also changed the argument passed into `g_exec_stack.branch()` which ended up breaking the gfx debugger. After digging into it, the argument passed into this function should be specifically the _caller_ command instruction. Before it was sometimes correct, sometimes not. Now all instances will receive the correct called instruction.

I also added a missing `g_exec_stack.branch` for BRANCH_Z instructions.

Also increased the line buffer size in the gfx debugger to 512 to account for the rare commands that are really long (usually SetOtherMode)