### PR TITLE
GfxDebugger for other f3d's

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -85,7 +85,7 @@ void Context::Init(const std::vector<std::string>& otrFiles, const std::unordere
     InitConsole();
     InitWindow();
     InitAudio();
-    InitGfxDebugger();
+    InitGfxDebugger(0);
 }
 
 void Context::InitLogging() {
@@ -236,12 +236,16 @@ void Context::InitAudio() {
     GetAudio()->Init();
 }
 
-void Context::InitGfxDebugger() {
+void Context::InitGfxDebugger(uint32_t ucode) {
     if (GetGfxDebugger() != nullptr) {
         return;
     }
 
     mGfxDebugger = std::make_shared<LUS::GfxDebugger>();
+
+#ifdef GFX_DEBUG_DISASSEMBLER
+    mGfxDebugger->SetUcode(ucode);
+#endif
 }
 
 void Context::InitConsole() {

--- a/src/Context.h
+++ b/src/Context.h
@@ -66,7 +66,7 @@ class Context {
     void InitControlDeck(std::vector<CONTROLLERBUTTONS_T> additionalBitmasks = {});
     void InitCrashHandler();
     void InitAudio();
-    void InitGfxDebugger();
+    void InitGfxDebugger(uint32_t ucode);
     void InitConsole();
     void InitWindow(std::vector<std::shared_ptr<GuiWindow>> guiWindows = {});
 

--- a/src/debug/GfxDebugger.cpp
+++ b/src/debug/GfxDebugger.cpp
@@ -1,5 +1,7 @@
 #include "GfxDebugger.h"
 #include <spdlog/fmt/fmt.h>
+#include <gfxd.h>
+#include <spdlog/spdlog.h>
 
 namespace LUS {
 
@@ -50,5 +52,30 @@ bool GfxDebugger::HasBreakPoint(const std::vector<const F3DGfx*>& path) const {
 
     return true;
 }
+
+#ifdef GFX_DEBUG_DISASSEMBLER
+
+gfxd_ucode_t GfxDebugger::GetUcode(void) {
+    return mSelectedUcode;
+}
+
+void GfxDebugger::SetUcode(uint32_t ucode) {
+    switch(ucode) {
+        case 0:
+            mSelectedUcode = gfxd_f3d;
+            break;
+        case 1:
+            mSelectedUcode = gfxd_f3dex;
+            break;
+        case 2:
+            mSelectedUcode = gfxd_f3dex2;
+            break;
+        default:
+            SPDLOG_ERROR("Incorrect ucode for GfxDebugger, defaulting to f3dex2");
+            mSelectedUcode = gfxd_f3dex2;
+            break;
+    }
+}
+#endif
 
 } // namespace LUS

--- a/src/debug/GfxDebugger.h
+++ b/src/debug/GfxDebugger.h
@@ -2,6 +2,9 @@
 
 #include <string>
 #include <vector>
+#ifdef GFX_DEBUG_DISASSEMBLER
+#include <gfxd.h>
+#endif
 
 union F3DGfx;
 
@@ -24,6 +27,11 @@ class GfxDebugger {
     bool HasBreakPoint(const std::vector<const F3DGfx*>& path) const;
 
     void SetBreakPoint(const std::vector<const F3DGfx*>& bp);
+#ifdef GFX_DEBUG_DISASSEMBLER
+    gfxd_ucode_t mSelectedUcode;
+    void SetUcode(uint32_t);
+    gfxd_ucode_t GetUcode(void);
+#endif
 
   private:
     bool mIsDebugging = false;

--- a/src/window/gui/GfxDebuggerWindow.cpp
+++ b/src/window/gui/GfxDebuggerWindow.cpp
@@ -96,7 +96,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
             char buff[512] = { 0 };
             gfxd_output_buffer(buff, sizeof(buff));
             gfxd_enable(gfxd_emit_dec_color);
-            gfxd_target(gfxd_f3dex2);
+            gfxd_target(dbg->GetUcode());
             gfxd_execute();
 
             node_with_text(cmd, fmt::format("{}", buff));
@@ -114,7 +114,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
         const F3DGfx* cmd0 = cmd;
         switch (opcode) {
 
-            case F3DEX2_G_NOOP: {
+            case F3DEX_G_NOOP: {
                 const char* filename = (const char*)cmd->words.w1;
                 uint32_t p = C0(16, 8);
                 uint32_t l = C0(0, 16);
@@ -191,7 +191,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 break;
             };
 
-            case F3DEX2_G_DL: {
+            case F3DEX_G_DL: {
                 F3DGfx* subGFX = (F3DGfx*)seg_addr(cmd->words.w1);
                 if (C0(16, 1) == 0) {
                     node_with_text(cmd0, fmt::format("G_DL: 0x{:x} -> {}", cmd->words.w1, (void*)subGFX), subGFX);
@@ -204,7 +204,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 break;
             }
 
-            case F3DEX2_G_ENDDL: {
+            case F3DEX_G_ENDDL: {
                 simple_node(cmd, opcode);
                 return;
             }


### PR DESCRIPTION
gfxd needs to know which version of f3dex to use. The ucode is passed through on Game creation, so I thought we could pass it through `InitGfxDebugger` as well.

This PR adds more `#ifdef's` not sure if there's a way around that.

Still need to auto change some of the macros too so don't merge yet.

`InitGfxDebugger()` is ran in Engine.cpp and in Context.cpp so that makes things confusing. Not sure how to handle that other than setting a default value.

Changes required to ports: (note that the extra new line is optional)
![image](https://github.com/Kenix3/libultraship/assets/7255464/586e5781-98df-43b1-b406-b663d56c3f76)
