### PR TITLE
fix: ensure the controller disconnected window updates before the controller reordering window

### DIFF
--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -9,6 +9,7 @@
 #include <imgui_internal.h>
 #include <memory>
 #include <string>
+#include <map>
 #include <unordered_map>
 #include <vector>
 #include <SDL2/SDL.h>
@@ -114,7 +115,7 @@ class Gui {
     std::shared_ptr<GameOverlay> mGameOverlay;
     std::shared_ptr<GuiMenuBar> mMenuBar;
     std::unordered_map<std::string, GuiTextureMetadata> mGuiTextures;
-    std::unordered_map<std::string, std::shared_ptr<GuiWindow>> mGuiWindows;
+    std::map<std::string, std::shared_ptr<GuiWindow>> mGuiWindows;
 };
 } // namespace Ship
 


### PR DESCRIPTION
the `ControllerDisconnectedWindow` handles `SDL_CONTROLLERDEVICEADDED` and `SDL_CONTROLLERDEVICEREMOVED` events

https://github.com/Kenix3/libultraship/blob/d7f4734e06c27511b4066490b0f7f77156c4ad42/src/controller/deviceindex/ControllerDisconnectedWindow.cpp#L16-L32

and when a device is added, it calls into `ShipDeviceIndexMappingManager::HandlePhysicalDeviceConnect`

https://github.com/Kenix3/libultraship/blob/d7f4734e06c27511b4066490b0f7f77156c4ad42/src/controller/deviceindex/ShipDeviceIndexMappingManager.cpp#L286-L289

which early returns if `ShipDeviceIndexMappingManager` has not been initalized.

we rely on this behavior to ensure the mapping manager is properly initialized before trying to add devices based on sdl events, since we iterate through all connected controllers in `ShipDeviceIndexMappingManager::InitializeMappingsSinglePlayer` and `ShipDeviceIndexMappingManager::InitializeMappingsMultiplayer`

this initialization is done in the controller reordering window, because the logic for setting first time mappings and reordering devices is the same

https://github.com/Kenix3/libultraship/blob/d7f4734e06c27511b4066490b0f7f77156c4ad42/src/controller/deviceindex/ControllerReorderingWindow.cpp#L59-L64

https://github.com/Kenix3/libultraship/blob/d7f4734e06c27511b4066490b0f7f77156c4ad42/src/controller/deviceindex/ControllerReorderingWindow.cpp#L107-L112

this is slightly complicated by the fact `SDL_CONTROLLERDEVICEADDED` events are fired off when the game starts. the reordering window is supposed to handle initialization, and the disconnected window is supposed to handle any changes (devices added/removed)

if, on boot, the disconnected window update happens before the reordering window update does this isn't an issue. the disconnected window early returns and doesn't try to add any devices, and then the initialization happens as expected via the reordering window

the update/draw calls for the gui windows happen in a loop over `mGuiWindows`

https://github.com/Kenix3/libultraship/blob/d7f4734e06c27511b4066490b0f7f77156c4ad42/src/window/gui/Gui.cpp#L374-L377

but without this PR, `mGuiWindows` is an `unordered_map`, meaning even though we add the disconnected window before the reordering window

https://github.com/Kenix3/libultraship/blob/d7f4734e06c27511b4066490b0f7f77156c4ad42/src/window/gui/Gui.cpp#L75-L83

there's no guarantee the disconnected window will come first when iterating. somehow we've lucked out and the disconnected window has always come first in soh, but in 2ship we haven't been so lucky

## tl;dr
### this changes `mGuiWindows` to be a `map` instead of an `unordered_map` because the order matters