### PR TITLE
Some fixes and improvements to the GUI class

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -723,6 +723,10 @@ void Gui::RemoveGuiWindow(const std::string& name) {
     mGuiWindows.erase(name);
 }
 
+void Ship::Gui::RemoveAllGuiWindows() {
+    mGuiWindows.clear();
+}
+
 std::shared_ptr<GuiWindow> Gui::GetGuiWindow(const std::string& name) {
     if (mGuiWindows.contains(name)) {
         return mGuiWindows[name];

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -82,6 +82,7 @@ class Gui {
     void AddGuiWindow(std::shared_ptr<GuiWindow> guiWindow);
     void RemoveGuiWindow(std::shared_ptr<GuiWindow> guiWindow);
     void RemoveGuiWindow(const std::string& name);
+    void RemoveAllGuiWindows();
     void LoadGuiTexture(const std::string& name, const std::string& path, const ImVec4& tint);
     bool HasTextureByName(const std::string& name);
     void LoadGuiTexture(const std::string& name, const LUS::Texture& tex, const ImVec4& tint);

--- a/src/window/gui/GuiWindow.h
+++ b/src/window/gui/GuiWindow.h
@@ -11,6 +11,7 @@
 namespace Ship {
 class GuiWindow : public GuiElement {
   public:
+    GuiWindow() = default;
     GuiWindow(const std::string& consoleVariable, bool isVisible, const std::string& name);
     GuiWindow(const std::string& consoleVariable, const std::string& name);
 


### PR DESCRIPTION
Fixes (in order of files changed)
1.  Calling functions for classes in the main `Context` would crash because the GUI is unloaded after some things. This could be fixed by manually removing every `GuiWindow` but this is a cleaner fix.
2. It was not possible to create custom constructors for `GuiWindow` child classes without some kind of default constructor for the base class.