### PR TITLE
clarify audioBackend getter and setter

### DIFF
--- a/src/audio/Audio.cpp
+++ b/src/audio/Audio.cpp
@@ -9,7 +9,7 @@ Audio::~Audio() {
 }
 
 void Audio::InitAudioPlayer() {
-    switch (GetAudioBackend()) {
+    switch (GetCurrentAudioBackend()) {
 #ifdef _WIN32
         case AudioBackend::WASAPI:
             mAudioPlayer = std::make_shared<WasapiAudioPlayer>(this->mAudioSettings);
@@ -23,7 +23,7 @@ void Audio::InitAudioPlayer() {
         if (!mAudioPlayer->Init()) {
             // Failed to initialize system audio player.
             // Fallback to SDL if the native system player does not work.
-            SetAudioBackend(AudioBackend::SDL);
+            SetCurrentAudioBackend(AudioBackend::SDL);
             mAudioPlayer = std::make_shared<SDLAudioPlayer>(this->mAudioSettings);
             mAudioPlayer->Init();
         }
@@ -37,20 +37,20 @@ void Audio::Init() {
 #endif
     mAvailableAudioBackends->push_back(AudioBackend::SDL);
 
-    SetAudioBackend(Context::GetInstance()->GetConfig()->GetAudioBackend());
+    SetCurrentAudioBackend(Context::GetInstance()->GetConfig()->GetCurrentAudioBackend());
 }
 
 std::shared_ptr<AudioPlayer> Audio::GetAudioPlayer() {
     return mAudioPlayer;
 }
 
-AudioBackend Audio::GetAudioBackend() {
+AudioBackend Audio::GetCurrentAudioBackend() {
     return mAudioBackend;
 }
 
-void Audio::SetAudioBackend(AudioBackend backend) {
+void Audio::SetCurrentAudioBackend(AudioBackend backend) {
     mAudioBackend = backend;
-    Context::GetInstance()->GetConfig()->SetAudioBackend(GetAudioBackend());
+    Context::GetInstance()->GetConfig()->SetCurrentAudioBackend(GetCurrentAudioBackend());
     Context::GetInstance()->GetConfig()->Save();
 
     InitAudioPlayer();

--- a/src/audio/Audio.h
+++ b/src/audio/Audio.h
@@ -16,9 +16,9 @@ class Audio {
 
     void Init();
     std::shared_ptr<AudioPlayer> GetAudioPlayer();
-    AudioBackend GetAudioBackend();
+    AudioBackend GetCurrentAudioBackend();
     std::shared_ptr<std::vector<AudioBackend>> GetAvailableAudioBackends();
-    void SetAudioBackend(AudioBackend backend);
+    void SetCurrentAudioBackend(AudioBackend backend);
 
   protected:
     void InitAudioPlayer();

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -206,7 +206,7 @@ bool Config::IsNewInstance() {
     return mIsNewInstance;
 }
 
-AudioBackend Config::GetAudioBackend() {
+AudioBackend Config::GetCurrentAudioBackend() {
     std::string backendName = GetString("Window.AudioBackend");
     if (backendName == "wasapi") {
         return AudioBackend::WASAPI;
@@ -214,7 +214,7 @@ AudioBackend Config::GetAudioBackend() {
 
     // Migrate pulse player in config to sdl
     if (backendName == "pulse") {
-        SetAudioBackend(AudioBackend::SDL);
+        SetCurrentAudioBackend(AudioBackend::SDL);
         return AudioBackend::SDL;
     }
 
@@ -231,7 +231,7 @@ AudioBackend Config::GetAudioBackend() {
     return AudioBackend::SDL;
 }
 
-void Config::SetAudioBackend(AudioBackend backend) {
+void Config::SetCurrentAudioBackend(AudioBackend backend) {
     switch (backend) {
         case AudioBackend::WASAPI:
             SetString("Window.AudioBackend", "wasapi");

--- a/src/config/Config.h
+++ b/src/config/Config.h
@@ -65,8 +65,8 @@ class Config {
     nlohmann::json GetFlattenedJson();
     bool IsNewInstance();
 
-    AudioBackend GetAudioBackend();
-    void SetAudioBackend(AudioBackend backend);
+    AudioBackend GetCurrentAudioBackend();
+    void SetCurrentAudioBackend(AudioBackend backend);
     WindowBackend GetWindowBackend();
     void SetWindowBackend(WindowBackend backend);
 


### PR DESCRIPTION
This PR updates `GetAudioBackend()` to `GetCurrentAudioBackend()` and `SetAudioBackend()` to `SetCurrentAudioBackend()` as suggested in #699 