### PR TITLE
PR for tracking f3dex progress

### DIFF
--- a/include/libultraship/libultra/gs2dex.h
+++ b/include/libultraship/libultra/gs2dex.h
@@ -371,9 +371,6 @@ extern void guS2DInitBg(uObjBg*);
 #define guS2DEmuSetScissor guS2D2EmuSetScissor /*Wrapper*/
 extern void guS2D2EmuSetScissor(u32, u32, u32, u32, u8);
 extern void guS2D2EmuBgRect1Cyc(Gfx**, uObjBg*);
-#else
-extern void guS2DEmuSetScissor(u32, u32, u32, u32, u8);
-extern void guS2DEmuBgRect1Cyc(F3DGfx**, uObjBg*);
 #endif
 
 #ifdef _LANGUAGE_C_PLUS_PLUS

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -148,7 +148,7 @@ struct MaskedTextureEntry {
 
 static map<string, MaskedTextureEntry> masked_textures;
 
-static UcodeHandlers ucode_handler_index = ucode_f3dex2;
+static UcodeHandlers ucode_handler_index = ucode_f3dex;
 
 const static std::unordered_map<Attribute, std::any> f3dex2AttrHandler = {
     { MTX_PROJECTION, F3DEX2_G_MTX_PROJECTION }, { MTX_LOAD, F3DEX2_G_MTX_LOAD },     { MTX_PUSH, F3DEX2_G_MTX_PUSH },
@@ -3791,7 +3791,7 @@ const char* GfxGetOpcodeName(int8_t opcode) {
         if (ucode_handlers[ucode_handler_index]->contains(opcode)) {
             return ucode_handlers[ucode_handler_index]->at(opcode).first;
         } else {
-            SPDLOG_CRITICAL("Unhandled OP code: {}, for loaded ucode: {}", opcode, (uint32_t)ucode_handler_index);
+            SPDLOG_CRITICAL("Unhandled OP code: 0x{:X}, for loaded ucode: {}", opcode, (uint32_t)ucode_handler_index);
             return nullptr;
         }
     }
@@ -3809,6 +3809,9 @@ static void gfx_step() {
     auto& cmd = g_exec_stack.currCmd();
     auto cmd0 = cmd;
     int8_t opcode = (int8_t)(cmd->words.w0 >> 24);
+
+            SPDLOG_INFO("Trace File: {}", cmd->words.trace.file);
+        SPDLOG_INFO("Trace Line: {}", cmd->words.trace.idx);
 
     if (opcode == F3DEX2_G_LOAD_UCODE) {
         gfx_set_ucode_handler((UcodeHandlers)(cmd->words.w0 & 0xFFFFFF));
@@ -3831,7 +3834,7 @@ static void gfx_step() {
                 return;
             }
         } else {
-            SPDLOG_CRITICAL("Unhandled OP code: {}, for loaded ucode: {}", opcode, (uint32_t)ucode_handler_index);
+            SPDLOG_CRITICAL("Unhandled OP code: 0x{:X}, for loaded ucode: {}", opcode, (uint32_t)ucode_handler_index);
         }
     }
 
@@ -3881,7 +3884,7 @@ void gfx_init(struct GfxWindowManagerAPI* wapi, struct GfxRenderingAPI* rapi, co
         tex_upload_buffer = (uint8_t*)malloc(max_tex_size * max_tex_size * 4);
     }
 
-    ucode_handler_index = UcodeHandlers::ucode_f3dex2;
+    ucode_handler_index = UcodeHandlers::ucode_f3dex;
 }
 
 void gfx_destroy(void) {

--- a/src/graphic/Fast3D/lus_gbi.h
+++ b/src/graphic/Fast3D/lus_gbi.h
@@ -1109,16 +1109,23 @@ typedef union {
     long int force_structure_alignment[4];
 } F3DHilite;
 
+typedef struct {
+    const char* file;
+    int idx;
+    bool valid;
+} Tracet;
+
 /*
  * Generic Gfx Packet
  */
 typedef struct {
     uintptr_t w0;
     uintptr_t w1;
+    Tracet trace;
 } F3DGwords;
 
 #ifdef __cplusplus
-static_assert(sizeof(F3DGwords) == 2 * sizeof(void*), "Display list size is bad");
+//static_assert(sizeof(F3DGwords) == 2 * sizeof(void*), "Display list size is bad");
 #endif
 
 /*


### PR DESCRIPTION
Notable issues:

F3DEX is not really working right now. `f3dex.h` and `gbi.h` have multiple issues: syntax, include errors, etc.

Is `F3DGfx` a necessary struct? There's not really any diff between Gfx and F3DGfx. I would imagine it's more difficult to work with two structs.

gbi.h:
* Whole file is behind f3dex2 `#ifdef`
* Not really a way to enable f3dex without deleting f3dex2 op codes since f3dex macros are stripped out.
* `gDPSetTextureImage` defined as `__gDPSetTextureImage`
* `#define G_GEOMETRYMODE 0xd9` required despite it not being used in f3dex.

gs2dex.h:
* These two functions result in F3DGfx** not defined error:
```
extern void guS2DEmuSetScissor(u32, u32, u32, u32, u8);
extern void guS2DEmuBgRect1Cyc(F3DGfx**, uObjBg*);
```

gfx_pc.cpp
* Not really a way to change the ucode atm without modifying the repo directly.
`static UcodeHandlers ucode_handler_index = ucode_f3dex;`

DisplaylistFactory.cpp
* File name conflicts with Torch's `DisplaylistFactory.cpp`
    * Could consider renaming it to something like DListFactory