### PR TITLE
Add calls to `Update()` for menu and menubar.

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -375,10 +375,12 @@ void Gui::DrawMenu() {
 #endif
 
     if (GetMenuBar()) {
+        GetMenuBar()->Update();
         GetMenuBar()->Draw();
     }
 
     if (GetMenu()) {
+        GetMenu()->Update();
         GetMenu()->Draw();
     }
 


### PR DESCRIPTION
When setting up menu support, I forgot to add a call to the menu's `Update()` function inside the check for an existent menu.
Also, don't know if it was my fault or not, but menubar also didn't have a call to its `Update()` function.