### PR TITLE
Audio Player Updates

### DIFF
--- a/src/audio/AudioPlayer.cpp
+++ b/src/audio/AudioPlayer.cpp
@@ -14,4 +14,28 @@ bool AudioPlayer::Init(void) {
 bool AudioPlayer::IsInitialized(void) {
     return mInitialized;
 }
+
+int32_t AudioPlayer::GetSampleRate() const {
+    return mAudioSettings.SampleRate;
+}
+
+int32_t AudioPlayer::GetSampleLength() const {
+    return mAudioSettings.SampleLength;
+}
+
+int32_t AudioPlayer::GetDesiredBuffered() const {
+    return mAudioSettings.DesiredBuffered;
+}
+
+void AudioPlayer::SetSampleRate(int32_t rate) {
+    mAudioSettings.SampleRate = rate;
+}
+
+void AudioPlayer::SetSampleLength(int32_t length) {
+    mAudioSettings.SampleLength = length;
+}
+
+void AudioPlayer::SetDesiredBuffered(int32_t size) {
+    mAudioSettings.DesiredBuffered = size;
+}
 } // namespace Ship

--- a/src/audio/AudioPlayer.h
+++ b/src/audio/AudioPlayer.h
@@ -24,29 +24,17 @@ class AudioPlayer {
 
     bool IsInitialized(void);
 
-    constexpr int32_t GetSampleRate() const {
-        return this->mAudioSettings.SampleRate;
-    }
+    int32_t GetSampleRate() const;
 
-    constexpr int32_t GetSampleLength() const {
-        return this->mAudioSettings.SampleLength;
-    }
+    int32_t GetSampleLength() const;
 
-    constexpr int32_t GetDesiredBuffered() const {
-        return this->mAudioSettings.DesiredBuffered;
-    }
+    int32_t GetDesiredBuffered() const;
 
-    void SetSampleRate(int32_t rate) {
-        this->mAudioSettings.SampleRate = rate;
-    }
+    void SetSampleRate(int32_t rate);
 
-    void SetSampleLength(int32_t length) {
-        this->mAudioSettings.SampleLength = length;
-    }
+    void SetSampleLength(int32_t length);
 
-    void SetDesiredBuffered(int32_t size) {
-        this->mAudioSettings.DesiredBuffered = size;
-    }
+    void SetDesiredBuffered(int32_t size);
 
   protected:
     virtual bool DoInit(void) = 0;

--- a/src/audio/AudioPlayer.h
+++ b/src/audio/AudioPlayer.h
@@ -6,9 +6,9 @@
 namespace Ship {
 
 struct AudioSettings {
-    int SampleRate = 44100;
-    int SampleLength = 1024;
-    int DesiredBuffered = 2480;
+    int32_t SampleRate = 44100;
+    int32_t SampleLength = 1024;
+    int32_t DesiredBuffered = 2480;
 };
 
 class AudioPlayer {
@@ -19,32 +19,32 @@ class AudioPlayer {
     ~AudioPlayer();
 
     bool Init(void);
-    virtual int Buffered(void) = 0;
+    virtual int32_t Buffered(void) = 0;
     virtual void Play(const uint8_t* buf, size_t len) = 0;
 
     bool IsInitialized(void);
 
-    constexpr int GetSampleRate() const {
+    constexpr int32_t GetSampleRate() const {
         return this->mAudioSettings.SampleRate;
     }
 
-    constexpr int GetSampleLength() const {
+    constexpr int32_t GetSampleLength() const {
         return this->mAudioSettings.SampleLength;
     }
 
-    constexpr int GetDesiredBuffered() const {
+    constexpr int32_t GetDesiredBuffered() const {
         return this->mAudioSettings.DesiredBuffered;
     }
 
-    void SetSampleRate(int rate) {
+    void SetSampleRate(int32_t rate) {
         this->mAudioSettings.SampleRate = rate;
     }
 
-    void SetSampleLength(int length) {
+    void SetSampleLength(int32_t length) {
         this->mAudioSettings.SampleLength = length;
     }
 
-    void SetDesiredBuffered(int size) {
+    void SetDesiredBuffered(int32_t size) {
         this->mAudioSettings.DesiredBuffered = size;
     }
 


### PR DESCRIPTION
Updates `int` -> `int32_t` in `AudioPlayer.h` to address #697 

Removes `constexpr` from getters in `AudioPlayer.h` and moves function definitions to `AudioPlayer.cpp` to address #700 