### PR TITLE
Add ImGui patch for Gamepad Update, Stormlib patch tweak

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -2,11 +2,17 @@ include(FetchContent)
 
 find_package(OpenGL QUIET)
 
+# When using the Visual Studio generator, it is necessary to suppress stderr output entirely so it does not interrupt the patch command.
+# Redirecting to nul is used here instead of the `--quiet` flag, as that flag was only recently introduced in git 2.25.0 (Jan 2022)
+if (CMAKE_GENERATOR MATCHES "Visual Studio")
+	set(git_hide_output 2> nul)
+endif()
+
 #=================== ImGui ===================
 set(sdl_gamepad_patch git apply ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/patches/sdl-gamepad-fix.patch)
-    # Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
-    # The `--quiet` flag is necessary to prevent stderr output from interupting the command when run inside Visual Studio.
-    set(sdl_apply_patch_if_needed ${sdl_gamepad_patch} --quiet || ${sdl_gamepad_patch} --reverse --check)
+
+# Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
+set(sdl_apply_patch_if_needed ${sdl_gamepad_patch} ${git_hide_output} || ${sdl_gamepad_patch} --reverse --check)
 FetchContent_Declare(
     ImGui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
@@ -39,9 +45,9 @@ target_include_directories(ImGui PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/
 # ========= StormLib =============
 if(NOT EXCLUDE_MPQ_SUPPORT)
     set(stormlib_patch_file ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/patches/stormlib-optimizations.patch)
+	
     # Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
-    # The `--quiet` flag is necessary to prevent stderr output from interupting the command when run inside Visual Studio.
-    set(stormlib_apply_patch_if_needed git apply --quiet ${stormlib_patch_file} || git apply --reverse --check ${stormlib_patch_file})
+    set(stormlib_apply_patch_if_needed git apply --quiet ${stormlib_patch_file} ${git_hide_output} || git apply --reverse --check ${stormlib_patch_file})
 
     FetchContent_Declare(
         StormLib

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -5,7 +5,7 @@ find_package(OpenGL QUIET)
 # When using the Visual Studio generator, it is necessary to suppress stderr output entirely so it does not interrupt the patch command.
 # Redirecting to nul is used here instead of the `--quiet` flag, as that flag was only recently introduced in git 2.25.0 (Jan 2022)
 if (CMAKE_GENERATOR MATCHES "Visual Studio")
-	set(git_hide_output 2> nul)
+    set(git_hide_output 2> nul)
 endif()
 
 #=================== ImGui ===================
@@ -17,7 +17,7 @@ FetchContent_Declare(
     ImGui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
     GIT_TAG v1.90.6-docking
-	PATCH_COMMAND ${sdl_apply_patch_if_needed}
+    PATCH_COMMAND ${sdl_apply_patch_if_needed}
 )
 FetchContent_MakeAvailable(ImGui)
 list(APPEND ADDITIONAL_LIB_INCLUDES ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends)
@@ -45,7 +45,7 @@ target_include_directories(ImGui PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/
 # ========= StormLib =============
 if(NOT EXCLUDE_MPQ_SUPPORT)
     set(stormlib_patch_file ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/patches/stormlib-optimizations.patch)
-	
+
     # Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
     set(stormlib_apply_patch_if_needed git apply --quiet ${stormlib_patch_file} ${git_hide_output} || git apply --reverse --check ${stormlib_patch_file})
 

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -3,10 +3,15 @@ include(FetchContent)
 find_package(OpenGL QUIET)
 
 #=================== ImGui ===================
+set(sdl_gamepad_patch git apply ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/patches/sdl-gamepad-fix.patch)
+    # Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
+    # The `--quiet` flag is necessary to prevent stderr output from interupting the command when run inside Visual Studio.
+    set(sdl_apply_patch_if_needed ${sdl_gamepad_patch} --quiet || ${sdl_gamepad_patch} --reverse --check)
 FetchContent_Declare(
     ImGui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
     GIT_TAG v1.90.6-docking
+	PATCH_COMMAND ${sdl_apply_patch_if_needed}
 )
 FetchContent_MakeAvailable(ImGui)
 list(APPEND ADDITIONAL_LIB_INCLUDES ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends)

--- a/cmake/dependencies/patches/sdl-gamepad-fix.patch
+++ b/cmake/dependencies/patches/sdl-gamepad-fix.patch
@@ -1,0 +1,17 @@
+ backends/imgui_impl_sdl2.cpp | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/backends/imgui_impl_sdl2.cpp b/backends/imgui_impl_sdl2.cpp
+index 569b01d1..c2f84dca 100644
+--- a/backends/imgui_impl_sdl2.cpp
++++ b/backends/imgui_impl_sdl2.cpp
+@@ -770,9 +770,6 @@ static void ImGui_ImplSDL2_UpdateGamepads()
+         bd->WantUpdateGamepadsList = false;
+     }
+ 
+-    // FIXME: Technically feeding gamepad shouldn't depend on this now that they are regular inputs.
+-    if ((io.ConfigFlags & ImGuiConfigFlags_NavEnableGamepad) == 0)
+-        return;
+     io.BackendFlags &= ~ImGuiBackendFlags_HasGamepad;
+     if (bd->Gamepads.Size == 0)
+         return;


### PR DESCRIPTION
In the process of addressing reviews of the modern menu, it was discovered that SDL was implemented differently from WASAPI, and several things were not behaving properly compared to WASAPI. This adds and implements a patch, following the precedent of the Stormlib patch, to remove a return in the SDL implementation preventing gamepad update when the menubar is closed. As far as I can tell, this had no negative effects on gameplay or menubar function with gamepad navigation.

Also incorporates the Stormlib patch tweak from #676 to avoid having to wait for merge times, unifies the variable setting for Visual Studio generator, and uses the tweak format for the gamepad patch, at Archez's suggestion.