### PR TITLE
remove a check to support any tile id

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2034,7 +2034,6 @@ static void gfx_dp_load_tlut(uint8_t tile, uint32_t high_index) {
 }
 
 static void gfx_dp_load_block(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t lrs, uint32_t dxt) {
-    SUPPORT_CHECK(tile == G_TX_LOADTILE || tile == 6);
     SUPPORT_CHECK(uls == 0);
     SUPPORT_CHECK(ult == 0);
 

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2034,7 +2034,7 @@ static void gfx_dp_load_tlut(uint8_t tile, uint32_t high_index) {
 }
 
 static void gfx_dp_load_block(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t lrs, uint32_t dxt) {
-    SUPPORT_CHECK(tile == G_TX_LOADTILE);
+    SUPPORT_CHECK(tile == G_TX_LOADTILE || tile == 6);
     SUPPORT_CHECK(uls == 0);
     SUPPORT_CHECK(ult == 0);
 


### PR DESCRIPTION
moo moo farm and other course sometime use gsDPLoadBlock(6,...) instead of gsDPLoadBlock(G_TX_LOADTILE, ...) by talking a little on hack64 it just appears that it can be any value so it's fine to remove it