### PR TITLE
Update github actions and images

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -7,14 +7,14 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build-macos:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         brew install $(cat .github/workflows/brew-deps.txt)
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.11
+      uses: hendrikmuhs/ccache-action@v1.2.14
       with:
         key: ${{ runner.os }}-mac-ccache-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
@@ -26,23 +26,23 @@ jobs:
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release
         cmake --build build-cmake --config Release --parallel 10
     - name: Upload build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: soh-mac
         path: build-cmake/src/*.a
         if-no-files-found: error
   build-ios:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Cache build folder
       uses: actions/cache@v4
       with:
         save-always: true
-        key: ${{ runner.os }}-ios-build-${{ github.ref }}-${{ github.sha }}
+        key: ${{ runner.os }}-14-ios-build-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-ios-build-${{ github.ref }}
-          ${{ runner.os }}-ios-build-
+          ${{ runner.os }}-14-ios-build-${{ github.ref }}
+          ${{ runner.os }}-14-ios-build-
         path: |
           build-cmake
     - name: Build libultraship
@@ -50,7 +50,7 @@ jobs:
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GXcode -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 -DCMAKE_BUILD_TYPE:STRING=Release
         cmake --build build-cmake --config Release --parallel 10
     - name: Upload build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: soh-ios
         path: build-cmake/src/*/*.a
@@ -58,13 +58,13 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y $(cat .github/workflows/apt-deps.txt)
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.11
+      uses: hendrikmuhs/ccache-action@v1.2.14
       with:
         key: ${{ matrix.os }}-ccache-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
@@ -99,7 +99,7 @@ jobs:
         CC: gcc-10
         CXX: g++-10
     - name: Upload build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: soh-linux
         path: build-cmake/src/*.a
@@ -111,9 +111,9 @@ jobs:
       run: |
         choco install ninja
         Remove-Item -Path "C:\ProgramData\Chocolatey\bin\ccache.exe" -Force -ErrorAction SilentlyContinue
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.11
+      uses: hendrikmuhs/ccache-action@v1.2.14
       with:
         variant: sccache
         key: ${{ runner.os }}-ccache-${{ github.ref }}-${{ github.sha }}

--- a/.github/workflows/tidy-format-validation.yml
+++ b/.github/workflows/tidy-format-validation.yml
@@ -7,7 +7,7 @@ jobs:
   tidy-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Install dependencies

--- a/.github/workflows/tidy-result-publish.yml
+++ b/.github/workflows/tidy-result-publish.yml
@@ -7,10 +7,10 @@ jobs:
   clang-tidy-results:
     # Trigger the job only if the previous (insecure) workflow completed successfully
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Download analysis results
-      uses: actions/github-script@v3.1.0
+      uses: actions/github-script@v7.0.1
       with:
         script: |
           let artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -36,13 +36,13 @@ jobs:
         echo "pr_id=$(cat clang-tidy-result/pr-id.txt)" >> $GITHUB_ENV
         echo "pr_head_repo=$(cat clang-tidy-result/pr-head-repo.txt)" >> $GITHUB_ENV
         echo "pr_head_ref=$(cat clang-tidy-result/pr-head-ref.txt)" >> $GITHUB_ENV
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         repository: ${{ env.pr_head_repo }}
         ref: ${{ env.pr_head_ref }}
         persist-credentials: false
     - name: Redownload analysis results
-      uses: actions/github-script@v3.1.0
+      uses: actions/github-script@v7.0.1
       with:
         script: |
           let artifacts = await github.actions.listWorkflowRunArtifacts({


### PR DESCRIPTION
Updates GitHub runner images and actions to Node 20 compliant version in preparation for when Node <16 support is dropped entirely on Oct 15