### PR TITLE
Fix DPI scaling issues on Windows (OpenGL)

### DIFF
--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -302,6 +302,11 @@ static void gfx_sdl_init(const char* game_name, const char* gfx_api_name, bool s
     window_width = width;
     window_height = height;
 
+#if SDL_VERSION_ATLEAST(2, 24, 0)
+    /* fix DPI scaling issues on Windows */
+    SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
+#endif
+
     SDL_Init(SDL_INIT_VIDEO);
 
     SDL_EventState(SDL_DROPFILE, SDL_ENABLE);


### PR DESCRIPTION
Adds an SDL hint to address DPI scaling issues on Windows when using OpenGL, where the window size can appear too large. This can also help with the resolution in general, making things look less crunchy (200% DPI, 100% internal resolution).

before
![image](https://github.com/user-attachments/assets/bb451d88-a2b6-4116-a4ac-9a7d47e1ccf7)

after
![Clipboard_09-01-2024_01](https://github.com/user-attachments/assets/3eab9da9-4385-46c9-b1de-b071ffb015b2)
