### PR TITLE
Fix GuiWindow crash when minimized

### DIFF
--- a/src/window/gui/GuiWindow.cpp
+++ b/src/window/gui/GuiWindow.cpp
@@ -66,9 +66,10 @@ void GuiWindow::Draw() {
     }
     if (!ImGui::Begin(mName.c_str(), &mIsVisible, mWindowFlags)) {
         ImGui::End();
+    } else {
+        DrawElement();
+        ImGui::End();
     }
-    DrawElement();
-    ImGui::End();
     // Sync up the IsVisible flag if it was changed by ImGui
     SyncVisibilityConsoleVariable();
 }


### PR DESCRIPTION
Found out that any GuiWindow, when popped out, would crash if the window was minimized. The cause is having `if (!ImGui::Begin())` and not having the `DrawContents()` and trailing `ImGui::End()` within an `else` tied to that `if`, therefore having too many `End()` calls as GuiWindow still showed as visible, so wouldn't return early, but wasn't drawing contents, and so `Begin()` was returning false and calling `End()` inside that block. This moves those two functions inside a tied `else` to prevent this.

I tried changing the logic to be affirmative instead of negative with `if (ImGui::Begin())`, but ended up getting a Begin...End/BeginChild...EndChild mismatch somehow, so I left it in the negative form.