### PR TITLE
Fixed render and compile issues on f3dex 

### DIFF
--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -47,8 +47,6 @@
         macro      \
     } while (0)
 
-#define F3DEX_GBI_2
-
 #ifdef F3DEX_GBI_2
 #ifndef F3DEX_GBI
 #define F3DEX_GBI
@@ -1687,6 +1685,13 @@ typedef union Gfx {
  */
 
 /*
+ * OTR macros
+ */
+
+#define gsSP1TriangleOTR(v0, v1, v2, flag) \
+    { _SHIFTL(G_TRI1_OTR, 24, 8) | __gsSP1Triangle_w1f(v0, v1, v2, flag), 0 }
+
+/*
  * DMA macros
  */
 #define gDma0p(pkt, c, s, l)                                      \
@@ -1751,7 +1756,7 @@ typedef union Gfx {
         _g->words.w0 = _SHIFTL(G_VTX, 24, 8) | _SHIFTL((n), 12, 8) | _SHIFTL((v0) + (n), 1, 7); \
         _g->words.w1 = (uintptr_t)(v);                                                          \
     })
-#define gsSPVertex(v, n, v0) \
+#define __gSPVertex(v, n, v0) \
     { (_SHIFTL(G_VTX, 24, 8) | _SHIFTL((n), 12, 8) | _SHIFTL((v0) + (n), 1, 7)), (uintptr_t)(v) }
 
 #elif (defined(F3DEX_GBI) || defined(F3DLP_GBI))
@@ -1764,10 +1769,10 @@ typedef union Gfx {
  *        | |seg|          address            |
  *        +-+---+-----------------------------+
  */
-#define gSPVertex(pkt, v, n, v0) gDma1p((pkt), G_VTX, (v), ((n) << 10) | (sizeof(Vtx) * (n)-1), (v0)*2)
+#define __gSPVertex(pkt, v, n, v0) gDma1p((pkt), G_VTX, (v), ((n) << 10) | (sizeof(Vtx) * (n)-1), (v0)*2)
 #define gsSPVertex(v, n, v0) gsDma1p(G_VTX, (v), ((n) << 10) | (sizeof(Vtx) * (n)-1), (v0)*2)
 #else
-#define gSPVertex(pkt, v, n, v0) gDma1p(pkt, G_VTX, v, sizeof(Vtx) * (n), ((n)-1) << 4 | (v0))
+#define __gSPVertex(pkt, v, n, v0) gDma1p(pkt, G_VTX, v, sizeof(Vtx) * (n), ((n)-1) << 4 | (v0))
 #define gsSPVertex(v, n, v0) gsDma1p(G_VTX, v, sizeof(Vtx) * (n), ((n)-1) << 4 | (v0))
 #endif
 
@@ -1929,9 +1934,6 @@ typedef union Gfx {
     })
 #define gsSP1Triangle(v0, v1, v2, flag) \
     { _SHIFTL(G_TRI1, 24, 8) | __gsSP1Triangle_w1f(v0, v1, v2, flag), 0 }
-
-#define gsSP1TriangleOTR(v0, v1, v2, flag) \
-    { _SHIFTL(G_TRI1_OTR, 24, 8) | __gsSP1Triangle_w1f(v0, v1, v2, flag), 0 }
 
 /***
  ***  Line
@@ -2878,9 +2880,9 @@ typedef union Gfx {
 #define gDPSetMaskImage(pkt, i) gDPSetDepthImage(pkt, i)
 #define gsDPSetMaskImage(i) gsDPSetDepthImage(i)
 
-#define __gDPSetTextureImage(pkt, f, s, w, i) gSetImage(pkt, G_SETTIMG, f, s, w, i)
+#define gDPSetTextureImage(pkt, f, s, w, i) gSetImage(pkt, G_SETTIMG, f, s, w, i)
 #define gsDPSetTextureImage(f, s, w, i) gsSetImage(G_SETTIMG, f, s, w, i)
-#define __gDPSetTextureImageFB(pkt, f, s, w, i) gSetImage(pkt, G_SETTIMG_FB, f, s, w, i)
+#define gDPSetTextureImageFB(pkt, f, s, w, i) gSetImage(pkt, G_SETTIMG_FB, f, s, w, i)
 
 /*
  * RDP macros

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -1756,7 +1756,7 @@ typedef union Gfx {
         _g->words.w0 = _SHIFTL(G_VTX, 24, 8) | _SHIFTL((n), 12, 8) | _SHIFTL((v0) + (n), 1, 7); \
         _g->words.w1 = (uintptr_t)(v);                                                          \
     })
-#define __gSPVertex(v, n, v0) \
+#define gsSPVertex(v, n, v0) \
     { (_SHIFTL(G_VTX, 24, 8) | _SHIFTL((n), 12, 8) | _SHIFTL((v0) + (n), 1, 7)), (uintptr_t)(v) }
 
 #elif (defined(F3DEX_GBI) || defined(F3DLP_GBI))

--- a/include/libultraship/libultra/gs2dex.h
+++ b/include/libultraship/libultra/gs2dex.h
@@ -373,7 +373,7 @@ extern void guS2D2EmuSetScissor(u32, u32, u32, u32, u8);
 extern void guS2D2EmuBgRect1Cyc(Gfx**, uObjBg*);
 #else
 extern void guS2DEmuSetScissor(u32, u32, u32, u32, u8);
-extern void guS2DEmuBgRect1Cyc(F3DGfx**, uObjBg*);
+extern void guS2DEmuBgRect1Cyc(Gfx**, uObjBg*);
 #endif
 
 #ifdef _LANGUAGE_C_PLUS_PLUS

--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -138,6 +138,10 @@ void Fast3dWindow::SetTextureFilter(FilteringMode filteringMode) {
     gfx_get_current_rendering_api()->set_texture_filter(filteringMode);
 }
 
+void Fast3dWindow::SetRendererUCode(UcodeHandlers ucode) {
+    gfx_set_target_ucode(ucode);
+}
+
 void Fast3dWindow::Close() {
     mWindowManagerApi->close();
 }

--- a/src/graphic/Fast3D/Fast3dWindow.h
+++ b/src/graphic/Fast3D/Fast3dWindow.h
@@ -2,7 +2,7 @@
 #include "window/Window.h"
 #include "graphic/Fast3D/gfx_window_manager_api.h"
 #include "graphic/Fast3D/gfx_rendering_api.h"
-#include "gfxbridge.h"
+#include "public/bridge/gfxbridge.h"
 
 namespace Fast {
 class Fast3dWindow : public Ship::Window {

--- a/src/graphic/Fast3D/Fast3dWindow.h
+++ b/src/graphic/Fast3D/Fast3dWindow.h
@@ -2,6 +2,7 @@
 #include "window/Window.h"
 #include "graphic/Fast3D/gfx_window_manager_api.h"
 #include "graphic/Fast3D/gfx_rendering_api.h"
+#include "gfxbridge.h"
 
 namespace Fast {
 class Fast3dWindow : public Ship::Window {
@@ -35,6 +36,7 @@ class Fast3dWindow : public Ship::Window {
     void GetPixelDepthPrepare(float x, float y);
     uint16_t GetPixelDepth(float x, float y);
     void SetTextureFilter(FilteringMode filteringMode);
+    void SetRendererUCode(UcodeHandlers ucode);
 
   protected:
     static bool KeyDown(int32_t scancode);

--- a/src/graphic/Fast3D/f3dex.h
+++ b/src/graphic/Fast3D/f3dex.h
@@ -87,22 +87,22 @@ constexpr uint32_t F3DEX_G_CULL_BOTH = 0x00003000;
  * which to store a 1-4 word DMA.
  *
  */
-constexpr int8_t F3DEX_G_MV_VIEWPORT = 0x80;
-constexpr int8_t F3DEX_G_MV_LOOKATY = 0x82;
-constexpr int8_t F3DEX_G_MV_LOOKATX = 0x84;
-constexpr int8_t F3DEX_G_MV_L0 = 0x86;
-constexpr int8_t F3DEX_G_MV_L1 = 0x88;
-constexpr int8_t F3DEX_G_MV_L2 = 0x8a;
-constexpr int8_t F3DEX_G_MV_L3 = 0x8c;
-constexpr int8_t F3DEX_G_MV_L4 = 0x8e;
-constexpr int8_t F3DEX_G_MV_L5 = 0x90;
-constexpr int8_t F3DEX_G_MV_L6 = 0x92;
-constexpr int8_t F3DEX_G_MV_L7 = 0x94;
-constexpr int8_t F3DEX_G_MV_TXTATT = 0x96;
-constexpr int8_t F3DEX_G_MV_MATRIX_1 = 0x9e;
-constexpr int8_t F3DEX_G_MV_MATRIX_2 = 0x98;
-constexpr int8_t F3DEX_G_MV_MATRIX_3 = 0x9a;
-constexpr int8_t F3DEX_G_MV_MATRIX_4 = 0x9c;
+constexpr uint8_t F3DEX_G_MV_VIEWPORT = 0x80;
+constexpr uint8_t F3DEX_G_MV_LOOKATY = 0x82;
+constexpr uint8_t F3DEX_G_MV_LOOKATX = 0x84;
+constexpr uint8_t F3DEX_G_MV_L0 = 0x86;
+constexpr uint8_t F3DEX_G_MV_L1 = 0x88;
+constexpr uint8_t F3DEX_G_MV_L2 = 0x8a;
+constexpr uint8_t F3DEX_G_MV_L3 = 0x8c;
+constexpr uint8_t F3DEX_G_MV_L4 = 0x8e;
+constexpr uint8_t F3DEX_G_MV_L5 = 0x90;
+constexpr uint8_t F3DEX_G_MV_L6 = 0x92;
+constexpr uint8_t F3DEX_G_MV_L7 = 0x94;
+constexpr uint8_t F3DEX_G_MV_TXTATT = 0x96;
+constexpr uint8_t F3DEX_G_MV_MATRIX_1 = 0x9e;
+constexpr uint8_t F3DEX_G_MV_MATRIX_2 = 0x98;
+constexpr uint8_t F3DEX_G_MV_MATRIX_3 = 0x9a;
+constexpr uint8_t F3DEX_G_MV_MATRIX_4 = 0x9c;
 
 /*
  * MOVEWORD indices

--- a/src/graphic/Fast3D/gfx_pc.h
+++ b/src/graphic/Fast3D/gfx_pc.h
@@ -12,7 +12,7 @@
 
 #include "graphic/Fast3D/lus_gbi.h"
 #include "libultraship/libultra/types.h"
-#include "gfxbridge.h"
+#include "public/bridge/gfxbridge.h"
 
 #include "resource/type/Texture.h"
 #include "resource/Resource.h"

--- a/src/graphic/Fast3D/gfx_pc.h
+++ b/src/graphic/Fast3D/gfx_pc.h
@@ -12,6 +12,7 @@
 
 #include "graphic/Fast3D/lus_gbi.h"
 #include "libultraship/libultra/types.h"
+#include "gfxbridge.h"
 
 #include "resource/type/Texture.h"
 #include "resource/Resource.h"
@@ -233,6 +234,7 @@ void gfx_start_frame(void);
 // Since this function is "exposted" to the games, it needs to take a normal Gfx
 void gfx_run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_replacements);
 void gfx_end_frame(void);
+void gfx_set_target_ucode(UcodeHandlers ucode);
 void gfx_set_target_fps(int);
 void gfx_set_maximum_frame_latency(int latency);
 void gfx_texture_cache_delete(const uint8_t* orig_addr);

--- a/src/public/bridge/gfxbridge.h
+++ b/src/public/bridge/gfxbridge.h
@@ -3,10 +3,6 @@
 
 #include "stdint.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef enum UcodeHandlers {
     ucode_f3d,
     ucode_f3dex,
@@ -14,6 +10,10 @@ typedef enum UcodeHandlers {
     ucode_s2dex,
     ucode_max,
 } UcodeHandlers;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 void GfxSetNativeDimensions(uint32_t width, uint32_t height);
 void GfxGetPixelDepthPrepare(float x, float y);

--- a/src/resource/factory/DisplayListFactory.cpp
+++ b/src/resource/factory/DisplayListFactory.cpp
@@ -152,7 +152,7 @@ std::shared_ptr<Ship::IResource> ResourceFactoryBinaryDisplayListV0::ReadResourc
 
         displayList->Instructions.push_back(command);
 
-        uint8_t opcode = (uint8_t)(command.words.w0 >> 24);
+        int8_t opcode = (int8_t)(command.words.w0 >> 24);
 
         // These are 128-bit commands, so read an extra 64 bits...
         if (opcode == G_SETTIMG_OTR_HASH || opcode == G_DL_OTR_HASH || opcode == G_VTX_OTR_HASH ||

--- a/src/resource/factory/DisplayListFactory.cpp
+++ b/src/resource/factory/DisplayListFactory.cpp
@@ -163,7 +163,7 @@ std::shared_ptr<Ship::IResource> ResourceFactoryBinaryDisplayListV0::ReadResourc
             displayList->Instructions.push_back(command);
         }
 
-        if (opcode ==  (int8_t) G_ENDDL) {
+        if (opcode == (int8_t)G_ENDDL) {
             break;
         }
     }

--- a/src/resource/factory/DisplayListFactory.cpp
+++ b/src/resource/factory/DisplayListFactory.cpp
@@ -390,9 +390,11 @@ std::shared_ptr<Ship::IResource> ResourceFactoryXMLDisplayListV0::ReadResource(s
             g.words.w1 |= v01 << 16;
             g.words.w1 |= v02 << 0;
         } else if (childName == "Triangles2") {
+#ifdef F3DEX_GBI_2
             g = gsSP2Triangles(child->IntAttribute("V00"), child->IntAttribute("V01"), child->IntAttribute("V02"),
                                child->IntAttribute("Flag0"), child->IntAttribute("V10"), child->IntAttribute("V11"),
                                child->IntAttribute("V12"), child->IntAttribute("Flag1"));
+#endif
         } else if (childName == "LoadVertices") {
             std::string fName = child->Attribute("Path");
             // fName = ">" + fName;

--- a/src/resource/factory/DisplayListFactory.cpp
+++ b/src/resource/factory/DisplayListFactory.cpp
@@ -163,7 +163,7 @@ std::shared_ptr<Ship::IResource> ResourceFactoryBinaryDisplayListV0::ReadResourc
             displayList->Instructions.push_back(command);
         }
 
-        if (opcode == G_ENDDL) {
+        if (opcode ==  (int8_t) G_ENDDL) {
             break;
         }
     }


### PR DESCRIPTION
The only breaking change on SOH is the removal of the hardcoded define of F3DEX_GBI from the main gbi.h, so it needs to be defined on the cmake now