### PR TITLE
Menu Support Cleanup

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -342,10 +342,14 @@ void Gui::DrawMenu() {
     if (ImGui::IsKeyPressed(TOGGLE_BTN) || ImGui::IsKeyPressed(ImGuiKey_Escape) ||
         (ImGui::IsKeyPressed(TOGGLE_PAD_BTN) && CVarGetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0))) {
         if (ImGui::IsKeyPressed(TOGGLE_BTN) || (ImGui::IsKeyPressed(TOGGLE_PAD_BTN) && !GetPadBtnTogglesMenu())) {
-            GetMenuBar()->ToggleVisibility();
+            if (GetMenuBar()) {
+                GetMenuBar()->ToggleVisibility();
+            }
         } else if (ImGui::IsKeyPressed(ImGuiKey_Escape) ||
                    (ImGui::IsKeyPressed(TOGGLE_PAD_BTN) && GetPadBtnTogglesMenu())) {
-            GetMenu()->ToggleVisibility();
+            if (GetMenu()) {
+                GetMenu()->ToggleVisibility();
+            }
         }
         if (wnd->IsFullscreen()) {
             Context::GetInstance()->GetWindow()->SetCursorVisibility(GetMenuOrMenubarVisible() ||

--- a/src/window/gui/GuiElement.cpp
+++ b/src/window/gui/GuiElement.cpp
@@ -25,20 +25,20 @@ void GuiElement::Update() {
     UpdateElement();
 }
 
-void GuiElement::SetVisiblity(bool visible) {
+void GuiElement::SetVisibility(bool visible) {
     mIsVisible = visible;
 }
 
 void GuiElement::Show() {
-    SetVisiblity(true);
+    SetVisibility(true);
 }
 
 void GuiElement::Hide() {
-    SetVisiblity(false);
+    SetVisibility(false);
 }
 
 void GuiElement::ToggleVisibility() {
-    SetVisiblity(!IsVisible());
+    SetVisibility(!IsVisible());
 }
 
 bool GuiElement::IsVisible() {

--- a/src/window/gui/GuiElement.h
+++ b/src/window/gui/GuiElement.h
@@ -24,7 +24,7 @@ class GuiElement {
     virtual void InitElement() = 0;
     virtual void UpdateElement() = 0;
 
-    virtual void SetVisiblity(bool visible);
+    virtual void SetVisibility(bool visible);
     bool mIsVisible;
 
   private:

--- a/src/window/gui/GuiMenuBar.cpp
+++ b/src/window/gui/GuiMenuBar.cpp
@@ -41,7 +41,7 @@ void GuiMenuBar::SyncVisibilityConsoleVariable() {
     }
 }
 
-void GuiMenuBar::SetVisiblity(bool visible) {
+void GuiMenuBar::SetVisibility(bool visible) {
     mIsVisible = visible;
     SyncVisibilityConsoleVariable();
 }

--- a/src/window/gui/GuiMenuBar.h
+++ b/src/window/gui/GuiMenuBar.h
@@ -11,7 +11,7 @@ class GuiMenuBar : public GuiElement {
     void Draw() override;
 
   protected:
-    void SetVisiblity(bool visible) override;
+    void SetVisibility(bool visible) override;
 
   private:
     void SyncVisibilityConsoleVariable();

--- a/src/window/gui/GuiWindow.cpp
+++ b/src/window/gui/GuiWindow.cpp
@@ -34,7 +34,7 @@ GuiWindow::GuiWindow(const std::string& consoleVariable, const std::string& name
     : GuiWindow(consoleVariable, false, name, ImVec2{ -1, -1 }, ImGuiWindowFlags_None) {
 }
 
-void GuiWindow::SetVisiblity(bool visible) {
+void GuiWindow::SetVisibility(bool visible) {
     mIsVisible = visible;
     SyncVisibilityConsoleVariable();
 }

--- a/src/window/gui/GuiWindow.h
+++ b/src/window/gui/GuiWindow.h
@@ -24,7 +24,7 @@ class GuiWindow : public GuiElement {
     std::string GetName();
 
   protected:
-    void SetVisiblity(bool visible) override;
+    void SetVisibility(bool visible) override;
     void BeginGroupPanel(const char* name, const ImVec2& size);
     void EndGroupPanel(float minHeight);
     void SyncVisibilityConsoleVariable();


### PR DESCRIPTION
Add Get() checks for the menu and menubar visibility toggles to make sure they're registered before toggling.
Rename `GuiElement::SetVisiblity` to `GuiElement::SetVisibility`.