### PR TITLE
Use alternate stderr suppression for git patch

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -33,10 +33,15 @@ target_include_directories(ImGui PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/
 
 # ========= StormLib =============
 if(NOT EXCLUDE_MPQ_SUPPORT)
+    # When using the Visual Studio generator, it is necessary to suppress stderr output entirely so it does not interrupt the patch command.
+    # Redirecting to nul is used here instead of the `--quiet` flag, as that flag was only recently introduced in git 2.25.0 (Jan 2022)
+    if (CMAKE_GENERATOR MATCHES "Visual Studio")
+        set(git_hide_output 2> nul)
+    endif()
     set(stormlib_patch_file ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/patches/stormlib-optimizations.patch)
+
     # Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
-    # The `--quiet` flag is necessary to prevent stderr output from interupting the command when run inside Visual Studio.
-    set(stormlib_apply_patch_if_needed git apply --quiet ${stormlib_patch_file} || git apply --reverse --check ${stormlib_patch_file})
+    set(stormlib_apply_patch_if_needed git apply ${stormlib_patch_file} ${git_hide_output} || git apply --reverse --check ${stormlib_patch_file})
 
     FetchContent_Declare(
         StormLib


### PR DESCRIPTION
Yet another tweak to the stormilb patch process for visual studio.

The previous solution used the `--quiet` flag on the git cli, which worked, however this was only "recently" introduced (~2 years ago)
In an effort to support older versions of git, and to avoid reports for when someone inevitably runs into it, I'm switching the command to instead redirect stderr output to `nul` and additionally only applying this logic for when the Visual Studio generator is used.

I've tested that this still works for VS setups.