### PR TITLE
fix a couple issues with handling controller connect/disconnect events

### DIFF
--- a/src/controller/controldevice/controller/mapping/sdl/SDLMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLMapping.cpp
@@ -45,11 +45,15 @@ bool SDLMapping::CloseController() {
     return true;
 }
 
-bool SDLMapping::ControllerLoaded() {
+bool SDLMapping::ControllerLoaded(bool closeIfDisconnected) {
     SDL_GameControllerUpdate();
 
-    // If the controller is disconnected, close it.
+    // If the controller is disconnected
     if (mController != nullptr && !SDL_GameControllerGetAttached(mController)) {
+        if (!closeIfDisconnected) {
+            return false;
+        }
+
         CloseController();
     }
 

--- a/src/controller/controldevice/controller/mapping/sdl/SDLMapping.h
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLMapping.h
@@ -17,7 +17,7 @@ class SDLMapping : public ControllerMapping {
     int32_t GetJoystickInstanceId();
     int32_t GetCurrentSDLDeviceIndex();
     bool CloseController();
-    bool ControllerLoaded();
+    bool ControllerLoaded(bool closeIfDisconnected = false);
 
   protected:
     SDL_GameControllerType GetSDLControllerType();


### PR DESCRIPTION
### issue 1: disconnecting

prior to this PR, there were times when disconnecting a controller would result in an invalid joystick instance id, meaning we didn't know which controller was disconnected. after a bit of investigation i found that the sdl controller on the mapping was already closed and a null pointer. this was because `ControllerLoaded` was being called in quite a few places, namely when getting the controller name to display on the mapping window, and had logic to close the controller when sdl reported it as disconnected. in the case that those draw calls from imgui led down that path before the sdl event was handled, we entered the controller disconnect handler without an sdl controller on the mappings.

i updated `ControllerLoaded` to take in `closeIfDisconnected` as an optional argument that defaults to false. this retains the ability for someone to use the `ControllerLoaded` check to close the controller on the mapping if it isn't loaded, but that is not currently being used anywhere in LUS or SoH.

with that change, i needed to ensure `CloseController` was being called for all mappings associated with a disconnected device. i found the best place to handle this (where i had access to all of the mappings as well as the disconnected device joystick instance id) was `GetShipDeviceIndexOfDisconnectedPhysicalDevice`. it feels like a bit of an odd place, but we already had the logic to find every mapping associated with the joystick instance id in there, so adding a call to close the controller on those mappings instead of just returning the ship device index felt somewhat reasonable (especially considering it is used in both single and multiplayer mapping mode)

### issue 2: connecting

with the disconnection issue resolved, i began to focus on an issue with connecting devices. i found that when i
* started the game with 2 connected controllers (SDL0, SDL1)
* disconnected the first controller (SDL0)
* saw the second controller update to be SDL0
* reconnected the first controller

the first controller would also be assigned to SDL0

the logic for updating the SDL index was working as expected for disconnects, but not for connects. i added logic to `HandlePhysicalDeviceConnect` to update the SDL index for all connected controllers before initializing the mappings for the newly connected device. i only updated the single player mode code path for this one. i figure it's worth getting it fixed in single player mode as that's what soh and 2ship are using. i'll be sure to do exhaustive testing of multiplayer mode before a port that utilizes that is released (and i'll have this to reference if i find any similar issues there)