### PR TITLE
Fix I4 and IA16 tile textures

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -684,7 +684,7 @@ static void import_texture_ia16(int tile, bool importReplacement) {
     uint32_t full_image_line_size_bytes =
         g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t line_size_bytes = g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].line_size_bytes;
-    //SUPPORT_CHECK(full_image_line_size_bytes == line_size_bytes);
+    // SUPPORT_CHECK(full_image_line_size_bytes == line_size_bytes);
 
     uint32_t width = g_rdp.texture_tile[tile].line_size_bytes / 2;
     uint32_t height = size_bytes / g_rdp.texture_tile[tile].line_size_bytes;

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -708,7 +708,7 @@ static void import_texture_ia16(int tile, bool importReplacement) {
             tex_upload_buffer[4 * i + 1] = g;
             tex_upload_buffer[4 * i + 2] = b;
             tex_upload_buffer[4 * i + 3] = alpha;
-            
+
             i++;
         }
     }
@@ -753,7 +753,7 @@ static void import_texture_i4(int tile, bool importReplacement) {
             tex_upload_buffer[4 * i + 1] = SCALE_4_8(g);
             tex_upload_buffer[4 * i + 2] = SCALE_4_8(b);
             tex_upload_buffer[4 * i + 3] = SCALE_4_8(a);
-            
+
             i++;
         }
     }

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -559,14 +559,14 @@ static void import_texture_rgba16(int tile, bool importReplacement) {
     uint32_t full_image_line_size_bytes =
         g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t line_size_bytes = g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].line_size_bytes;
-    // SUPPORT_CHECK(full_image_line_size_bytes == line_size_bytes);
 
     uint32_t width = g_rdp.texture_tile[tile].line_size_bytes / 2;
     uint32_t height = size_bytes / g_rdp.texture_tile[tile].line_size_bytes;
 
     // A single line of pixels should not equal the entire image (height == 1 non-withstanding)
-    if (full_image_line_size_bytes == size_bytes)
+    if (full_image_line_size_bytes == size_bytes) {
         full_image_line_size_bytes = width * 2;
+    }
 
     uint32_t i = 0;
 
@@ -684,14 +684,14 @@ static void import_texture_ia16(int tile, bool importReplacement) {
     uint32_t full_image_line_size_bytes =
         g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t line_size_bytes = g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].line_size_bytes;
-    // SUPPORT_CHECK(full_image_line_size_bytes == line_size_bytes);
 
     uint32_t width = g_rdp.texture_tile[tile].line_size_bytes / 2;
     uint32_t height = size_bytes / g_rdp.texture_tile[tile].line_size_bytes;
 
     // A single line of pixels should not equal the entire image (height == 1 non-withstanding)
-    if (full_image_line_size_bytes == size_bytes)
+    if (full_image_line_size_bytes == size_bytes) {
         full_image_line_size_bytes = width * 2;
+    }
 
     uint32_t i = 0;
 
@@ -727,14 +727,14 @@ static void import_texture_i4(int tile, bool importReplacement) {
     uint32_t full_image_line_size_bytes =
         g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t line_size_bytes = g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].line_size_bytes;
-    // SUPPORT_CHECK(full_image_line_size_bytes == line_size_bytes);
 
     uint32_t width = g_rdp.texture_tile[tile].line_size_bytes * 2;
     uint32_t height = size_bytes / g_rdp.texture_tile[tile].line_size_bytes;
 
     // A single line of pixels should not equal the entire image (height == 1 non-withstanding)
-    if (full_image_line_size_bytes == size_bytes)
+    if (full_image_line_size_bytes == size_bytes) {
         full_image_line_size_bytes = width / 2;
+    }
 
     uint32_t i = 0;
 
@@ -772,7 +772,6 @@ static void import_texture_i8(int tile, bool importReplacement) {
     uint32_t full_image_line_size_bytes =
         g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t line_size_bytes = g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].line_size_bytes;
-    // SUPPORT_CHECK(full_image_line_size_bytes == line_size_bytes);
 
     for (uint32_t i = 0; i < size_bytes; i++) {
         uint8_t intensity = addr[i];

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -684,22 +684,34 @@ static void import_texture_ia16(int tile, bool importReplacement) {
     uint32_t full_image_line_size_bytes =
         g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t line_size_bytes = g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].line_size_bytes;
-    SUPPORT_CHECK(full_image_line_size_bytes == line_size_bytes);
-
-    for (uint32_t i = 0; i < size_bytes / 2; i++) {
-        uint8_t intensity = addr[2 * i];
-        uint8_t alpha = addr[2 * i + 1];
-        uint8_t r = intensity;
-        uint8_t g = intensity;
-        uint8_t b = intensity;
-        tex_upload_buffer[4 * i + 0] = r;
-        tex_upload_buffer[4 * i + 1] = g;
-        tex_upload_buffer[4 * i + 2] = b;
-        tex_upload_buffer[4 * i + 3] = alpha;
-    }
+    //SUPPORT_CHECK(full_image_line_size_bytes == line_size_bytes);
 
     uint32_t width = g_rdp.texture_tile[tile].line_size_bytes / 2;
     uint32_t height = size_bytes / g_rdp.texture_tile[tile].line_size_bytes;
+
+    // A single line of pixels should not equal the entire image (height == 1 non-withstanding)
+    if (full_image_line_size_bytes == size_bytes)
+        full_image_line_size_bytes = width * 2;
+
+    uint32_t i = 0;
+
+    for (uint32_t y = 0; y < height; y++) {
+        for (uint32_t x = 0; x < width; x++) {
+            uint32_t clrIdx = (y * (full_image_line_size_bytes / 2)) + (x);
+
+            uint8_t intensity = addr[2 * clrIdx];
+            uint8_t alpha = addr[2 * clrIdx + 1];
+            uint8_t r = intensity;
+            uint8_t g = intensity;
+            uint8_t b = intensity;
+            tex_upload_buffer[4 * i + 0] = r;
+            tex_upload_buffer[4 * i + 1] = g;
+            tex_upload_buffer[4 * i + 2] = b;
+            tex_upload_buffer[4 * i + 3] = alpha;
+            
+            i++;
+        }
+    }
 
     gfx_rapi->upload_texture(tex_upload_buffer, width, height);
 }
@@ -717,22 +729,34 @@ static void import_texture_i4(int tile, bool importReplacement) {
     uint32_t line_size_bytes = g_rdp.loaded_texture[g_rdp.texture_tile[tile].tmem_index].line_size_bytes;
     // SUPPORT_CHECK(full_image_line_size_bytes == line_size_bytes);
 
-    for (uint32_t i = 0; i < size_bytes * 2; i++) {
-        uint8_t byte = addr[i / 2];
-        uint8_t part = (byte >> (4 - (i % 2) * 4)) & 0xf;
-        uint8_t intensity = part;
-        uint8_t r = intensity;
-        uint8_t g = intensity;
-        uint8_t b = intensity;
-        uint8_t a = intensity;
-        tex_upload_buffer[4 * i + 0] = SCALE_4_8(r);
-        tex_upload_buffer[4 * i + 1] = SCALE_4_8(g);
-        tex_upload_buffer[4 * i + 2] = SCALE_4_8(b);
-        tex_upload_buffer[4 * i + 3] = SCALE_4_8(a);
-    }
-
     uint32_t width = g_rdp.texture_tile[tile].line_size_bytes * 2;
     uint32_t height = size_bytes / g_rdp.texture_tile[tile].line_size_bytes;
+
+    // A single line of pixels should not equal the entire image (height == 1 non-withstanding)
+    if (full_image_line_size_bytes == size_bytes)
+        full_image_line_size_bytes = width / 2;
+
+    uint32_t i = 0;
+
+    for (uint32_t y = 0; y < height; y++) {
+        for (uint32_t x = 0; x < width; x++) {
+            uint32_t clrIdx = (y * (full_image_line_size_bytes * 2)) + (x);
+
+            uint8_t byte = addr[clrIdx / 2];
+            uint8_t part = (byte >> (4 - (clrIdx % 2) * 4)) & 0xf;
+            uint8_t intensity = part;
+            uint8_t r = intensity;
+            uint8_t g = intensity;
+            uint8_t b = intensity;
+            uint8_t a = intensity;
+            tex_upload_buffer[4 * i + 0] = SCALE_4_8(r);
+            tex_upload_buffer[4 * i + 1] = SCALE_4_8(g);
+            tex_upload_buffer[4 * i + 2] = SCALE_4_8(b);
+            tex_upload_buffer[4 * i + 3] = SCALE_4_8(a);
+            
+            i++;
+        }
+    }
 
     gfx_rapi->upload_texture(tex_upload_buffer, width, height);
 }


### PR DESCRIPTION
Using the same checks from `import_texture_rgba16`. Fixes texture rendering on those formats if they are used with `gDPLoadTextureTile_4b` and `gDPLoadTextureTile` respectively.

Ideally every `import_texture` function should have those checks but I could only test those 2 formats so far.