### PR TITLE
Fix texture edge with transparent objects

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -1510,6 +1510,10 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
     bool use_grayscale = g_rdp.grayscale;
 
     if (texture_edge) {
+        if (use_alpha) {
+            alpha_threshold = true;
+            texture_edge = false;
+        }
         use_alpha = true;
     }
 


### PR DESCRIPTION
The "texture edge" mode as it is written in the shader assumes non-transparent objects, or actually that the alpha mask goes around a non-transparent object. Texture edge + transparent objects can be represented with the threshold solution instead.

The transparent balloons in Mario Kart 64 use CVG_X_ALPHA with blender turned on (new colour * alpha + previous colour * (1-alpha)).