### PR TITLE
remove unused methods from InputEditorWindow

### DIFF
--- a/src/window/gui/InputEditorWindow.h
+++ b/src/window/gui/InputEditorWindow.h
@@ -19,11 +19,8 @@ class InputEditorWindow : public GuiWindow {
     using GuiWindow::GuiWindow;
     ~InputEditorWindow();
 
-    void DrawButton(const char* label, int32_t n64Btn, int32_t currentPort, int32_t* btnReading);
-
     void DrawInputChip(const char* buttonName, ImVec4 color);
     void DrawAnalogPreview(const char* label, ImVec2 stick, float deadzone = 0, bool gyro = false);
-    void DrawControllerSchema();
     bool TestingRumble();
 
   protected:


### PR DESCRIPTION
Removes `void DrawControllerSchema()` and `void DrawButton(const char* label, int32_t n64Btn, int32_t currentPort, int32_t* btnReading)`.

Addresses #712 