### PR TITLE
Fix some two_cycle color combiner issues

### DIFF
--- a/src/graphic/Fast3D/gfx_cc.cpp
+++ b/src/graphic/Fast3D/gfx_cc.cpp
@@ -41,9 +41,15 @@ void gfx_cc_get_features(uint64_t shader_id0, uint32_t shader_id1, struct CCFeat
                 }
                 if (cc_features->c[c][i][j] == SHADER_TEXEL0 || cc_features->c[c][i][j] == SHADER_TEXEL0A) {
                     cc_features->used_textures[0] = true;
+                    if (cc_features->opt_2cyc) {
+                        cc_features->used_textures[1] = true;
+                    }
                 }
                 if (cc_features->c[c][i][j] == SHADER_TEXEL1 || cc_features->c[c][i][j] == SHADER_TEXEL1A) {
                     cc_features->used_textures[1] = true;
+                    if (cc_features->opt_2cyc) {
+                        cc_features->used_textures[0] = true;
+                    }
                 }
             }
         }

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -336,18 +336,30 @@ static void gfx_generate_cc(struct ColorCombiner* comb, const ColorCombinerKey& 
                     case G_CCMUX_TEXEL0:
                         val = SHADER_TEXEL0;
                         used_textures[0] = true;
+                        if (is_2cyc) {
+                            used_textures[1] = true;
+                        }
                         break;
                     case G_CCMUX_TEXEL1:
                         val = SHADER_TEXEL1;
                         used_textures[1] = true;
+                        if (is_2cyc) {
+                            used_textures[0] = true;
+                        }
                         break;
                     case G_CCMUX_TEXEL0_ALPHA:
                         val = SHADER_TEXEL0A;
                         used_textures[0] = true;
+                        if (is_2cyc) {
+                            used_textures[1] = true;
+                        }
                         break;
                     case G_CCMUX_TEXEL1_ALPHA:
                         val = SHADER_TEXEL1A;
                         used_textures[1] = true;
+                        if (is_2cyc) {
+                            used_textures[0] = true;
+                        }
                         break;
                     case G_CCMUX_NOISE:
                         val = SHADER_NOISE;
@@ -389,10 +401,16 @@ static void gfx_generate_cc(struct ColorCombiner* comb, const ColorCombinerKey& 
                     case G_ACMUX_TEXEL0:
                         val = SHADER_TEXEL0;
                         used_textures[0] = true;
+                        if (is_2cyc) {
+                            used_textures[1] = true;
+                        }
                         break;
                     case G_ACMUX_TEXEL1:
                         val = SHADER_TEXEL1;
                         used_textures[1] = true;
+                        if (is_2cyc) {
+                            used_textures[0] = true;
+                        }
                         break;
                     case G_ACMUX_LOD_FRACTION:
                         // case G_ACMUX_COMBINED: same numerical value


### PR DESCRIPTION
I know it's gross with all the nested ternaries, but I don't really want to clean all this up rn

Used this as a reference: https://github.dev/rt64/rt64/blob/main/src/shared/rt64_color_combiner.h

Verified fixed:
- Song of Soaring (MM)
- Grate in Laundry (MM)
- Juggler balls (MM)
- Morpha (OoT)

Crashes (shader compilation issue I don't fully understand how to fix)
- Water temple (likely the spike guys) (OoT)
  - Just debug warp to Water temple 
- Romani Ranch Aliens (Likely due to documented texel bug?)
  - Debug warp to Romani ranch entrance `1`, after finishing dialog with malon fast forward time to 3am

## Before / After

<img width="300" alt="Screenshot 2024-06-01 at 9 06 22 PM" src="https://github.com/Kenix3/libultraship/assets/7316699/655472bc-3407-4997-8036-869a02ea5fba">
<img width="300" alt="Screenshot 2024-06-01 at 8 51 57 PM" src="https://github.com/Kenix3/libultraship/assets/7316699/7833fb18-97e5-4299-b60f-1161bc4f7cfa">

<img width="300" alt="Screenshot 2024-06-01 at 9 01 05 PM" src="https://github.com/Kenix3/libultraship/assets/7316699/33f8e61c-3df0-4b08-9025-945da44a9962">
<img width="300" alt="Screenshot 2024-06-01 at 8 49 39 PM" src="https://github.com/Kenix3/libultraship/assets/7316699/104f9833-f224-43c2-9603-2a478e3d8c03">

<img width="300" alt="Screenshot 2024-06-01 at 9 05 02 PM" src="https://github.com/Kenix3/libultraship/assets/7316699/5684531b-2af6-4f2c-9f41-5e350999ccc9">
<img width="300" alt="Screenshot 2024-06-01 at 8 51 04 PM" src="https://github.com/Kenix3/libultraship/assets/7316699/d0d9ba01-a192-4a81-8c7c-0841a7cf279e">

<img width="300" alt="Screenshot 2024-06-01 at 8 59 20 PM" src="https://github.com/Kenix3/libultraship/assets/7316699/05108cb5-791d-4059-b33c-7360ca6e35be">
<img width="300" alt="Screenshot 2024-06-01 at 8 58 13 PM" src="https://github.com/Kenix3/libultraship/assets/7316699/a6d8faee-fbf7-4c7a-a564-c72dcee44819">
