### PR TITLE
Removed framebuffer clear to make the game do it

### DIFF
--- a/src/graphic/Fast3D/gfx_direct3d11.cpp
+++ b/src/graphic/Fast3D/gfx_direct3d11.cpp
@@ -945,8 +945,6 @@ void gfx_d3d11_start_draw_to_framebuffer(int fb_id, float noise_scale) {
 
 void gfx_d3d11_clear_framebuffer(void) {
     Framebuffer& fb = d3d.framebuffers[d3d.current_framebuffer];
-    const float clearColor[] = { 0.0f, 0.0f, 0.0f, 1.0f };
-    d3d.context->ClearRenderTargetView(fb.render_target_view.Get(), clearColor);
     if (fb.has_depth_buffer) {
         d3d.context->ClearDepthStencilView(fb.depth_stencil_view.Get(), D3D11_CLEAR_DEPTH, 1.0f, 0);
     }

--- a/src/graphic/Fast3D/gfx_metal.cpp
+++ b/src/graphic/Fast3D/gfx_metal.cpp
@@ -748,11 +748,9 @@ static void gfx_metal_setup_screen_framebuffer(uint32_t width, uint32_t height) 
     tex.texture = mctx.current_drawable->texture();
 
     MTL::RenderPassDescriptor* render_pass_descriptor = MTL::RenderPassDescriptor::renderPassDescriptor();
-    MTL::ClearColor clear_color = MTL::ClearColor::Make(0, 0, 0, 1);
     render_pass_descriptor->colorAttachments()->object(0)->setTexture(tex.texture);
-    render_pass_descriptor->colorAttachments()->object(0)->setLoadAction(MTL::LoadActionClear);
+    render_pass_descriptor->colorAttachments()->object(0)->setLoadAction(MTL::LoadActionLoad);
     render_pass_descriptor->colorAttachments()->object(0)->setStoreAction(MTL::StoreActionStore);
-    render_pass_descriptor->colorAttachments()->object(0)->setClearColor(clear_color);
 
     tex.width = width;
     tex.height = height;
@@ -851,20 +849,17 @@ static void gfx_metal_update_framebuffer_parameters(int fb_id, uint32_t width, u
 
             bool fb_msaa_enabled = (msaa_level > 1);
             bool game_msaa_enabled = CVarGetInteger("gMSAAValue", 1) > 1;
-            MTL::ClearColor clear_color = MTL::ClearColor::Make(0.0, 0.0, 0.0, 1.0);
 
             if (fb_msaa_enabled) {
                 render_pass_descriptor->colorAttachments()->object(0)->setTexture(tex.msaaTexture);
                 render_pass_descriptor->colorAttachments()->object(0)->setResolveTexture(tex.texture);
-                render_pass_descriptor->colorAttachments()->object(0)->setLoadAction(MTL::LoadActionClear);
+                render_pass_descriptor->colorAttachments()->object(0)->setLoadAction(MTL::LoadActionLoad);
                 render_pass_descriptor->colorAttachments()->object(0)->setStoreAction(
                     MTL::StoreActionStoreAndMultisampleResolve);
-                render_pass_descriptor->colorAttachments()->object(0)->setClearColor(clear_color);
             } else {
                 render_pass_descriptor->colorAttachments()->object(0)->setTexture(tex.texture);
-                render_pass_descriptor->colorAttachments()->object(0)->setLoadAction(MTL::LoadActionClear);
+                render_pass_descriptor->colorAttachments()->object(0)->setLoadAction(MTL::LoadActionLoad);
                 render_pass_descriptor->colorAttachments()->object(0)->setStoreAction(MTL::StoreActionStore);
-                render_pass_descriptor->colorAttachments()->object(0)->setClearColor(clear_color);
             }
 
             if (fb.render_pass_descriptor != nullptr)

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -988,8 +988,7 @@ void gfx_opengl_start_draw_to_framebuffer(int fb_id, float noise_scale) {
 void gfx_opengl_clear_framebuffer() {
     glDisable(GL_SCISSOR_TEST);
     glDepthMask(GL_TRUE);
-    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glClear(GL_DEPTH_BUFFER_BIT);
     glDepthMask(current_depth_mask ? GL_TRUE : GL_FALSE);
     glEnable(GL_SCISSOR_TEST);
 }


### PR DESCRIPTION
This PR removes framebuffer cleaning because some games rely on it to make some hack effects like blur when clearing with alpha.

This could be a breaking change because it means each game is now responsible to do it

Example PR: https://github.com/HarbourMasters/Shipwright/pull/4187/files