### PR TITLE
Add geometry mode for always executing branches

### DIFF
--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -369,6 +369,7 @@
  * G_EXTRAGEOMETRY flags: set extra custom geometry modes
  */
 #define G_EX_INVERT_CULLING 0x00000001
+#define G_EX_ALWAYS_EXECUTE_BRANCH 0x00000002
 
 /* Need these defined for Sprite Microcode */
 #ifdef _LANGUAGE_ASSEMBLY

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -3030,7 +3030,7 @@ bool gfx_branch_z_otr_handler_f3dex2(F3DGfx** cmd0) {
 
     (*cmd0)++;
 
-    if (g_rsp.loaded_vertices[vbidx].z <= zval) {
+    if (g_rsp.loaded_vertices[vbidx].z <= zval || (g_rsp.extra_geometry_mode & G_EX_ALWAYS_EXECUTE_BRANCH) != 0) {
         uint64_t hash = ((uint64_t)(*cmd0)->words.w0 << 32) + (*cmd0)->words.w1;
 
         F3DGfx* gfx = (F3DGfx*)ResourceGetDataByCrc(hash);

--- a/src/graphic/Fast3D/lus_gbi.h
+++ b/src/graphic/Fast3D/lus_gbi.h
@@ -196,6 +196,7 @@ constexpr int8_t OTR_G_SETINTENSITY = OPCODE(0x40);
  * G_EXTRAGEOMETRY flags: set extra custom geometry modes
  */
 #define G_EX_INVERT_CULLING 0x00000001
+#define G_EX_ALWAYS_EXECUTE_BRANCH 0x00000002
 
 /*
  * G_SETIMG fmt: set image formats


### PR DESCRIPTION
BRANCH_Z can optionally be used in combination with args to conditionally render it. This is used in Majora's Mask for culling scene geometry. This adds an override to always execute the branch. 