### PR TITLE
Fix stormlib patch stability for windows

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -33,15 +33,16 @@ target_include_directories(ImGui PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/
 
 # ========= StormLib =============
 if(NOT EXCLUDE_MPQ_SUPPORT)
-    set(stormlib_optimizations_patch git apply ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/patches/stormlib-optimizations.patch)
+    set(stormlib_pacth_file ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/patches/stormlib-optimizations.patch)
     # Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
-    set(stormlib_apply_path_if_needed ${stormlib_optimizations_patch} || ${stormlib_optimizations_patch} --reverse --check)
+    # The `--quiet` flag is necessary to prevent stderr output from interupting the command when run inside Visual Studio.
+    set(stormlib_apply_patch_if_needed git apply --quiet ${stormlib_pacth_file} || git apply --reverse --check ${stormlib_pacth_file})
 
     FetchContent_Declare(
         StormLib
         GIT_REPOSITORY https://github.com/ladislav-zezula/StormLib.git
         GIT_TAG v9.25
-        PATCH_COMMAND ${stormlib_apply_path_if_needed}
+        PATCH_COMMAND ${stormlib_apply_patch_if_needed}
     )
     FetchContent_MakeAvailable(StormLib)
     list(APPEND ADDITIONAL_LIB_INCLUDES ${stormlib_SOURCE_DIR}/src)

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -33,10 +33,10 @@ target_include_directories(ImGui PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/
 
 # ========= StormLib =============
 if(NOT EXCLUDE_MPQ_SUPPORT)
-    set(stormlib_pacth_file ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/patches/stormlib-optimizations.patch)
+    set(stormlib_patch_file ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/patches/stormlib-optimizations.patch)
     # Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
     # The `--quiet` flag is necessary to prevent stderr output from interupting the command when run inside Visual Studio.
-    set(stormlib_apply_patch_if_needed git apply --quiet ${stormlib_pacth_file} || git apply --reverse --check ${stormlib_pacth_file})
+    set(stormlib_apply_patch_if_needed git apply --quiet ${stormlib_patch_file} || git apply --reverse --check ${stormlib_patch_file})
 
     FetchContent_Declare(
         StormLib


### PR DESCRIPTION
Adjusts stormilb git patching to be stable on windows when using the Visual Studio generator. The issue was that although we had a short-circuited pattern with `||`, Visual Studio was failing the patch because of output in `stderr`.
This PR adds `--quiet` flag to suppress `stderr` output so that the `||` can still be executed.

I've verified that this finally stabilizes the patching with the following setups:
* Windows using Ninja generator
* Windows using Visual Studio generator
* Mac using Ninja generator
* Mac using Xcode generator

All of these included a test with afresh clone and existing setups that had the patch applied previously.