### PR TITLE
Temporarily add back new frame logic until gui refactors are done

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -297,6 +297,12 @@ void Gui::UnblockImGuiGamepadNavigation() {
 }
 
 void Gui::DrawMenu() {
+    // TODO: These 3 functions are placed here temporarily until future GUI/Frame refactoring
+    // is finished and gives these a new home
+    ImGuiBackendNewFrame();
+    ImGuiWMNewFrame();
+    ImGui::NewFrame();
+
     Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console")->Update();
 
     const std::shared_ptr<Window> wnd = Context::GetInstance()->GetWindow();


### PR DESCRIPTION
This just adds back a few lines removed from #664 so that LUS can continue to be used on ports without major issues.

The understanding is that there will be continued refactor work around the GUI/Frame handling, which will give these lines of code a better home.