### PR TITLE
Prevent crash if `XDG_CURRENT_DESKTOP` isn't set

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -234,7 +234,8 @@ void Gui::LoadTextureFromRawImage(const std::string& name, const std::string& pa
 
 bool Gui::SupportsViewports() {
 #ifdef __linux__
-    if (std::string(std::getenv("XDG_CURRENT_DESKTOP")) == "gamescope") {
+    const char* currentDesktop = std::getenv("XDG_CURRENT_DESKTOP");
+    if (currentDesktop && std::string(currentDesktop) == "gamescope") {
         return false;
     }
 #endif


### PR DESCRIPTION
`std::getenv` will return `nullptr` if the environment variable isn't set, which would cause `std::string` to throw an error resulting in a crash.