### PR TITLE
fix(o2r): don't index directories as files

### DIFF
--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -187,6 +187,10 @@ std::shared_ptr<Archive> ArchiveManager::AddArchive(std::shared_ptr<Archive> arc
     }
     const auto fileList = archive->ListFiles();
     for (auto& [hash, filename] : *fileList.get()) {
+        if (filename.ends_with("/")) {
+            continue;
+        }
+
         mHashes[hash] = filename;
         mFileToArchive[hash] = archive;
     }

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -187,10 +187,6 @@ std::shared_ptr<Archive> ArchiveManager::AddArchive(std::shared_ptr<Archive> arc
     }
     const auto fileList = archive->ListFiles();
     for (auto& [hash, filename] : *fileList.get()) {
-        if (filename.ends_with("/")) {
-            continue;
-        }
-
         mHashes[hash] = filename;
         mFileToArchive[hash] = archive;
     }

--- a/src/resource/archive/O2rArchive.cpp
+++ b/src/resource/archive/O2rArchive.cpp
@@ -69,6 +69,12 @@ bool O2rArchive::Open() {
     for (auto i = 0; i < zipNumEntries; i++) {
         auto zipEntryName = zip_get_name(mZipArchive, i, 0);
 
+        // It is possible for directories to have entries in a zip
+        // file, we don't want those indexed as files in the archive
+        if (zipEntryName[strlen(zipEntryName) - 1] == '/') {
+            continue;
+        }
+
         IndexFile(zipEntryName);
     }
 


### PR DESCRIPTION
it seems making zips using applications (gnome's build it "compress" option and 7zip) adds directories in a way that they show up when we're listing files

~~i'm not sure if this is actually *where* we should have this fix, mostly a proof of concept at the moment~~ (this was when i had the fix in archivemanager, it's in o2rarchive now which is where it should live)