### PR TITLE
Add a missing include in GuiWindows.h

### DIFF
--- a/src/window/gui/GuiWindow.h
+++ b/src/window/gui/GuiWindow.h
@@ -7,6 +7,7 @@
 #include <imgui.h>
 #include <imgui_internal.h>
 #include "window/gui/GuiElement.h"
+#include <stdint.h>
 
 namespace Ship {
 class GuiWindow : public GuiElement {


### PR DESCRIPTION
Strangely my os complain about unknow defenition of uint32_t so just the import for it