### PR TITLE
Fixed gfx_pc memory leak

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -3901,6 +3901,7 @@ void gfx_init(struct GfxWindowManagerAPI* wapi, struct GfxRenderingAPI* rapi, co
 
 void gfx_destroy(void) {
     // TODO: should also destroy rapi, and any other resources acquired in fast3d
+    free(tex_upload_buffer);
     gfx_wapi->destroy();
 
     // Texture cache and loaded textures store references to Resources which need to be unreferenced.


### PR DESCRIPTION
This PR fixes an 8k malloc texture that doesnt get free when the game closes