### PR TITLE
Config and ConsoleVariable Updates

### DIFF
--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -130,6 +130,39 @@ void Config::Erase(const std::string& key) {
     mFlattenedJson.erase(FormatNestedKey(key));
 }
 
+void Config::EraseBlock(const std::string& key) {
+    nlohmann::json gjson = mFlattenedJson.unflatten();
+    if (key.find(".") != std::string::npos) {
+        nlohmann::json& gjson2 = gjson;
+        std::vector<std::string> dots = StringHelper::Split(key, ".");
+        if (dots.size() > 1) {
+            int curDot = 0;
+            for (auto& dot : dots) {
+                if (gjson2.contains(dot)) {
+                    if (curDot == dots.size()) {
+                        gjson2.erase(dot);
+                    } else {
+                        gjson2 = gjson2[dot].items();
+                    }
+                }
+            }
+        }
+    } else {
+        if (gjson.contains(key)) {
+            gjson.erase(key);
+        }
+    }
+    mFlattenedJson = gjson.flatten();
+}
+
+void Config::Copy(const std::string& fromKey, const std::string& toKey) {
+    auto nestedFromKey = FormatNestedKey(fromKey);
+    auto nestedToKey = FormatNestedKey(toKey);
+    if (mFlattenedJson.contains(nestedFromKey)) {
+        mFlattenedJson[nestedToKey] = mFlattenedJson[nestedFromKey];
+    }
+}
+
 void Config::Reload() {
     if (mPath == "None" || !fs::exists(mPath) || !fs::is_regular_file(mPath)) {
         mIsNewInstance = true;

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -142,7 +142,7 @@ void Config::EraseBlock(const std::string& key) {
                     if (curDot == dots.size()) {
                         gjson2.erase(dot);
                     } else {
-                        gjson2 = gjson2[dot].items();
+                        gjson2 = gjson2[dot];
                     }
                 }
             }

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -56,6 +56,8 @@ class Config {
     void SetInt(const std::string& key, int32_t value);
     void SetUInt(const std::string& key, uint32_t value);
     void Erase(const std::string& key);
+    void EraseBlock(const std::string& key);
+    void Copy(const std::string& fromKey, const std::string& toKey);
     bool Contains(const std::string& key);
     void Reload();
     void Save();

--- a/src/config/ConsoleVariable.cpp
+++ b/src/config/ConsoleVariable.cpp
@@ -168,8 +168,7 @@ void ConsoleVariable::ClearVariable(const char* name) {
     std::shared_ptr<Config> conf = Ship::Context::GetInstance()->GetConfig();
     auto var = Get(name);
     if (var != nullptr) {
-        bool color = var->Type == ConsoleVariableType::Color ||
-                     var->Type == ConsoleVariableType::Color24;
+        bool color = var->Type == ConsoleVariableType::Color || var->Type == ConsoleVariableType::Color24;
         if (color) {
             std::string a = StringHelper::Sprintf("%s.%s", name, "A");
             std::string b = StringHelper::Sprintf("%s.%s", name, "B");

--- a/src/config/ConsoleVariable.h
+++ b/src/config/ConsoleVariable.h
@@ -46,6 +46,8 @@ class ConsoleVariable {
     void RegisterColor24(const char* name, Color_RGB8 defaultValue);
 
     void ClearVariable(const char* name);
+    void ClearBlock(const char* name);
+    void CopyVariable(const char* from, const char* to);
 
     void Save();
     void Load();

--- a/src/public/bridge/consolevariablebridge.cpp
+++ b/src/public/bridge/consolevariablebridge.cpp
@@ -70,6 +70,14 @@ void CVarClear(const char* name) {
     Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(name);
 }
 
+void CVarClearBlock(const char* name) {
+    Ship::Context::GetInstance()->GetConsoleVariables()->ClearBlock(name);
+}
+
+void CVarCopy(const char* from, const char* to) {
+    Ship::Context::GetInstance()->GetConsoleVariables()->CopyVariable(from, to);
+}
+
 void CVarLoad() {
     Ship::Context::GetInstance()->GetConsoleVariables()->Load();
 }

--- a/src/public/bridge/consolevariablebridge.h
+++ b/src/public/bridge/consolevariablebridge.h
@@ -33,6 +33,9 @@ void CVarRegisterColor(const char* name, Color_RGBA8 defaultValue);
 void CVarRegisterColor24(const char* name, Color_RGB8 defaultValue);
 
 void CVarClear(const char* name);
+bool CVarExists(const char* name);
+void CVarClearBlock(const char* name);
+void CVarCopy(const char* from, const char* to);
 
 void CVarLoad();
 void CVarSave();


### PR DESCRIPTION
Adds `EraseBlock` and `Copy` to `Ship::Config`, with ConsoleVariable versions and bridges. This allows the removal of root config values and CVars that have sub-objects, and direct-copy config values and CVars without needing types or defaults.

Modifies CVarClear to make it capable of deleting a whole Color or Color24 block rather than needing to call `CVarClear` on each individual subvalue.

Removes size check from String type saving to allow for blank strings to be saved. `CVarSetString` never ignored it, this shouldn't either.

Sets `ConsoleVariable::Load` to clear `mVariables` if it's not empty when loading from Config. Trying to remove any possible CVar bleed in the future.