### PR TITLE
Add missing standard header to gfx debugger

### DIFF
--- a/src/graphic/Fast3D/debug/GfxDebugger.cpp
+++ b/src/graphic/Fast3D/debug/GfxDebugger.cpp
@@ -1,4 +1,5 @@
 #include "GfxDebugger.h"
+#include <stddef.h>
 
 namespace Fast {
 


### PR DESCRIPTION
add missing standard header to gfx debugger for `size_t` typedef