### PR TITLE
Clearer errors in ResourceLoader.cpp

### DIFF
--- a/src/resource/ResourceLoader.cpp
+++ b/src/resource/ResourceLoader.cpp
@@ -58,7 +58,7 @@ std::string ResourceLoader::DecodeASCII(uint32_t value) {
 std::shared_ptr<ResourceFactory> ResourceLoader::GetFactory(uint32_t format, uint32_t type, uint32_t version) {
     ResourceFactoryKey key{ .resourceFormat = format, .resourceType = type, .resourceVersion = version };
     if (!mFactories.contains(key)) {
-        SPDLOG_ERROR("GetFactory failed find an import factory for resource of type {} as hex: 0x{:X}. Format: {}, Version: {}",
+        SPDLOG_ERROR("GetFactory failed to find an import factory for resource of type {} as hex: 0x{:X}. Format: {}, Version: {}",
                      DecodeASCII(type), type, format, version);
         return nullptr;
     }

--- a/src/resource/ResourceLoader.cpp
+++ b/src/resource/ResourceLoader.cpp
@@ -44,10 +44,22 @@ bool ResourceLoader::RegisterResourceFactory(std::shared_ptr<ResourceFactory> fa
     return true;
 }
 
+std::string ResourceLoader::DecodeASCII(uint32_t value) {
+    std::string str(4, '\0'); // Initialize the string with 4 null characters
+
+    str[0] = (value >> 24) & 0xFF;
+    str[1] = (value >> 16) & 0xFF;
+    str[2] = (value >> 8) & 0xFF;
+    str[3] = value & 0xFF;
+
+    return str;
+}
+
 std::shared_ptr<ResourceFactory> ResourceLoader::GetFactory(uint32_t format, uint32_t type, uint32_t version) {
     ResourceFactoryKey key{ .resourceFormat = format, .resourceType = type, .resourceVersion = version };
     if (!mFactories.contains(key)) {
-        SPDLOG_ERROR("Could not find resource factory with key {}{}{}", format, type, version);
+        SPDLOG_ERROR("GetFactory failed find an import factory for resource of type {} as hex: 0x{:X}. Format: {}, Version: {}",
+                     DecodeASCII(type), type, format, version);
         return nullptr;
     }
 
@@ -77,13 +89,7 @@ std::shared_ptr<Ship::IResource> ResourceLoader::LoadResource(std::shared_ptr<Sh
     auto factory =
         GetFactory(fileToLoad->InitData->Format, fileToLoad->InitData->Type, fileToLoad->InitData->ResourceVersion);
     if (factory == nullptr) {
-        SPDLOG_ERROR("Failed to load resource: Factory does not exist.\n"
-                     "Path: {}\n"
-                     "Type: {}\n"
-                     "Format: {}\n"
-                     "Version: {}",
-                     fileToLoad->InitData->Path, fileToLoad->InitData->Type, fileToLoad->InitData->Format,
-                     fileToLoad->InitData->ResourceVersion);
+        SPDLOG_ERROR("LoadResource failed to find factory for the resource at path: {}", fileToLoad->InitData->Path);
         return nullptr;
     }
 

--- a/src/resource/ResourceLoader.cpp
+++ b/src/resource/ResourceLoader.cpp
@@ -58,7 +58,8 @@ std::string ResourceLoader::DecodeASCII(uint32_t value) {
 std::shared_ptr<ResourceFactory> ResourceLoader::GetFactory(uint32_t format, uint32_t type, uint32_t version) {
     ResourceFactoryKey key{ .resourceFormat = format, .resourceType = type, .resourceVersion = version };
     if (!mFactories.contains(key)) {
-        SPDLOG_ERROR("GetFactory failed to find an import factory for resource of type {} as hex: 0x{:X}. Format: {}, Version: {}",
+        SPDLOG_ERROR("GetFactory failed to find an import factory for resource of type {} as hex: 0x{:X}. Format: {}, "
+                     "Version: {}",
                      DecodeASCII(type), type, format, version);
         return nullptr;
     }

--- a/src/resource/ResourceLoader.h
+++ b/src/resource/ResourceLoader.h
@@ -44,6 +44,7 @@ class ResourceLoader {
     std::shared_ptr<ResourceFactory> GetFactory(uint32_t format, std::string typeName, uint32_t version);
 
   private:
+    std::string DecodeASCII(uint32_t value);
     std::unordered_map<std::string, uint32_t> mResourceTypes;
     std::unordered_map<ResourceFactoryKey, std::shared_ptr<ResourceFactory>, ResourceFactoryKeyHash> mFactories;
 };


### PR DESCRIPTION
We might not need to output str and hex for type. Not really sure if both is helpful or not.

![image](https://github.com/Kenix3/libultraship/assets/7255464/60d5df80-9f88-44cf-bfc7-4b98020902d0)
Note that the grammar issue in the screenshot has been fixed.