### PR TITLE
chore: remove redundant `Ship::` usage inside `Ship` namespaced files

### DIFF
--- a/src/config/ConsoleVariable.cpp
+++ b/src/config/ConsoleVariable.cpp
@@ -165,7 +165,7 @@ void ConsoleVariable::RegisterColor24(const char* name, Color_RGB8 defaultValue)
 }
 
 void ConsoleVariable::ClearVariable(const char* name) {
-    std::shared_ptr<Config> conf = Ship::Context::GetInstance()->GetConfig();
+    std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();
     auto var = Get(name);
     if (var != nullptr) {
         bool color = var->Type == ConsoleVariableType::Color || var->Type == ConsoleVariableType::Color24;
@@ -192,7 +192,7 @@ void ConsoleVariable::ClearVariable(const char* name) {
 }
 
 void ConsoleVariable::ClearBlock(const char* name) {
-    std::shared_ptr<Config> conf = Ship::Context::GetInstance()->GetConfig();
+    std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();
     conf->EraseBlock(StringHelper::Sprintf("CVars.%s", name));
     Load();
 }
@@ -228,7 +228,7 @@ void ConsoleVariable::CopyVariable(const char* from, const char* to) {
 }
 
 void ConsoleVariable::Save() {
-    std::shared_ptr<Config> conf = Ship::Context::GetInstance()->GetConfig();
+    std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();
 
     for (const auto& variable : mVariables) {
         const std::string key = StringHelper::Sprintf("CVars.%s", variable.first.c_str());
@@ -264,7 +264,7 @@ void ConsoleVariable::Save() {
 }
 
 void ConsoleVariable::Load() {
-    std::shared_ptr<Config> conf = Ship::Context::GetInstance()->GetConfig();
+    std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();
     conf->Reload();
     if (!mVariables.empty()) {
         mVariables.clear();
@@ -324,7 +324,7 @@ void ConsoleVariable::LoadFromPath(
     }
 }
 void ConsoleVariable::LoadLegacy() {
-    auto conf = Ship::Context::GetPathRelativeToAppDirectory("cvars.cfg");
+    auto conf = Context::GetPathRelativeToAppDirectory("cvars.cfg");
     if (DiskFile::Exists(conf)) {
         const auto lines = DiskFile::ReadAllLines(conf);
 

--- a/src/controller/controldeck/ControlDeck.h
+++ b/src/controller/controldeck/ControlDeck.h
@@ -26,7 +26,7 @@ class ControlDeck {
     void SetSinglePlayerMappingMode(bool singlePlayer);
     bool IsSinglePlayerMappingMode();
 
-    bool ProcessKeyboardEvent(Ship::KbEventType eventType, Ship::KbScancode scancode);
+    bool ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode);
 
     std::shared_ptr<ShipDeviceIndexMappingManager> GetDeviceIndexMappingManager();
 

--- a/src/controller/controldevice/controller/Controller.cpp
+++ b/src/controller/controldevice/controller/Controller.cpp
@@ -175,7 +175,7 @@ void Controller::ReadToPad(OSContPad* pad) {
     }
 }
 
-bool Controller::ProcessKeyboardEvent(Ship::KbEventType eventType, Ship::KbScancode scancode) {
+bool Controller::ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode) {
     bool result = false;
     for (auto [bitmask, button] : GetAllButtons()) {
         result = button->ProcessKeyboardEvent(eventType, scancode) || result;

--- a/src/controller/controldevice/controller/Controller.h
+++ b/src/controller/controldevice/controller/Controller.h
@@ -48,7 +48,7 @@ class Controller : public ControlDevice {
     uint8_t GetPortIndex();
     std::vector<std::shared_ptr<ControllerMapping>> GetAllMappings();
 
-    bool ProcessKeyboardEvent(Ship::KbEventType eventType, Ship::KbScancode scancode);
+    bool ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode);
 
     bool HasMappingsForShipDeviceIndex(ShipDeviceIndex lusIndex);
     void MoveMappingsToDifferentController(std::shared_ptr<Controller> newController, ShipDeviceIndex lusIndex);

--- a/src/controller/controldevice/controller/ControllerButton.cpp
+++ b/src/controller/controldevice/controller/ControllerButton.cpp
@@ -205,7 +205,7 @@ bool ControllerButton::AddOrEditButtonMappingFromRawPress(CONTROLLERBUTTONS_T bi
     return true;
 }
 
-bool ControllerButton::ProcessKeyboardEvent(Ship::KbEventType eventType, Ship::KbScancode scancode) {
+bool ControllerButton::ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode) {
     if (mUseKeydownEventToCreateNewMapping && eventType == LUS_KB_EVENT_KEY_DOWN) {
         mKeyboardScancodeForNewMapping = scancode;
         return true;

--- a/src/controller/controldevice/controller/ControllerButton.h
+++ b/src/controller/controldevice/controller/ControllerButton.h
@@ -36,7 +36,7 @@ class ControllerButton {
 
     void UpdatePad(CONTROLLERBUTTONS_T& padButtons);
 
-    bool ProcessKeyboardEvent(Ship::KbEventType eventType, Ship::KbScancode scancode);
+    bool ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode);
 
     bool HasMappingsForShipDeviceIndex(ShipDeviceIndex lusIndex);
 

--- a/src/controller/controldevice/controller/ControllerStick.cpp
+++ b/src/controller/controldevice/controller/ControllerStick.cpp
@@ -314,7 +314,7 @@ void ControllerStick::UpdatePad(int8_t& x, int8_t& y) {
     Process(x, y);
 }
 
-bool ControllerStick::ProcessKeyboardEvent(Ship::KbEventType eventType, Ship::KbScancode scancode) {
+bool ControllerStick::ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode) {
     if (mUseKeydownEventToCreateNewMapping && eventType == LUS_KB_EVENT_KEY_DOWN) {
         mKeyboardScancodeForNewMapping = scancode;
         return true;

--- a/src/controller/controldevice/controller/ControllerStick.h
+++ b/src/controller/controldevice/controller/ControllerStick.h
@@ -51,7 +51,7 @@ class ControllerStick {
     uint8_t GetNotchSnapAngle();
     bool NotchSnapAngleIsDefault();
 
-    bool ProcessKeyboardEvent(Ship::KbEventType eventType, Ship::KbScancode scancode);
+    bool ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode);
 
     bool HasMappingsForShipDeviceIndex(ShipDeviceIndex lusIndex);
     Stick LeftOrRightStick();

--- a/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAnyMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAnyMapping.cpp
@@ -16,7 +16,7 @@ std::string KeyboardKeyToAnyMapping::GetPhysicalInputName() {
     return Context::GetInstance()->GetWindow()->GetKeyName(mKeyboardScancode);
 }
 
-bool KeyboardKeyToAnyMapping::ProcessKeyboardEvent(Ship::KbEventType eventType, Ship::KbScancode scancode) {
+bool KeyboardKeyToAnyMapping::ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode) {
     if (eventType == KbEventType::LUS_KB_EVENT_ALL_KEYS_UP) {
         mKeyPressed = false;
         return true;

--- a/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAnyMapping.h
+++ b/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAnyMapping.h
@@ -9,7 +9,7 @@ class KeyboardKeyToAnyMapping : virtual public ControllerInputMapping {
     KeyboardKeyToAnyMapping(KbScancode scancode);
     ~KeyboardKeyToAnyMapping();
     std::string GetPhysicalInputName() override;
-    bool ProcessKeyboardEvent(Ship::KbEventType eventType, Ship::KbScancode scancode);
+    bool ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode);
     std::string GetPhysicalDeviceName() override;
     bool PhysicalDeviceIsConnected() override;
 

--- a/src/controller/controldevice/controller/mapping/sdl/SDLMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLMapping.cpp
@@ -14,7 +14,7 @@ SDLMapping::~SDLMapping() {
 
 bool SDLMapping::OpenController() {
     auto deviceIndexMapping = std::static_pointer_cast<ShipDeviceIndexToSDLDeviceIndexMapping>(
-        Ship::Context::GetInstance()
+        Context::GetInstance()
             ->GetControlDeck()
             ->GetDeviceIndexMappingManager()
             ->GetDeviceIndexMappingFromShipDeviceIndex(mShipDeviceIndex));
@@ -116,7 +116,7 @@ bool SDLMapping::UsesGameCubeLayout() {
 
 int32_t SDLMapping::GetSDLDeviceIndex() {
     auto deviceIndexMapping = std::static_pointer_cast<ShipDeviceIndexToSDLDeviceIndexMapping>(
-        Ship::Context::GetInstance()
+        Context::GetInstance()
             ->GetControlDeck()
             ->GetDeviceIndexMappingManager()
             ->GetDeviceIndexMappingFromShipDeviceIndex(mShipDeviceIndex));
@@ -130,7 +130,7 @@ int32_t SDLMapping::GetSDLDeviceIndex() {
 }
 
 std::string SDLMapping::GetSDLControllerName() {
-    return Ship::Context::GetInstance()
+    return Context::GetInstance()
         ->GetControlDeck()
         ->GetDeviceIndexMappingManager()
         ->GetSDLControllerNameFromShipDeviceIndex(mShipDeviceIndex);

--- a/src/controller/deviceindex/ShipDeviceIndexMappingManager.cpp
+++ b/src/controller/deviceindex/ShipDeviceIndexMappingManager.cpp
@@ -300,7 +300,7 @@ void ShipDeviceIndexMappingManager::HandlePhysicalDeviceConnect(int32_t sdlDevic
     }
 
     if (Context::GetInstance()->GetControlDeck()->IsSinglePlayerMappingMode()) {
-        std::set<Ship::ShipDeviceIndex> alreadyConnectedDevices;
+        std::set<ShipDeviceIndex> alreadyConnectedDevices;
         for (auto mapping : Context::GetInstance()->GetControlDeck()->GetControllerByPort(0)->GetAllMappings()) {
             auto sdlMapping = std::dynamic_pointer_cast<SDLMapping>(mapping);
             if (sdlMapping == nullptr) {

--- a/src/debug/CrashHandler.cpp
+++ b/src/debug/CrashHandler.cpp
@@ -138,7 +138,7 @@ void CrashHandler::PrintRegisters(ucontext_t* ctx) {
 }
 
 static void ErrorHandler(int sig, siginfo_t* sigInfo, void* data) {
-    std::shared_ptr<CrashHandler> crashHandler = Ship::Context::GetInstance()->GetCrashHandler();
+    std::shared_ptr<CrashHandler> crashHandler = Context::GetInstance()->GetCrashHandler();
     char intToCharBuffer[16];
 
     std::array<void*, 4096> arr;
@@ -189,15 +189,15 @@ static void ErrorHandler(int sig, siginfo_t* sigInfo, void* data) {
         snprintf(intToCharBuffer, sizeof(intToCharBuffer), "%i ", (int)i);
         WRITE_VAR_LINE(crashHandler, intToCharBuffer, functionName.c_str());
     }
-    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, (Ship::Context::GetInstance()->GetName() + " has crashed").c_str(),
-                             (Ship::Context::GetInstance()->GetName() +
-                              " has crashed. Please upload the logs to the support channel in discord.")
-                                 .c_str(),
-                             nullptr);
+    SDL_ShowSimpleMessageBox(
+        SDL_MESSAGEBOX_ERROR, (Context::GetInstance()->GetName() + " has crashed").c_str(),
+        (Context::GetInstance()->GetName() + " has crashed. Please upload the logs to the support channel in discord.")
+            .c_str(),
+        nullptr);
     free(symbols);
     crashHandler->PrintCommon();
 
-    Ship::Context::GetInstance()->GetLogger()->flush();
+    Context::GetInstance()->GetLogger()->flush();
     spdlog::shutdown();
     exit(1);
 }
@@ -385,23 +385,23 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
         }
     }
     PrintCommon();
-    Ship::Context::GetInstance()->GetLogger()->flush();
+    Context::GetInstance()->GetLogger()->flush();
     spdlog::shutdown();
 }
 
 extern "C" LONG WINAPI seh_filter(PEXCEPTION_POINTERS ex) {
     char exceptionString[20];
-    std::shared_ptr<CrashHandler> crashHandler = Ship::Context::GetInstance()->GetCrashHandler();
+    std::shared_ptr<CrashHandler> crashHandler = Context::GetInstance()->GetCrashHandler();
 
     snprintf(exceptionString, std::size(exceptionString), "0x%x", ex->ExceptionRecord->ExceptionCode);
 
     WRITE_VAR_LINE(crashHandler, "Exception: ", exceptionString);
     crashHandler->PrintStack(ex->ContextRecord);
-    MessageBoxA(nullptr,
-                (Ship::Context::GetInstance()->GetName() +
-                 " has crashed. Please upload the logs to the support channel in discord.")
-                    .c_str(),
-                "Crash", MB_OK | MB_ICONERROR);
+    MessageBoxA(
+        nullptr,
+        (Context::GetInstance()->GetName() + " has crashed. Please upload the logs to the support channel in discord.")
+            .c_str(),
+        "Crash", MB_OK | MB_ICONERROR);
 
     return EXCEPTION_EXECUTE_HANDLER;
 }

--- a/src/resource/File.h
+++ b/src/resource/File.h
@@ -27,9 +27,9 @@ struct ResourceInitData {
 
 struct File {
     std::shared_ptr<Archive> Parent;
-    std::shared_ptr<Ship::ResourceInitData> InitData;
+    std::shared_ptr<ResourceInitData> InitData;
     std::shared_ptr<std::vector<char>> Buffer;
-    std::variant<std::shared_ptr<tinyxml2::XMLDocument>, std::shared_ptr<Ship::BinaryReader>> Reader;
+    std::variant<std::shared_ptr<tinyxml2::XMLDocument>, std::shared_ptr<BinaryReader>> Reader;
     bool IsLoaded = false;
 };
 } // namespace Ship

--- a/src/resource/Resource.cpp
+++ b/src/resource/Resource.cpp
@@ -2,7 +2,7 @@
 #include <spdlog/spdlog.h>
 
 namespace Ship {
-IResource::IResource(std::shared_ptr<Ship::ResourceInitData> initData) : mInitData(initData) {
+IResource::IResource(std::shared_ptr<ResourceInitData> initData) : mInitData(initData) {
 }
 
 IResource::~IResource() {
@@ -17,7 +17,7 @@ void IResource::Dirty() {
     mIsDirty = true;
 }
 
-std::shared_ptr<Ship::ResourceInitData> IResource::GetInitData() {
+std::shared_ptr<ResourceInitData> IResource::GetInitData() {
     return mInitData;
 }
 } // namespace Ship

--- a/src/resource/Resource.h
+++ b/src/resource/Resource.h
@@ -9,7 +9,7 @@ class IResource {
   public:
     inline static const std::string gAltAssetPrefix = "alt/";
 
-    IResource(std::shared_ptr<Ship::ResourceInitData> initData);
+    IResource(std::shared_ptr<ResourceInitData> initData);
     virtual ~IResource();
 
     virtual void* GetRawPointer() = 0;
@@ -17,10 +17,10 @@ class IResource {
 
     bool IsDirty();
     void Dirty();
-    std::shared_ptr<Ship::ResourceInitData> GetInitData();
+    std::shared_ptr<ResourceInitData> GetInitData();
 
   private:
-    std::shared_ptr<Ship::ResourceInitData> mInitData;
+    std::shared_ptr<ResourceInitData> mInitData;
     bool mIsDirty = false;
 };
 

--- a/src/resource/ResourceFactory.h
+++ b/src/resource/ResourceFactory.h
@@ -7,9 +7,9 @@
 namespace Ship {
 class ResourceFactory {
   public:
-    virtual std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) = 0;
+    virtual std::shared_ptr<IResource> ReadResource(std::shared_ptr<File> file) = 0;
 
   protected:
-    virtual bool FileHasValidFormatAndReader(std::shared_ptr<Ship::File> file) = 0;
+    virtual bool FileHasValidFormatAndReader(std::shared_ptr<File> file) = 0;
 };
 } // namespace Ship

--- a/src/resource/ResourceFactoryBinary.cpp
+++ b/src/resource/ResourceFactoryBinary.cpp
@@ -3,13 +3,13 @@
 #include "spdlog/spdlog.h"
 
 namespace Ship {
-bool ResourceFactoryBinary::FileHasValidFormatAndReader(std::shared_ptr<Ship::File> file) {
+bool ResourceFactoryBinary::FileHasValidFormatAndReader(std::shared_ptr<File> file) {
     if (file->InitData->Format != RESOURCE_FORMAT_BINARY) {
         SPDLOG_ERROR("resource file format does not match factory format.");
         return false;
     }
 
-    if (!std::holds_alternative<std::shared_ptr<Ship::BinaryReader>>(file->Reader)) {
+    if (!std::holds_alternative<std::shared_ptr<BinaryReader>>(file->Reader)) {
         SPDLOG_ERROR("Failed to load resource: File has Reader ({} - {})", file->InitData->Type, file->InitData->Path);
         return false;
     }

--- a/src/resource/ResourceFactoryBinary.h
+++ b/src/resource/ResourceFactoryBinary.h
@@ -5,6 +5,6 @@
 namespace Ship {
 class ResourceFactoryBinary : public ResourceFactory {
   protected:
-    bool FileHasValidFormatAndReader(std::shared_ptr<Ship::File> file) override;
+    bool FileHasValidFormatAndReader(std::shared_ptr<File> file) override;
 };
 } // namespace Ship

--- a/src/resource/ResourceFactoryXML.cpp
+++ b/src/resource/ResourceFactoryXML.cpp
@@ -2,7 +2,7 @@
 #include "spdlog/spdlog.h"
 
 namespace Ship {
-bool ResourceFactoryXML::FileHasValidFormatAndReader(std::shared_ptr<Ship::File> file) {
+bool ResourceFactoryXML::FileHasValidFormatAndReader(std::shared_ptr<File> file) {
     if (file->InitData->Format != RESOURCE_FORMAT_XML) {
         SPDLOG_ERROR("resource file format does not match factory format.");
         return false;

--- a/src/resource/ResourceFactoryXML.h
+++ b/src/resource/ResourceFactoryXML.h
@@ -5,6 +5,6 @@
 namespace Ship {
 class ResourceFactoryXML : public ResourceFactory {
   protected:
-    bool FileHasValidFormatAndReader(std::shared_ptr<Ship::File> file) override;
+    bool FileHasValidFormatAndReader(std::shared_ptr<File> file) override;
 };
 } // namespace Ship

--- a/src/resource/ResourceLoader.cpp
+++ b/src/resource/ResourceLoader.cpp
@@ -18,8 +18,8 @@ ResourceLoader::~ResourceLoader() {
 }
 
 void ResourceLoader::RegisterGlobalResourceFactories() {
-    RegisterResourceFactory(std::make_shared<Ship::ResourceFactoryBinaryJsonV0>(), RESOURCE_FORMAT_BINARY, "Json",
-                            static_cast<uint32_t>(Ship::ResourceType::Json), 0);
+    RegisterResourceFactory(std::make_shared<ResourceFactoryBinaryJsonV0>(), RESOURCE_FORMAT_BINARY, "Json",
+                            static_cast<uint32_t>(ResourceType::Json), 0);
 }
 
 bool ResourceLoader::RegisterResourceFactory(std::shared_ptr<ResourceFactory> factory, uint32_t format,
@@ -76,7 +76,7 @@ std::shared_ptr<ResourceFactory> ResourceLoader::GetFactory(uint32_t format, std
     return GetFactory(format, mResourceTypes[typeName], version);
 }
 
-std::shared_ptr<Ship::IResource> ResourceLoader::LoadResource(std::shared_ptr<Ship::File> fileToLoad) {
+std::shared_ptr<IResource> ResourceLoader::LoadResource(std::shared_ptr<File> fileToLoad) {
     if (fileToLoad == nullptr) {
         SPDLOG_ERROR("Failed to load resource: File not loaded");
         return nullptr;

--- a/src/resource/ResourceLoader.h
+++ b/src/resource/ResourceLoader.h
@@ -32,7 +32,7 @@ class ResourceLoader {
     ResourceLoader();
     ~ResourceLoader();
 
-    std::shared_ptr<Ship::IResource> LoadResource(std::shared_ptr<Ship::File> fileToLoad);
+    std::shared_ptr<IResource> LoadResource(std::shared_ptr<File> fileToLoad);
     bool RegisterResourceFactory(std::shared_ptr<ResourceFactory> factory, uint32_t format, std::string typeName,
                                  uint32_t type, uint32_t version);
 

--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -38,8 +38,8 @@ bool ResourceManager::DidLoadSuccessfully() {
     return mArchiveManager != nullptr && mArchiveManager->IsArchiveLoaded();
 }
 
-std::shared_ptr<Ship::File> ResourceManager::LoadFileProcess(const std::string& filePath,
-                                                             std::shared_ptr<Ship::ResourceInitData> initData) {
+std::shared_ptr<File> ResourceManager::LoadFileProcess(const std::string& filePath,
+                                                       std::shared_ptr<ResourceInitData> initData) {
     auto file = mArchiveManager->LoadFile(filePath, initData);
     if (file != nullptr) {
         SPDLOG_TRACE("Loaded File {} on ResourceManager", file->InitData->Path);
@@ -49,9 +49,8 @@ std::shared_ptr<Ship::File> ResourceManager::LoadFileProcess(const std::string& 
     return file;
 }
 
-std::shared_ptr<Ship::IResource>
-ResourceManager::LoadResourceProcess(const std::string& filePath, bool loadExact,
-                                     std::shared_ptr<Ship::ResourceInitData> initData) {
+std::shared_ptr<IResource> ResourceManager::LoadResourceProcess(const std::string& filePath, bool loadExact,
+                                                                std::shared_ptr<ResourceInitData> initData) {
     // Check for and remove the OTR signature
     if (OtrSignatureCheck(filePath.c_str())) {
         const auto newFilePath = filePath.substr(7);
@@ -132,9 +131,9 @@ ResourceManager::LoadResourceProcess(const std::string& filePath, bool loadExact
     return resource;
 }
 
-std::shared_future<std::shared_ptr<Ship::IResource>>
+std::shared_future<std::shared_ptr<IResource>>
 ResourceManager::LoadResourceAsync(const std::string& filePath, bool loadExact, BS::priority_t priority,
-                                   std::shared_ptr<Ship::ResourceInitData> initData) {
+                                   std::shared_ptr<ResourceInitData> initData) {
     // Check for and remove the OTR signature
     if (OtrSignatureCheck(filePath.c_str())) {
         auto newFilePath = filePath.substr(7);
@@ -144,7 +143,7 @@ ResourceManager::LoadResourceAsync(const std::string& filePath, bool loadExact, 
     // Check the cache before queueing the job.
     auto cacheCheck = GetCachedResource(filePath, loadExact);
     if (cacheCheck) {
-        auto promise = std::make_shared<std::promise<std::shared_ptr<Ship::IResource>>>();
+        auto promise = std::make_shared<std::promise<std::shared_ptr<IResource>>>();
         promise->set_value(cacheCheck);
         return promise->get_future().share();
     }
@@ -155,8 +154,8 @@ ResourceManager::LoadResourceAsync(const std::string& filePath, bool loadExact, 
         std::bind(&ResourceManager::LoadResourceProcess, this, newFilePath, loadExact, initData), priority);
 }
 
-std::shared_ptr<Ship::IResource> ResourceManager::LoadResource(const std::string& filePath, bool loadExact,
-                                                               std::shared_ptr<Ship::ResourceInitData> initData) {
+std::shared_ptr<IResource> ResourceManager::LoadResource(const std::string& filePath, bool loadExact,
+                                                         std::shared_ptr<ResourceInitData> initData) {
     auto resource = LoadResourceAsync(filePath, loadExact, BS::pr::highest, initData).get();
     if (resource == nullptr) {
         SPDLOG_ERROR("Failed to load resource file at path {}", filePath);
@@ -164,7 +163,7 @@ std::shared_ptr<Ship::IResource> ResourceManager::LoadResource(const std::string
     return resource;
 }
 
-std::variant<ResourceManager::ResourceLoadError, std::shared_ptr<Ship::IResource>>
+std::variant<ResourceManager::ResourceLoadError, std::shared_ptr<IResource>>
 ResourceManager::CheckCache(const std::string& filePath, bool loadExact) {
     if (!loadExact && mAltAssetsEnabled && !filePath.starts_with(IResource::gAltAssetPrefix)) {
         const auto altPath = IResource::gAltAssetPrefix + filePath;
@@ -172,7 +171,7 @@ ResourceManager::CheckCache(const std::string& filePath, bool loadExact) {
 
         // If the type held at this cache index is a resource, then we return it.
         // Else we attempt to load standard definition assets.
-        if (std::holds_alternative<std::shared_ptr<Ship::IResource>>(altCacheResult)) {
+        if (std::holds_alternative<std::shared_ptr<IResource>>(altCacheResult)) {
             return altCacheResult;
         }
     }
@@ -187,17 +186,17 @@ ResourceManager::CheckCache(const std::string& filePath, bool loadExact) {
     return resourceCacheFind->second;
 }
 
-std::shared_ptr<Ship::IResource> ResourceManager::GetCachedResource(const std::string& filePath, bool loadExact) {
+std::shared_ptr<IResource> ResourceManager::GetCachedResource(const std::string& filePath, bool loadExact) {
     // Gets the cached resource based on filePath.
     return GetCachedResource(CheckCache(filePath, loadExact));
 }
 
-std::shared_ptr<Ship::IResource>
-ResourceManager::GetCachedResource(std::variant<ResourceLoadError, std::shared_ptr<Ship::IResource>> cacheLine) {
+std::shared_ptr<IResource>
+ResourceManager::GetCachedResource(std::variant<ResourceLoadError, std::shared_ptr<IResource>> cacheLine) {
     // Gets the cached resource based on a cache line std::variant from the cache map.
-    if (std::holds_alternative<std::shared_ptr<Ship::IResource>>(cacheLine)) {
+    if (std::holds_alternative<std::shared_ptr<IResource>>(cacheLine)) {
         try {
-            auto resource = std::get<std::shared_ptr<Ship::IResource>>(cacheLine);
+            auto resource = std::get<std::shared_ptr<IResource>>(cacheLine);
 
             if (resource.use_count() <= 0) {
                 return nullptr;
@@ -216,9 +215,9 @@ ResourceManager::GetCachedResource(std::variant<ResourceLoadError, std::shared_p
     return nullptr;
 }
 
-std::shared_ptr<std::vector<std::shared_future<std::shared_ptr<Ship::IResource>>>>
+std::shared_ptr<std::vector<std::shared_future<std::shared_ptr<IResource>>>>
 ResourceManager::LoadDirectoryAsync(const std::string& searchMask, BS::priority_t priority) {
-    auto loadedList = std::make_shared<std::vector<std::shared_future<std::shared_ptr<Ship::IResource>>>>();
+    auto loadedList = std::make_shared<std::vector<std::shared_future<std::shared_ptr<IResource>>>>();
     auto fileList = GetArchiveManager()->ListFiles(searchMask);
     loadedList->reserve(fileList->size());
 
@@ -231,10 +230,9 @@ ResourceManager::LoadDirectoryAsync(const std::string& searchMask, BS::priority_
     return loadedList;
 }
 
-std::shared_ptr<std::vector<std::shared_ptr<Ship::IResource>>>
-ResourceManager::LoadDirectory(const std::string& searchMask) {
+std::shared_ptr<std::vector<std::shared_ptr<IResource>>> ResourceManager::LoadDirectory(const std::string& searchMask) {
     auto futureList = LoadDirectoryAsync(searchMask, true);
-    auto loadedList = std::make_shared<std::vector<std::shared_ptr<Ship::IResource>>>();
+    auto loadedList = std::make_shared<std::vector<std::shared_ptr<IResource>>>();
 
     for (size_t i = 0; i < futureList->size(); i++) {
         const auto future = futureList->at(i);
@@ -279,7 +277,7 @@ size_t ResourceManager::UnloadResource(const std::string& filePath) {
     // Store a shared pointer here so that erase doesn't destruct the resource.
     // The resource will attempt to load other resources on the destructor, and this will fail because we already hold
     // the mutex.
-    std::variant<ResourceLoadError, std::shared_ptr<Ship::IResource>> value = nullptr;
+    std::variant<ResourceLoadError, std::shared_ptr<IResource>> value = nullptr;
     size_t ret = 0;
     {
         const std::lock_guard<std::mutex> lock(mMutex);

--- a/src/resource/ResourceManager.h
+++ b/src/resource/ResourceManager.h
@@ -32,17 +32,17 @@ class ResourceManager {
     bool DidLoadSuccessfully();
     std::shared_ptr<ArchiveManager> GetArchiveManager();
     std::shared_ptr<ResourceLoader> GetResourceLoader();
-    std::shared_ptr<Ship::IResource> GetCachedResource(const std::string& filePath, bool loadExact = false);
-    std::shared_ptr<Ship::IResource> LoadResource(const std::string& filePath, bool loadExact = false,
-                                                  std::shared_ptr<Ship::ResourceInitData> initData = nullptr);
-    std::shared_ptr<Ship::IResource> LoadResourceProcess(const std::string& filePath, bool loadExact = false,
-                                                         std::shared_ptr<Ship::ResourceInitData> initData = nullptr);
+    std::shared_ptr<IResource> GetCachedResource(const std::string& filePath, bool loadExact = false);
+    std::shared_ptr<IResource> LoadResource(const std::string& filePath, bool loadExact = false,
+                                            std::shared_ptr<ResourceInitData> initData = nullptr);
+    std::shared_ptr<IResource> LoadResourceProcess(const std::string& filePath, bool loadExact = false,
+                                                   std::shared_ptr<ResourceInitData> initData = nullptr);
     size_t UnloadResource(const std::string& filePath);
-    std::shared_future<std::shared_ptr<Ship::IResource>>
+    std::shared_future<std::shared_ptr<IResource>>
     LoadResourceAsync(const std::string& filePath, bool loadExact = false, BS::priority_t priority = BS::pr::normal,
-                      std::shared_ptr<Ship::ResourceInitData> initData = nullptr);
-    std::shared_ptr<std::vector<std::shared_ptr<Ship::IResource>>> LoadDirectory(const std::string& searchMask);
-    std::shared_ptr<std::vector<std::shared_future<std::shared_ptr<Ship::IResource>>>>
+                      std::shared_ptr<ResourceInitData> initData = nullptr);
+    std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadDirectory(const std::string& searchMask);
+    std::shared_ptr<std::vector<std::shared_future<std::shared_ptr<IResource>>>>
     LoadDirectoryAsync(const std::string& searchMask, BS::priority_t priority = BS::pr::normal);
     void DirtyDirectory(const std::string& searchMask);
     void UnloadDirectory(const std::string& searchMask);
@@ -51,15 +51,14 @@ class ResourceManager {
     void SetAltAssetsEnabled(bool isEnabled);
 
   protected:
-    std::shared_ptr<Ship::File> LoadFileProcess(const std::string& filePath,
-                                                std::shared_ptr<Ship::ResourceInitData> initData = nullptr);
-    std::shared_ptr<Ship::IResource>
-    GetCachedResource(std::variant<ResourceLoadError, std::shared_ptr<Ship::IResource>> cacheLine);
-    std::variant<ResourceLoadError, std::shared_ptr<Ship::IResource>> CheckCache(const std::string& filePath,
-                                                                                 bool loadExact = false);
+    std::shared_ptr<File> LoadFileProcess(const std::string& filePath,
+                                          std::shared_ptr<ResourceInitData> initData = nullptr);
+    std::shared_ptr<IResource> GetCachedResource(std::variant<ResourceLoadError, std::shared_ptr<IResource>> cacheLine);
+    std::variant<ResourceLoadError, std::shared_ptr<IResource>> CheckCache(const std::string& filePath,
+                                                                           bool loadExact = false);
 
   private:
-    std::unordered_map<std::string, std::variant<ResourceLoadError, std::shared_ptr<Ship::IResource>>> mResourceCache;
+    std::unordered_map<std::string, std::variant<ResourceLoadError, std::shared_ptr<IResource>>> mResourceCache;
     std::shared_ptr<ResourceLoader> mResourceLoader;
     std::shared_ptr<ArchiveManager> mArchiveManager;
     std::shared_ptr<BS::thread_pool> mThreadPool;

--- a/src/resource/archive/Archive.cpp
+++ b/src/resource/archive/Archive.cpp
@@ -30,7 +30,7 @@ void Archive::Load() {
         mHasGameVersion = true;
         auto stream = std::make_shared<MemoryStream>(t->Buffer->data(), t->Buffer->size());
         auto reader = std::make_shared<BinaryReader>(stream);
-        Ship::Endianness endianness = (Endianness)reader->ReadUByte();
+        Endianness endianness = (Endianness)reader->ReadUByte();
         reader->SetEndianness(endianness);
         SetGameVersion(reader->ReadUInt32());
         isGameVersionValid =
@@ -109,8 +109,8 @@ void Archive::IndexFile(const std::string& filePath) {
     (*mHashes)[CRC64(filePath.c_str())] = filePath;
 }
 
-std::shared_ptr<Ship::ResourceInitData> Archive::ReadResourceInitData(const std::string& filePath,
-                                                                      std::shared_ptr<Ship::File> metaFileToLoad) {
+std::shared_ptr<ResourceInitData> Archive::ReadResourceInitData(const std::string& filePath,
+                                                                std::shared_ptr<File> metaFileToLoad) {
     auto initData = CreateDefaultResourceInitData();
 
     // just using metaFileToLoad->Buffer->data() leads to garbage at the end
@@ -137,8 +137,8 @@ std::shared_ptr<Ship::ResourceInitData> Archive::ReadResourceInitData(const std:
     return initData;
 }
 
-std::shared_ptr<Ship::ResourceInitData> Archive::ReadResourceInitDataLegacy(const std::string& filePath,
-                                                                            std::shared_ptr<Ship::File> fileToLoad) {
+std::shared_ptr<ResourceInitData> Archive::ReadResourceInitDataLegacy(const std::string& filePath,
+                                                                      std::shared_ptr<File> fileToLoad) {
     // Determine if file is binary or XML...
     if (fileToLoad->Buffer->at(0) == '<') {
         // File is XML
@@ -177,14 +177,14 @@ std::shared_ptr<Ship::ResourceInitData> Archive::ReadResourceInitDataLegacy(cons
     }
 }
 
-std::shared_ptr<Ship::BinaryReader> Archive::CreateBinaryReader(std::shared_ptr<Ship::File> fileToLoad) {
+std::shared_ptr<BinaryReader> Archive::CreateBinaryReader(std::shared_ptr<File> fileToLoad) {
     auto stream = std::make_shared<MemoryStream>(fileToLoad->Buffer);
     auto reader = std::make_shared<BinaryReader>(stream);
     reader->SetEndianness(fileToLoad->InitData->ByteOrder);
     return reader;
 }
 
-std::shared_ptr<tinyxml2::XMLDocument> Archive::CreateXMLReader(std::shared_ptr<Ship::File> fileToLoad) {
+std::shared_ptr<tinyxml2::XMLDocument> Archive::CreateXMLReader(std::shared_ptr<File> fileToLoad) {
     auto stream = std::make_shared<MemoryStream>(fileToLoad->Buffer);
     auto binaryReader = std::make_shared<BinaryReader>(stream);
 
@@ -199,9 +199,8 @@ std::shared_ptr<tinyxml2::XMLDocument> Archive::CreateXMLReader(std::shared_ptr<
     return xmlReader;
 }
 
-std::shared_ptr<Ship::File> Archive::LoadFile(const std::string& filePath,
-                                              std::shared_ptr<Ship::ResourceInitData> initData) {
-    std::shared_ptr<Ship::File> fileToLoad = nullptr;
+std::shared_ptr<File> Archive::LoadFile(const std::string& filePath, std::shared_ptr<ResourceInitData> initData) {
+    std::shared_ptr<File> fileToLoad = nullptr;
 
     if (initData != nullptr) {
         fileToLoad = LoadFileRaw(filePath);
@@ -237,13 +236,13 @@ std::shared_ptr<Ship::File> Archive::LoadFile(const std::string& filePath,
     return fileToLoad;
 }
 
-std::shared_ptr<Ship::File> Archive::LoadFile(uint64_t hash, std::shared_ptr<Ship::ResourceInitData> initData) {
+std::shared_ptr<File> Archive::LoadFile(uint64_t hash, std::shared_ptr<ResourceInitData> initData) {
     const std::string& filePath =
         *Context::GetInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
     return LoadFile(filePath, initData);
 }
 
-std::shared_ptr<Ship::ResourceInitData> Archive::CreateDefaultResourceInitData() {
+std::shared_ptr<ResourceInitData> Archive::CreateDefaultResourceInitData() {
     auto resourceInitData = std::make_shared<ResourceInitData>();
     resourceInitData->Id = 0xDEADBEEFDEADBEEF;
     resourceInitData->Type = static_cast<uint32_t>(ResourceType::None);
@@ -254,8 +253,8 @@ std::shared_ptr<Ship::ResourceInitData> Archive::CreateDefaultResourceInitData()
     return resourceInitData;
 }
 
-std::shared_ptr<Ship::ResourceInitData>
-Archive::ReadResourceInitDataBinary(const std::string& filePath, std::shared_ptr<Ship::BinaryReader> headerReader) {
+std::shared_ptr<ResourceInitData> Archive::ReadResourceInitDataBinary(const std::string& filePath,
+                                                                      std::shared_ptr<BinaryReader> headerReader) {
     auto resourceInitData = CreateDefaultResourceInitData();
     resourceInitData->Path = filePath;
 
@@ -294,8 +293,8 @@ Archive::ReadResourceInitDataBinary(const std::string& filePath, std::shared_ptr
     return resourceInitData;
 }
 
-std::shared_ptr<Ship::ResourceInitData>
-Archive::ReadResourceInitDataXml(const std::string& filePath, std::shared_ptr<tinyxml2::XMLDocument> document) {
+std::shared_ptr<ResourceInitData> Archive::ReadResourceInitDataXml(const std::string& filePath,
+                                                                   std::shared_ptr<tinyxml2::XMLDocument> document) {
     auto resourceInitData = CreateDefaultResourceInitData();
     resourceInitData->Path = filePath;
 

--- a/src/resource/archive/Archive.h
+++ b/src/resource/archive/Archive.h
@@ -23,10 +23,9 @@ class Archive {
     void Load();
     void Unload();
 
-    virtual std::shared_ptr<Ship::File> LoadFile(const std::string& filePath,
-                                                 std::shared_ptr<Ship::ResourceInitData> initData = nullptr);
-    virtual std::shared_ptr<Ship::File> LoadFile(uint64_t hash,
-                                                 std::shared_ptr<Ship::ResourceInitData> initData = nullptr);
+    virtual std::shared_ptr<File> LoadFile(const std::string& filePath,
+                                           std::shared_ptr<ResourceInitData> initData = nullptr);
+    virtual std::shared_ptr<File> LoadFile(uint64_t hash, std::shared_ptr<ResourceInitData> initData = nullptr);
     std::shared_ptr<std::unordered_map<uint64_t, std::string>> ListFiles();
     std::shared_ptr<std::unordered_map<uint64_t, std::string>> ListFiles(const std::string& filter);
     bool HasFile(const std::string& filePath);
@@ -43,21 +42,21 @@ class Archive {
     void SetLoaded(bool isLoaded);
     void SetGameVersion(uint32_t gameVersion);
     void IndexFile(const std::string& filePath);
-    virtual std::shared_ptr<Ship::File> LoadFileRaw(const std::string& filePath) = 0;
-    virtual std::shared_ptr<Ship::File> LoadFileRaw(uint64_t hash) = 0;
+    virtual std::shared_ptr<File> LoadFileRaw(const std::string& filePath) = 0;
+    virtual std::shared_ptr<File> LoadFileRaw(uint64_t hash) = 0;
 
   private:
-    static std::shared_ptr<Ship::ResourceInitData> CreateDefaultResourceInitData();
-    std::shared_ptr<Ship::ResourceInitData> ReadResourceInitData(const std::string& filePath,
-                                                                 std::shared_ptr<Ship::File> metaFileToLoad);
-    std::shared_ptr<Ship::ResourceInitData> ReadResourceInitDataLegacy(const std::string& filePath,
-                                                                       std::shared_ptr<Ship::File> fileToLoad);
-    static std::shared_ptr<Ship::ResourceInitData>
-    ReadResourceInitDataBinary(const std::string& filePath, std::shared_ptr<Ship::BinaryReader> headerReader);
-    static std::shared_ptr<Ship::ResourceInitData>
-    ReadResourceInitDataXml(const std::string& filePath, std::shared_ptr<tinyxml2::XMLDocument> document);
-    std::shared_ptr<Ship::BinaryReader> CreateBinaryReader(std::shared_ptr<Ship::File> fileToLoad);
-    std::shared_ptr<tinyxml2::XMLDocument> CreateXMLReader(std::shared_ptr<Ship::File> fileToLoad);
+    static std::shared_ptr<ResourceInitData> CreateDefaultResourceInitData();
+    std::shared_ptr<ResourceInitData> ReadResourceInitData(const std::string& filePath,
+                                                           std::shared_ptr<File> metaFileToLoad);
+    std::shared_ptr<ResourceInitData> ReadResourceInitDataLegacy(const std::string& filePath,
+                                                                 std::shared_ptr<File> fileToLoad);
+    static std::shared_ptr<ResourceInitData> ReadResourceInitDataBinary(const std::string& filePath,
+                                                                        std::shared_ptr<BinaryReader> headerReader);
+    static std::shared_ptr<ResourceInitData> ReadResourceInitDataXml(const std::string& filePath,
+                                                                     std::shared_ptr<tinyxml2::XMLDocument> document);
+    std::shared_ptr<BinaryReader> CreateBinaryReader(std::shared_ptr<File> fileToLoad);
+    std::shared_ptr<tinyxml2::XMLDocument> CreateXMLReader(std::shared_ptr<File> fileToLoad);
 
     bool mIsLoaded;
     bool mHasGameVersion;

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -38,8 +38,8 @@ bool ArchiveManager::IsArchiveLoaded() {
     return !mArchives.empty();
 }
 
-std::shared_ptr<Ship::File> ArchiveManager::LoadFile(const std::string& filePath,
-                                                     std::shared_ptr<Ship::ResourceInitData> initData) {
+std::shared_ptr<File> ArchiveManager::LoadFile(const std::string& filePath,
+                                               std::shared_ptr<ResourceInitData> initData) {
     if (filePath == "") {
         return nullptr;
     }
@@ -47,7 +47,7 @@ std::shared_ptr<Ship::File> ArchiveManager::LoadFile(const std::string& filePath
     return LoadFile(CRC64(filePath.c_str()), initData);
 }
 
-std::shared_ptr<Ship::File> ArchiveManager::LoadFile(uint64_t hash, std::shared_ptr<Ship::ResourceInitData> initData) {
+std::shared_ptr<File> ArchiveManager::LoadFile(uint64_t hash, std::shared_ptr<ResourceInitData> initData) {
     const auto archive = mFileToArchive[hash];
     if (archive == nullptr) {
         return nullptr;

--- a/src/resource/archive/ArchiveManager.h
+++ b/src/resource/archive/ArchiveManager.h
@@ -20,9 +20,8 @@ class ArchiveManager {
     ~ArchiveManager();
 
     bool IsArchiveLoaded();
-    std::shared_ptr<Ship::File> LoadFile(const std::string& filePath,
-                                         std::shared_ptr<Ship::ResourceInitData> initData = nullptr);
-    std::shared_ptr<Ship::File> LoadFile(uint64_t hash, std::shared_ptr<Ship::ResourceInitData> initData = nullptr);
+    std::shared_ptr<File> LoadFile(const std::string& filePath, std::shared_ptr<ResourceInitData> initData = nullptr);
+    std::shared_ptr<File> LoadFile(uint64_t hash, std::shared_ptr<ResourceInitData> initData = nullptr);
     bool HasFile(const std::string& filePath);
     bool HasFile(uint64_t hash);
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& filter);

--- a/src/resource/archive/O2rArchive.cpp
+++ b/src/resource/archive/O2rArchive.cpp
@@ -11,13 +11,13 @@ O2rArchive::~O2rArchive() {
     SPDLOG_TRACE("destruct o2rarchive: {}", GetPath());
 }
 
-std::shared_ptr<Ship::File> O2rArchive::LoadFileRaw(uint64_t hash) {
+std::shared_ptr<File> O2rArchive::LoadFileRaw(uint64_t hash) {
     const std::string& filePath =
         *Context::GetInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
     return LoadFileRaw(filePath);
 }
 
-std::shared_ptr<Ship::File> O2rArchive::LoadFileRaw(const std::string& filePath) {
+std::shared_ptr<File> O2rArchive::LoadFileRaw(const std::string& filePath) {
     if (mZipArchive == nullptr) {
         SPDLOG_TRACE("Failed to open file {} from zip archive {}. Archive not open.", filePath, GetPath());
         return nullptr;

--- a/src/resource/archive/O2rArchive.h
+++ b/src/resource/archive/O2rArchive.h
@@ -24,8 +24,8 @@ class O2rArchive : virtual public Archive {
     bool Close();
 
   protected:
-    std::shared_ptr<Ship::File> LoadFileRaw(const std::string& filePath);
-    std::shared_ptr<Ship::File> LoadFileRaw(uint64_t hash);
+    std::shared_ptr<File> LoadFileRaw(const std::string& filePath);
+    std::shared_ptr<File> LoadFileRaw(uint64_t hash);
 
   private:
     zip_t* mZipArchive;

--- a/src/resource/archive/OtrArchive.cpp
+++ b/src/resource/archive/OtrArchive.cpp
@@ -18,7 +18,7 @@ OtrArchive::~OtrArchive() {
     SPDLOG_TRACE("destruct otrarchive: {}", GetPath());
 }
 
-std::shared_ptr<Ship::File> OtrArchive::LoadFileRaw(const std::string& filePath) {
+std::shared_ptr<File> OtrArchive::LoadFileRaw(const std::string& filePath) {
     if (mHandle == nullptr) {
         SPDLOG_TRACE("Failed to open file {} from mpq archive {}. Archive not open.", filePath, GetPath());
         return nullptr;
@@ -57,7 +57,7 @@ std::shared_ptr<Ship::File> OtrArchive::LoadFileRaw(const std::string& filePath)
     return fileToLoad;
 }
 
-std::shared_ptr<Ship::File> OtrArchive::LoadFileRaw(uint64_t hash) {
+std::shared_ptr<File> OtrArchive::LoadFileRaw(uint64_t hash) {
     const std::string& filePath =
         *Context::GetInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
     return LoadFileRaw(filePath);

--- a/src/resource/archive/OtrArchive.h
+++ b/src/resource/archive/OtrArchive.h
@@ -30,8 +30,8 @@ class OtrArchive : virtual public Archive {
     bool Close();
 
   protected:
-    std::shared_ptr<Ship::File> LoadFileRaw(const std::string& filePath);
-    std::shared_ptr<Ship::File> LoadFileRaw(uint64_t hash);
+    std::shared_ptr<File> LoadFileRaw(const std::string& filePath);
+    std::shared_ptr<File> LoadFileRaw(uint64_t hash);
 
   private:
     HANDLE mHandle;

--- a/src/window/Window.cpp
+++ b/src/window/Window.cpp
@@ -81,8 +81,8 @@ bool Window::IsAvailableWindowBackend(int32_t backendId) {
 
 void Window::SetWindowBackend(WindowBackend backend) {
     mWindowBackend = backend;
-    Ship::Context::GetInstance()->GetConfig()->SetWindowBackend(GetWindowBackend());
-    Ship::Context::GetInstance()->GetConfig()->Save();
+    Context::GetInstance()->GetConfig()->SetWindowBackend(GetWindowBackend());
+    Context::GetInstance()->GetConfig()->Save();
 }
 
 void Window::AddAvailableWindowBackend(WindowBackend backend) {

--- a/src/window/gui/ConsoleWindow.cpp
+++ b/src/window/gui/ConsoleWindow.cpp
@@ -24,8 +24,8 @@ int32_t ConsoleWindow::HelpCommand(std::shared_ptr<Console> console, const std::
 
 int32_t ConsoleWindow::ClearCommand(std::shared_ptr<Console> console, const std::vector<std::string>& args,
                                     std::string* output) {
-    auto window = std::static_pointer_cast<Ship::ConsoleWindow>(
-        Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"));
+    auto window =
+        std::static_pointer_cast<ConsoleWindow>(Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"));
     if (!window) {
         if (output) {
             *output += "A console window is necessary for Clear";
@@ -41,7 +41,7 @@ int32_t ConsoleWindow::ClearCommand(std::shared_ptr<Console> console, const std:
 int32_t ConsoleWindow::BindCommand(std::shared_ptr<Console> console, const std::vector<std::string>& args,
                                    std::string* output) {
     if (args.size() > 2) {
-        auto window = std::static_pointer_cast<Ship::ConsoleWindow>(
+        auto window = std::static_pointer_cast<ConsoleWindow>(
             Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"));
         if (!window) {
             if (output) {
@@ -81,7 +81,7 @@ int32_t ConsoleWindow::BindCommand(std::shared_ptr<Console> console, const std::
 int32_t ConsoleWindow::BindToggleCommand(std::shared_ptr<Console> console, const std::vector<std::string>& args,
                                          std::string* output) {
     if (args.size() > 2) {
-        auto window = std::static_pointer_cast<Ship::ConsoleWindow>(
+        auto window = std::static_pointer_cast<ConsoleWindow>(
             Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"));
         if (!window) {
             if (output) {
@@ -164,19 +164,19 @@ int32_t ConsoleWindow::GetCommand(std::shared_ptr<Console> console, const std::v
     auto cvar = CVarGet(args[1].c_str());
 
     if (cvar != nullptr) {
-        if (cvar->Type == Ship::ConsoleVariableType::Integer) {
+        if (cvar->Type == ConsoleVariableType::Integer) {
             if (output) {
                 *output += StringHelper::Sprintf("[LUS] Variable %s is %i", args[1].c_str(), cvar->Integer);
             }
-        } else if (cvar->Type == Ship::ConsoleVariableType::Float) {
+        } else if (cvar->Type == ConsoleVariableType::Float) {
             if (output) {
                 *output += StringHelper::Sprintf("[LUS] Variable %s is %f", args[1].c_str(), cvar->Float);
             }
-        } else if (cvar->Type == Ship::ConsoleVariableType::String) {
+        } else if (cvar->Type == ConsoleVariableType::String) {
             if (output) {
                 *output += StringHelper::Sprintf("[LUS] Variable %s is %s", args[1].c_str(), cvar->String.c_str());
             }
-        } else if (cvar->Type == Ship::ConsoleVariableType::Color) {
+        } else if (cvar->Type == ConsoleVariableType::Color) {
             if (output) {
                 *output += StringHelper::Sprintf("[LUS] Variable %s is %08X", args[1].c_str(), cvar->Color);
             }
@@ -231,19 +231,18 @@ void ConsoleWindow::InitElement() {
     Context::GetInstance()->GetConsole()->AddCommand(
         "set", { SetCommand,
                  "Sets a console variable.",
-                 { { "varName", Ship::ArgumentType::TEXT }, { "varValue", Ship::ArgumentType::TEXT } } });
+                 { { "varName", ArgumentType::TEXT }, { "varValue", ArgumentType::TEXT } } });
     Context::GetInstance()->GetConsole()->AddCommand(
-        "get", { GetCommand, "Bind key as a bool toggle", { { "varName", Ship::ArgumentType::TEXT } } });
+        "get", { GetCommand, "Bind key as a bool toggle", { { "varName", ArgumentType::TEXT } } });
     Context::GetInstance()->GetConsole()->AddCommand("help", { HelpCommand, "Shows all the commands" });
     Context::GetInstance()->GetConsole()->AddCommand("clear", { ClearCommand, "Clear the console history" });
     Context::GetInstance()->GetConsole()->AddCommand(
-        "bind", { BindCommand,
-                  "Binds key to commands",
-                  { { "key", Ship::ArgumentType::TEXT }, { "cmd", Ship::ArgumentType::TEXT } } });
+        "bind",
+        { BindCommand, "Binds key to commands", { { "key", ArgumentType::TEXT }, { "cmd", ArgumentType::TEXT } } });
     Context::GetInstance()->GetConsole()->AddCommand(
         "bind-toggle", { BindToggleCommand,
                          "Bind key as a bool toggle",
-                         { { "key", Ship::ArgumentType::TEXT }, { "cmd", Ship::ArgumentType::TEXT } } });
+                         { { "key", ArgumentType::TEXT }, { "cmd", ArgumentType::TEXT } } });
 }
 
 void ConsoleWindow::UpdateElement() {

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -125,8 +125,8 @@ void Gui::Init(GuiWindowInitData windowImpl) {
     mImGuiIo->FontGlobalScale = 2.0f;
 #endif
 
-    auto imguiIniPath = Ship::Context::GetPathRelativeToAppDirectory("imgui.ini");
-    auto imguiLogPath = Ship::Context::GetPathRelativeToAppDirectory("imgui_log.txt");
+    auto imguiIniPath = Context::GetPathRelativeToAppDirectory("imgui.ini");
+    auto imguiLogPath = Context::GetPathRelativeToAppDirectory("imgui_log.txt");
     mImGuiIo->IniFilename = strcpy(new char[imguiIniPath.length() + 1], imguiIniPath.c_str());
     mImGuiIo->LogFilename = strcpy(new char[imguiLogPath.length() + 1], imguiLogPath.c_str());
 
@@ -266,7 +266,7 @@ void Gui::Update(WindowEvent event) {
         case WindowBackend::FAST3D_SDL_METAL:
             ImGui_ImplSDL2_ProcessEvent(static_cast<const SDL_Event*>(event.Sdl.Event));
 #if defined(__ANDROID__) || defined(__IOS__)
-            Ship::Mobile::ImGuiProcessEvent(mImGuiIo->WantTextInput);
+            Mobile::ImGuiProcessEvent(mImGuiIo->WantTextInput);
 #endif
             break;
 #ifdef ENABLE_DX11
@@ -295,7 +295,7 @@ void Gui::UnblockImGuiGamepadNavigation() {
 }
 
 void Gui::DrawMenu() {
-    Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console")->Update();
+    Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console")->Update();
     ImGuiBackendNewFrame();
     ImGuiWMNewFrame();
     ImGui::NewFrame();
@@ -353,15 +353,15 @@ void Gui::DrawMenu() {
 #if __APPLE__
     if ((ImGui::IsKeyDown(ImGuiKey_LeftSuper) || ImGui::IsKeyDown(ImGuiKey_RightSuper)) &&
         ImGui::IsKeyPressed(ImGuiKey_R, false)) {
-        std::reinterpret_pointer_cast<Ship::ConsoleWindow>(
-            Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
+        std::reinterpret_pointer_cast<ConsoleWindow>(
+            Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
             ->Dispatch("reset");
     }
 #else
     if ((ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) &&
         ImGui::IsKeyPressed(ImGuiKey_R, false)) {
-        std::reinterpret_pointer_cast<Ship::ConsoleWindow>(
-            Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
+        std::reinterpret_pointer_cast<ConsoleWindow>(
+            Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
             ->Dispatch("reset");
     }
 #endif

--- a/src/window/gui/GuiElement.cpp
+++ b/src/window/gui/GuiElement.cpp
@@ -60,7 +60,7 @@ void GuiElement::SyncVisibilityConsoleVariable() {
     }
 
     if (shouldSave) {
-        Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+        Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
     }
 }
 

--- a/src/window/gui/InputEditorWindow.cpp
+++ b/src/window/gui/InputEditorWindow.cpp
@@ -1462,7 +1462,7 @@ void InputEditorWindow::DrawPortTab(uint8_t portIndex) {
     if (ImGui::BeginTabItem(StringHelper::Sprintf("Port %d###port%d", portIndex + 1, portIndex).c_str())) {
         DrawClearAllButton(portIndex);
         DrawSetDefaultsButton(portIndex);
-        if (!Ship::Context::GetInstance()->GetControlDeck()->IsSinglePlayerMappingMode()) {
+        if (!Context::GetInstance()->GetControlDeck()->IsSinglePlayerMappingMode()) {
             ImGui::SameLine();
             if (ImGui::Button("Reorder controllers")) {
                 Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Controller Reordering")->Show();

--- a/src/window/gui/InputEditorWindow.h
+++ b/src/window/gui/InputEditorWindow.h
@@ -57,7 +57,7 @@ class InputEditorWindow : public GuiWindow {
     int32_t mGameInputBlockTimer;
     int32_t mMappingInputBlockTimer;
     int32_t mRumbleTimer;
-    std::shared_ptr<Ship::ControllerRumbleMapping> mRumbleMappingToTest;
+    std::shared_ptr<ControllerRumbleMapping> mRumbleMappingToTest;
 
     // mBitmaskToMappingIds[port][bitmask] = { id0, id1, ... }
     std::unordered_map<uint8_t, std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::string>>> mBitmaskToMappingIds;
@@ -74,7 +74,7 @@ class InputEditorWindow : public GuiWindow {
     std::set<CONTROLLERBUTTONS_T> mButtonsBitmasks;
     std::set<CONTROLLERBUTTONS_T> mDpadBitmasks;
     void DrawButtonDeviceIcons(uint8_t portIndex, std::set<CONTROLLERBUTTONS_T> bitmasks);
-    void DrawAnalogStickDeviceIcons(uint8_t portIndex, Ship::Stick stick);
+    void DrawAnalogStickDeviceIcons(uint8_t portIndex, Stick stick);
     void DrawRumbleDeviceIcons(uint8_t portIndex);
     void DrawGyroDeviceIcons(uint8_t portIndex);
     void DrawLEDDeviceIcons(uint8_t portIndex);
@@ -82,7 +82,7 @@ class InputEditorWindow : public GuiWindow {
     void DrawSetDefaultsButton(uint8_t portIndex);
     void DrawClearAllButton(uint8_t portIndex);
 
-    std::map<Ship::ShipDeviceIndex, bool> mDeviceIndexVisiblity;
+    std::map<ShipDeviceIndex, bool> mDeviceIndexVisiblity;
     void DrawDeviceVisibilityButtons();
 };
 } // namespace Ship


### PR DESCRIPTION
resolves https://github.com/Kenix3/libultraship/issues/578