### PR TITLE
Fix 2cyc color combiner texture detection

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -339,28 +339,29 @@ static void gfx_generate_cc(struct ColorCombiner* comb, const ColorCombinerKey& 
                     case G_CCMUX_TEXEL0:
                         val = SHADER_TEXEL0;
                         used_textures[0] = true;
-                        if (is_2cyc) {
+                        // Set the opposite texture when reading from the second cycle color options
+                        if (i != 0) {
                             used_textures[1] = true;
                         }
                         break;
                     case G_CCMUX_TEXEL1:
                         val = SHADER_TEXEL1;
                         used_textures[1] = true;
-                        if (is_2cyc) {
+                        if (i != 0) {
                             used_textures[0] = true;
                         }
                         break;
                     case G_CCMUX_TEXEL0_ALPHA:
                         val = SHADER_TEXEL0A;
                         used_textures[0] = true;
-                        if (is_2cyc) {
+                        if (i != 0) {
                             used_textures[1] = true;
                         }
                         break;
                     case G_CCMUX_TEXEL1_ALPHA:
                         val = SHADER_TEXEL1A;
                         used_textures[1] = true;
-                        if (is_2cyc) {
+                        if (i != 0) {
                             used_textures[0] = true;
                         }
                         break;
@@ -404,14 +405,15 @@ static void gfx_generate_cc(struct ColorCombiner* comb, const ColorCombinerKey& 
                     case G_ACMUX_TEXEL0:
                         val = SHADER_TEXEL0;
                         used_textures[0] = true;
-                        if (is_2cyc) {
+                        // Set the opposite texture when reading from the second cycle color options
+                        if (i != 0) {
                             used_textures[1] = true;
                         }
                         break;
                     case G_ACMUX_TEXEL1:
                         val = SHADER_TEXEL1;
                         used_textures[1] = true;
-                        if (is_2cyc) {
+                        if (i != 0) {
                             used_textures[0] = true;
                         }
                         break;

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -338,30 +338,34 @@ static void gfx_generate_cc(struct ColorCombiner* comb, const ColorCombinerKey& 
                         break;
                     case G_CCMUX_TEXEL0:
                         val = SHADER_TEXEL0;
-                        used_textures[0] = true;
                         // Set the opposite texture when reading from the second cycle color options
-                        if (i != 0) {
+                        if (i == 0) {
+                            used_textures[0] = true;
+                        } else {
                             used_textures[1] = true;
                         }
                         break;
                     case G_CCMUX_TEXEL1:
                         val = SHADER_TEXEL1;
-                        used_textures[1] = true;
-                        if (i != 0) {
+                        if (i == 0) {
+                            used_textures[1] = true;
+                        } else {
                             used_textures[0] = true;
                         }
                         break;
                     case G_CCMUX_TEXEL0_ALPHA:
                         val = SHADER_TEXEL0A;
-                        used_textures[0] = true;
-                        if (i != 0) {
+                        if (i == 0) {
+                            used_textures[0] = true;
+                        } else {
                             used_textures[1] = true;
                         }
                         break;
                     case G_CCMUX_TEXEL1_ALPHA:
                         val = SHADER_TEXEL1A;
-                        used_textures[1] = true;
-                        if (i != 0) {
+                        if (i == 0) {
+                            used_textures[1] = true;
+                        } else {
                             used_textures[0] = true;
                         }
                         break;
@@ -404,16 +408,18 @@ static void gfx_generate_cc(struct ColorCombiner* comb, const ColorCombinerKey& 
                         break;
                     case G_ACMUX_TEXEL0:
                         val = SHADER_TEXEL0;
-                        used_textures[0] = true;
                         // Set the opposite texture when reading from the second cycle color options
-                        if (i != 0) {
+                        if (i == 0) {
+                            used_textures[0] = true;
+                        } else {
                             used_textures[1] = true;
                         }
                         break;
                     case G_ACMUX_TEXEL1:
                         val = SHADER_TEXEL1;
-                        used_textures[1] = true;
-                        if (i != 0) {
+                        if (i == 0) {
+                            used_textures[1] = true;
+                        } else {
                             used_textures[0] = true;
                         }
                         break;


### PR DESCRIPTION
This PR continues to optimize two cycle texture detection in the color combiner based on the changes from https://github.com/Kenix3/libultraship/pull/628

Rather than setting the opposite texture if 2cyc mode is on, it should strictly be when we are parsing the second cycle part of the color combiner.

This resolves the issues observed in this ticket https://github.com/HarbourMasters/2ship2harkinian/issues/705 and other instances from SoH