### PR TITLE
Updates to Context.cpp for macOS Game mode support

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -379,7 +379,7 @@ std::string Context::GetAppDirectoryPath(std::string appName) {
         return std::string(fpath);
     }
 #endif
-    
+
 #if defined(__linux__)
     char* fpath = std::getenv("SHIP_HOME");
     if (fpath != NULL) {

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -7,7 +7,6 @@
 #include "install_config.h"
 #include "graphic/Fast3D/debug/GfxDebugger.h"
 #include "graphic/Fast3D/Fast3dWindow.h"
-#include <fstream>
 
 #ifdef _WIN32
 #include <tchar.h>
@@ -317,17 +316,7 @@ std::string Context::GetShortName() {
     return mShortName;
 }
 
-#if defined(__APPLE__)
-//Expanded tilde function to get the full path to the application user directory
-std::string ExpandTilde(const std::string& path) {
-    if (path[0] == '~') {
-        const char* home = getenv("HOME") ? getenv("HOME") : getpwuid(getuid())->pw_dir;
-        return std::string(home) + path.substr(1);
-    }
-    return path;
-}
 #endif
-
 std::string Context::GetAppBundlePath() {
 #if defined(__ANDROID__)
     const char* externaldir = SDL_AndroidGetExternalStoragePath();
@@ -384,24 +373,11 @@ std::string Context::GetAppDirectoryPath(std::string appName) {
 
 #if defined(__APPLE__)
     if (char* fpath = std::getenv("SHIP_HOME")) {
-        std::string expandedPath = ExpandTilde(fpath);
-        std::string modsPath = expandedPath + "/mods";
-        std::string filePath = modsPath + "/custom_otr_files_go_here.txt";
-
-        // Ensure SHIP_HOME and "mods" directory exist
-        if (std::filesystem::create_directories(modsPath)) {
-            std::cout << "Directory created at: " << modsPath << std::endl;
+        if (fpath[0] == '~') {
+            const char* home = getenv("HOME") ? getenv("HOME") : getpwuid(getuid())->pw_dir;
+            return std::string(home) + std::string(fpath).substr(1);
         }
-
-        // Check if the text file exists, if not, create it
-        if (!std::filesystem::exists(filePath)) {
-            std::ofstream(filePath).close();
-            std::cout << "Text file created at: " << filePath << std::endl;
-        } else {
-            std::cout << "Text file already exists at: " << filePath << std::endl;
-        }
-
-        return expandedPath;
+        return std::string(fpath);
     }
 #endif
     

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -316,7 +316,7 @@ std::string Context::GetShortName() {
     return mShortName;
 }
 
-#endif
+
 std::string Context::GetAppBundlePath() {
 #if defined(__ANDROID__)
     const char* externaldir = SDL_AndroidGetExternalStoragePath();

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -316,7 +316,6 @@ std::string Context::GetShortName() {
     return mShortName;
 }
 
-
 std::string Context::GetAppBundlePath() {
 #if defined(__ANDROID__)
     const char* externaldir = SDL_AndroidGetExternalStoragePath();


### PR DESCRIPTION
The needed changes to get Game Mode working for both 2ship and soh. It is dynamic, and with the correct changes to info.plist and packaging-2.cmake, it will work for all future projects as well. 
Moves finding the games user files directory and making the directories out of the shell scripts to allow the macOS builds to be run directly instead of as a child process. 

Needs to be pulled here before, and merged into 2Ship2Harkinian and Shipwright at the same time as merging the PRs for those projects. 