### PR TITLE
don't call `SDL_DestroyRenderer` or `SDL_Quit` until we get to `gfx_sdl_destroy`

### DIFF
--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -414,8 +414,6 @@ static void gfx_sdl_init(const char* game_name, const char* gfx_api_name, bool s
 
 static void gfx_sdl_close(void) {
     is_running = false;
-    SDL_DestroyRenderer(renderer);
-    SDL_Quit();
 }
 
 static void gfx_sdl_set_fullscreen_changed_callback(void (*on_fullscreen_changed)(bool is_now_fullscreen)) {


### PR DESCRIPTION
soh testing pr: https://github.com/HarbourMasters/Shipwright/pull/4172

in soh, quitting the game using the "Quit" option in the "Ship" menu was leading to garbage values in the config

this was happening because we call `SaveWindowToConfig()` in the `Context` destructor

https://github.com/Kenix3/libultraship/blob/6b8a8d8fb1d4f680f6fe2263ddef32b94aa429f8/src/Context.cpp#L26-L28

which makes calls to `Get`(`Width`/`Height`/`PosX`/`PosY`)

https://github.com/Kenix3/libultraship/blob/6b8a8d8fb1d4f680f6fe2263ddef32b94aa429f8/src/window/Window.cpp#L48-L60

which all call into `mWindowManagerApi->get_dimensions`

https://github.com/Kenix3/libultraship/blob/6b8a8d8fb1d4f680f6fe2263ddef32b94aa429f8/src/graphic/Fast3D/Fast3dWindow.cpp#L156-L161

which in SDL then calls `SDL_GL_GetDrawableSize` and `SDL_GetWindowPosition`

https://github.com/Kenix3/libultraship/blob/6b8a8d8fb1d4f680f6fe2263ddef32b94aa429f8/src/graphic/Fast3D/gfx_sdl2.cpp#L444-L447

which gives us garbage if we've already called
```cpp
    SDL_DestroyRenderer(renderer);
    SDL_Quit();
```

so, instead of directly calling these in `gfx_sdl_close`, we can rely on the fact that these get called when we destruct `Fast3dWindow` by calling `gfx_destroy` 

https://github.com/Kenix3/libultraship/blob/6b8a8d8fb1d4f680f6fe2263ddef32b94aa429f8/src/graphic/Fast3D/Fast3dWindow.cpp#L35-L38

which in SDL land is `gfx_sdl_destroy`

https://github.com/Kenix3/libultraship/blob/6b8a8d8fb1d4f680f6fe2263ddef32b94aa429f8/src/graphic/Fast3D/gfx_sdl2.cpp#L606-L611