### PR TITLE
Improved help command

### DIFF
--- a/src/window/gui/ConsoleWindow.cpp
+++ b/src/window/gui/ConsoleWindow.cpp
@@ -11,9 +11,30 @@ namespace Ship {
 int32_t ConsoleWindow::HelpCommand(std::shared_ptr<Console> console, const std::vector<std::string>& args,
                                    std::string* output) {
     if (output) {
-        *output += "Commands:\n";
+        *output += "Commands:";
         for (const auto& cmd : console->GetCommands()) {
-            *output += " - " + cmd.first + "\n";
+            *output += "\n - " + cmd.first + ": " + cmd.second.Description;
+
+            if (!cmd.second.Arguments.empty()) {
+                *output += "\n   - Arguments:";
+                for (int i = 0; i < cmd.second.Arguments.size(); i += 1) {
+                    const CommandArgument& argument = cmd.second.Arguments[i];
+
+                    *output += "\n     - Info=" + argument.Info;
+
+                    if (argument.Type == ArgumentType::NUMBER) {
+                        *output += " Type=Text";
+                    } else if (argument.Type == ArgumentType::TEXT) {
+                        *output += " Type=Number";
+                    } else {
+                        *output += " Type=Unknown";
+                    }
+
+                    if (argument.Optional) {
+                        *output += " [Optional]";
+                    }
+                }
+            }
         }
 
         return 0;

--- a/src/window/gui/ConsoleWindow.cpp
+++ b/src/window/gui/ConsoleWindow.cpp
@@ -575,10 +575,10 @@ int ConsoleWindow::CallbackStub(ImGuiInputTextCallbackData* data) {
 void ConsoleWindow::Append(const std::string& channel, spdlog::level::level_enum priority, const char* fmt,
                            va_list args) {
     // Determine the size of the formatted string
-    va_list args_copy;
-    va_copy(args_copy, args);
-    int size = vsnprintf(nullptr, 0, fmt, args_copy);
-    va_end(args_copy);
+    va_list argsCopy;
+    va_copy(argsCopy, args);
+    int size = vsnprintf(nullptr, 0, fmt, argsCopy);
+    va_end(argsCopy);
 
     if (size < 0) {
         SPDLOG_ERROR("Error during formatting.");


### PR DESCRIPTION
Improves the help command by adding the command descriptions and the arguments.
Example of how it looks on SoH:
![imagen](https://github.com/user-attachments/assets/f7b268ab-e442-46b9-b625-5c21498380d3)
