### PR TITLE
Revert frame timing changes

### DIFF
--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -524,7 +524,8 @@ static uint64_t qpc_to_ns(uint64_t qpc) {
 }
 
 static uint64_t qpc_to_100ns(uint64_t qpc) {
-    return qpc / dxgi.qpc_freq * _100NANOSECONDS_IN_SECOND + qpc % dxgi.qpc_freq * _100NANOSECONDS_IN_SECOND / dxgi.qpc_freq;
+    return qpc / dxgi.qpc_freq * _100NANOSECONDS_IN_SECOND +
+           qpc % dxgi.qpc_freq * _100NANOSECONDS_IN_SECOND / dxgi.qpc_freq;
 }
 
 static bool gfx_dxgi_start_frame(void) {

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -41,6 +41,9 @@
 #define FRAME_INTERVAL_NS_NUMERATOR 1000000000
 #define FRAME_INTERVAL_NS_DENOMINATOR (dxgi.target_fps)
 
+#define NANOSECOND_IN_SECOND 1000000000
+#define _100NANOSECONDS_IN_SECOND 10000000
+
 using namespace Microsoft::WRL; // For ComPtr
 
 static struct {
@@ -517,11 +520,11 @@ static void gfx_dxgi_handle_events(void) {
 }
 
 static uint64_t qpc_to_ns(uint64_t qpc) {
-    return qpc / dxgi.qpc_freq * 1000000000 + qpc % dxgi.qpc_freq * 1000000000 / dxgi.qpc_freq;
+    return qpc / dxgi.qpc_freq * NANOSECOND_IN_SECOND + qpc % dxgi.qpc_freq * NANOSECOND_IN_SECOND / dxgi.qpc_freq;
 }
 
 static uint64_t qpc_to_100ns(uint64_t qpc) {
-    return qpc / dxgi.qpc_freq * 10000000 + qpc % dxgi.qpc_freq * 10000000 / dxgi.qpc_freq;
+    return qpc / dxgi.qpc_freq * _100NANOSECONDS_IN_SECOND + qpc % dxgi.qpc_freq * _100NANOSECONDS_IN_SECOND / dxgi.qpc_freq;
 }
 
 static bool gfx_dxgi_start_frame(void) {

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -526,8 +526,7 @@ static bool gfx_sdl_start_frame(void) {
 
 static uint64_t qpc_to_100ns(uint64_t qpc) {
     const uint64_t qpc_freq = SDL_GetPerformanceFrequency();
-    qpc *= 10000000;
-    return qpc / qpc_freq;
+    return qpc / qpc_freq * 10000000 + qpc % qpc_freq * 10000000 / qpc_freq;
 }
 
 static inline void sync_framerate_with_timer(void) {
@@ -554,10 +553,11 @@ static inline void sync_framerate_with_timer(void) {
     }
 
 #ifdef _WIN32
-    do {
+    t = qpc_to_100ns(SDL_GetPerformanceCounter());
+    while (t < next) {
         YieldProcessor(); // TODO: Find a way for other compilers, OSes and architectures
         t = qpc_to_100ns(SDL_GetPerformanceCounter());
-    } while (t < next);
+    }
 #endif
     t = qpc_to_100ns(SDL_GetPerformanceCounter());
     if (left > 0 && t - next < 10000) {

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #define GFX_BACKEND_NAME "SDL"
+#define _100NANOSECONDS_IN_SECOND 10000000
 
 static SDL_Window* wnd;
 static SDL_GLContext ctx;
@@ -526,7 +527,7 @@ static bool gfx_sdl_start_frame(void) {
 
 static uint64_t qpc_to_100ns(uint64_t qpc) {
     const uint64_t qpc_freq = SDL_GetPerformanceFrequency();
-    return qpc / qpc_freq * 10000000 + qpc % qpc_freq * 10000000 / qpc_freq;
+    return qpc / qpc_freq * _100NANOSECONDS_IN_SECOND + qpc % qpc_freq * _100NANOSECONDS_IN_SECOND / qpc_freq;
 }
 
 static inline void sync_framerate_with_timer(void) {


### PR DESCRIPTION
(based on discussions in discord) It was found that the calculation changes in the `qpc_to_` methods were truncating/overflowing for a lot of values which lead to the vsync calculations to be incorrect and no longer drop frames as needed causing frame slowdown/slowmotion. On some machines this could manifest as early as 30 minutes of elapsed gameplay.

This reverts the changes to how they are in LUS 1.x which does not truncate/overflow.

This also adjusts the `do {} while` loop for `YieldProcessor` to a regular `while` loop so that we aren't yielding when we don't need to.