### PR TITLE
Fixed shader_ids getting cleaned up by accident

### DIFF
--- a/src/graphic/Fast3D/gfx_cc.cpp
+++ b/src/graphic/Fast3D/gfx_cc.cpp
@@ -4,24 +4,24 @@ void gfx_cc_get_features(uint64_t shader_id0, uint32_t shader_id1, struct CCFeat
     for (int i = 0; i < 2; i++) {
         for (int j = 0; j < 2; j++) {
             for (int k = 0; k < 4; k++) {
-                cc_features->c[i][j][k] = (shader_id0 >> (i * 32 + j * 16 + k * 4)) & 0xf;
+                cc_features->c[i][j][k] = shader_id0 >> i * 32 + j * 16 + k * 4 & 0xf;
             }
         }
     }
 
-    cc_features->opt_alpha = (shader_id1 & SHADER_OPT_ALPHA) != 0;
-    cc_features->opt_fog = (shader_id1 & SHADER_OPT_FOG) != 0;
-    cc_features->opt_texture_edge = (shader_id1 & SHADER_OPT_TEXTURE_EDGE) != 0;
-    cc_features->opt_noise = (shader_id1 & SHADER_OPT_NOISE) != 0;
-    cc_features->opt_2cyc = (shader_id1 & SHADER_OPT_2CYC) != 0;
-    cc_features->opt_alpha_threshold = (shader_id1 & SHADER_OPT_ALPHA_THRESHOLD) != 0;
-    cc_features->opt_invisible = (shader_id1 & SHADER_OPT_INVISIBLE) != 0;
-    cc_features->opt_grayscale = (shader_id1 & SHADER_OPT_GRAYSCALE) != 0;
+    cc_features->opt_alpha = (shader_id1 & SHADER_OPT(ALPHA)) != 0;
+    cc_features->opt_fog = (shader_id1 & SHADER_OPT(FOG)) != 0;
+    cc_features->opt_texture_edge = (shader_id1 & SHADER_OPT(TEXTURE_EDGE)) != 0;
+    cc_features->opt_noise = (shader_id1 & SHADER_OPT(NOISE)) != 0;
+    cc_features->opt_2cyc = (shader_id1 & SHADER_OPT(_2CYC)) != 0;
+    cc_features->opt_alpha_threshold = (shader_id1 & SHADER_OPT(ALPHA_THRESHOLD)) != 0;
+    cc_features->opt_invisible = (shader_id1 & SHADER_OPT(INVISIBLE)) != 0;
+    cc_features->opt_grayscale = (shader_id1 & SHADER_OPT(GRAYSCALE)) != 0;
 
-    cc_features->clamp[0][0] = (shader_id1 & SHADER_OPT_TEXEL0_CLAMP_S);
-    cc_features->clamp[0][1] = (shader_id1 & SHADER_OPT_TEXEL0_CLAMP_T);
-    cc_features->clamp[1][0] = (shader_id1 & SHADER_OPT_TEXEL1_CLAMP_S);
-    cc_features->clamp[1][1] = (shader_id1 & SHADER_OPT_TEXEL1_CLAMP_T);
+    cc_features->clamp[0][0] = shader_id1 & SHADER_OPT(TEXEL0_CLAMP_S);
+    cc_features->clamp[0][1] = shader_id1 & SHADER_OPT(TEXEL0_CLAMP_T);
+    cc_features->clamp[1][0] = shader_id1 & SHADER_OPT(TEXEL1_CLAMP_S);
+    cc_features->clamp[1][1] = shader_id1 & SHADER_OPT(TEXEL1_CLAMP_T);
 
     cc_features->used_textures[0] = false;
     cc_features->used_textures[1] = false;
@@ -56,21 +56,20 @@ void gfx_cc_get_features(uint64_t shader_id0, uint32_t shader_id1, struct CCFeat
         cc_features->do_multiply[c][1] = cc_features->c[c][1][1] == SHADER_0 && cc_features->c[c][1][3] == SHADER_0;
         cc_features->do_mix[c][0] = cc_features->c[c][0][1] == cc_features->c[c][0][3];
         cc_features->do_mix[c][1] = cc_features->c[c][1][1] == cc_features->c[c][1][3];
-        cc_features->color_alpha_same[c] =
-            ((shader_id0 >> c * 32) & 0xffff) == ((shader_id0 >> (c * 32 + 16)) & 0xffff);
+        cc_features->color_alpha_same[c] = (shader_id0 >> c * 32 & 0xffff) == (shader_id0 >> c * 32 + 16 & 0xffff);
     }
 
-    if (cc_features->used_textures[0] && (shader_id1 & SHADER_OPT_TEXEL0_MASK)) {
+    if (cc_features->used_textures[0] && shader_id1 & SHADER_OPT(TEXEL0_MASK)) {
         cc_features->used_masks[0] = true;
     }
-    if (cc_features->used_textures[1] && (shader_id1 & SHADER_OPT_TEXEL1_MASK)) {
+    if (cc_features->used_textures[1] && shader_id1 & SHADER_OPT(TEXEL1_MASK)) {
         cc_features->used_masks[1] = true;
     }
 
-    if (cc_features->used_textures[0] && (shader_id1 & SHADER_OPT_TEXEL0_BLEND)) {
+    if (cc_features->used_textures[0] && shader_id1 & SHADER_OPT(TEXEL0_BLEND)) {
         cc_features->used_blend[0] = true;
     }
-    if (cc_features->used_textures[1] && (shader_id1 & SHADER_OPT_TEXEL1_BLEND)) {
+    if (cc_features->used_textures[1] && shader_id1 & SHADER_OPT(TEXEL1_BLEND)) {
         cc_features->used_blend[1] = true;
     }
 }

--- a/src/graphic/Fast3D/gfx_cc.h
+++ b/src/graphic/Fast3D/gfx_cc.h
@@ -37,22 +37,29 @@ enum {
     SHADER_NOISE
 };
 
-#define SHADER_OPT_ALPHA (1 << 0)
-#define SHADER_OPT_FOG (1 << 1)
-#define SHADER_OPT_TEXTURE_EDGE (1 << 2)
-#define SHADER_OPT_NOISE (1 << 3)
-#define SHADER_OPT_2CYC (1 << 4)
-#define SHADER_OPT_ALPHA_THRESHOLD (1 << 5)
-#define SHADER_OPT_INVISIBLE (1 << 6)
-#define SHADER_OPT_GRAYSCALE (1 << 7)
-#define SHADER_OPT_TEXEL0_CLAMP_S (1 << 8)
-#define SHADER_OPT_TEXEL0_CLAMP_T (1 << 9)
-#define SHADER_OPT_TEXEL1_CLAMP_S (1 << 10)
-#define SHADER_OPT_TEXEL1_CLAMP_T (1 << 11)
-#define SHADER_OPT_TEXEL0_MASK (1 << 12)
-#define SHADER_OPT_TEXEL1_MASK (1 << 13)
-#define SHADER_OPT_TEXEL0_BLEND (1 << 14)
-#define SHADER_OPT_TEXEL1_BLEND (1 << 15)
+#ifdef __cplusplus
+enum class ShaderOpts {
+    ALPHA,
+    FOG,
+    TEXTURE_EDGE,
+    NOISE,
+    _2CYC,
+    ALPHA_THRESHOLD,
+    INVISIBLE,
+    GRAYSCALE,
+    TEXEL0_CLAMP_S,
+    TEXEL0_CLAMP_T,
+    TEXEL1_CLAMP_S,
+    TEXEL1_CLAMP_T,
+    TEXEL0_MASK,
+    TEXEL1_MASK,
+    TEXEL0_BLEND,
+    TEXEL1_BLEND,
+    MAX
+};
+
+#define SHADER_OPT(opt) ((uint64_t)(1 << static_cast<int>(ShaderOpts::opt)))
+#endif
 
 struct ColorCombinerKey {
     uint64_t combine_mode;

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -249,7 +249,7 @@ static const char* acmux_to_string(uint32_t acmux) {
 }
 
 static void gfx_generate_cc(struct ColorCombiner* comb, const ColorCombinerKey& key) {
-    bool is_2cyc = (key.options & (uint64_t)SHADER_OPT_2CYC) != 0;
+    bool is_2cyc = (key.options & SHADER_OPT(_2CYC)) != 0;
 
     uint8_t c[2][2][4];
     uint64_t shader_id0 = 0;
@@ -1459,50 +1459,50 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
     }
 
     if (use_alpha) {
-        cc_options |= (uint64_t)SHADER_OPT_ALPHA;
+        cc_options |= SHADER_OPT(ALPHA);
     }
     if (use_fog) {
-        cc_options |= (uint64_t)SHADER_OPT_FOG;
+        cc_options |= SHADER_OPT(FOG);
     }
     if (texture_edge) {
-        cc_options |= (uint64_t)SHADER_OPT_TEXTURE_EDGE;
+        cc_options |= SHADER_OPT(TEXTURE_EDGE);
     }
     if (use_noise) {
-        cc_options |= (uint64_t)SHADER_OPT_NOISE;
+        cc_options |= SHADER_OPT(NOISE);
     }
     if (use_2cyc) {
-        cc_options |= (uint64_t)SHADER_OPT_2CYC;
+        cc_options |= SHADER_OPT(_2CYC);
     }
     if (alpha_threshold) {
-        cc_options |= (uint64_t)SHADER_OPT_ALPHA_THRESHOLD;
+        cc_options |= SHADER_OPT(ALPHA_THRESHOLD);
     }
     if (invisible) {
-        cc_options |= (uint64_t)SHADER_OPT_INVISIBLE;
+        cc_options |= SHADER_OPT(INVISIBLE);
     }
     if (use_grayscale) {
-        cc_options |= (uint64_t)SHADER_OPT_GRAYSCALE;
+        cc_options |= SHADER_OPT(GRAYSCALE);
     }
     if (g_rdp.loaded_texture[0].masked) {
-        cc_options |= (uint64_t)SHADER_OPT_TEXEL0_MASK;
+        cc_options |= SHADER_OPT(TEXEL0_MASK);
     }
     if (g_rdp.loaded_texture[1].masked) {
-        cc_options |= (uint64_t)SHADER_OPT_TEXEL1_MASK;
+        cc_options |= SHADER_OPT(TEXEL1_MASK);
     }
     if (g_rdp.loaded_texture[0].blended) {
-        cc_options |= (uint64_t)SHADER_OPT_TEXEL0_BLEND;
+        cc_options |= SHADER_OPT(TEXEL0_BLEND);
     }
     if (g_rdp.loaded_texture[1].blended) {
-        cc_options |= (uint64_t)SHADER_OPT_TEXEL1_BLEND;
-    }
-
-    // If we are not using alpha, clear the alpha components of the combiner as they have no effect
-    if (!use_alpha) {
-        cc_options &= ~((0xfff << 16) | ((uint64_t)0xfff << 44));
+        cc_options |= SHADER_OPT(TEXEL1_BLEND);
     }
 
     ColorCombinerKey key;
     key.combine_mode = g_rdp.combine_mode;
     key.options = cc_options;
+
+    // If we are not using alpha, clear the alpha components of the combiner as they have no effect
+    if (!use_alpha) {
+        key.combine_mode &= ~((0xfff << 16) | ((uint64_t)0xfff << 44));
+    }
 
     ColorCombiner* comb = gfx_lookup_or_create_color_combiner(key);
 
@@ -1587,7 +1587,7 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
     struct ShaderProgram* prg = comb->prg[tm];
     if (prg == NULL) {
         comb->prg[tm] = prg =
-            gfx_lookup_or_create_shader_program(comb->shader_id0, comb->shader_id1 | (tm * SHADER_OPT_TEXEL0_CLAMP_S));
+            gfx_lookup_or_create_shader_program(comb->shader_id0, comb->shader_id1 | tm * SHADER_OPT(TEXEL0_CLAMP_S));
     }
     if (prg != rendering_state.shader_program) {
         gfx_flush();


### PR DESCRIPTION
This PRs fixes the shader_ids getting cleaned if its above (1 >> 15), and cleans them up a little bit