### PR TITLE
Only include relevant headers for gu

### DIFF
--- a/include/libultraship/libultra/gu.h
+++ b/include/libultraship/libultra/gu.h
@@ -1,7 +1,8 @@
 #ifndef ULTRA64_GU_H
 #define ULTRA64_GU_H
 
-#include "../libultraship.h"
+#include "types.h"
+#include "gbi.h"
 #include "sptask.h"
 
 #define GU_PI 3.1415926


### PR DESCRIPTION
This header was importing the "global" libultraship header, which has different side effects when imported from a .cpp file (starts to include all of the LUS classes).

I've updated this to only directly include the the headers it depends on, which also resolves any issues when this header is included from .cpp


SoH PR demo https://github.com/HarbourMasters/Shipwright/pull/4137