### PR TITLE
Add control for managing framebuffer clearing

### DIFF
--- a/src/graphic/Fast3D/gfx_direct3d11.cpp
+++ b/src/graphic/Fast3D/gfx_direct3d11.cpp
@@ -946,9 +946,13 @@ void gfx_d3d11_start_draw_to_framebuffer(int fb_id, float noise_scale) {
     d3d.context->Unmap(d3d.per_frame_cb.Get(), 0);
 }
 
-void gfx_d3d11_clear_framebuffer(void) {
+void gfx_d3d11_clear_framebuffer(bool color, bool depth) {
     Framebuffer& fb = d3d.framebuffers[d3d.current_framebuffer];
-    if (fb.has_depth_buffer) {
+    if (color) {
+        const float clearColor[] = { 0.0f, 0.0f, 0.0f, 1.0f };
+        d3d.context->ClearRenderTargetView(fb.render_target_view.Get(), clearColor);
+    }
+    if (depth && fb.has_depth_buffer) {
         d3d.context->ClearDepthStencilView(fb.depth_stencil_view.Get(), D3D11_CLEAR_DEPTH, 1.0f, 0);
     }
 }

--- a/src/graphic/Fast3D/gfx_metal.cpp
+++ b/src/graphic/Fast3D/gfx_metal.cpp
@@ -782,7 +782,7 @@ static void gfx_metal_setup_screen_framebuffer(uint32_t width, uint32_t height) 
     }
 
     render_pass_descriptor->depthAttachment()->setTexture(fb.depth_texture);
-    render_pass_descriptor->depthAttachment()->setLoadAction(MTL::LoadActionClear);
+    render_pass_descriptor->depthAttachment()->setLoadAction(MTL::LoadActionLoad);
     render_pass_descriptor->depthAttachment()->setStoreAction(MTL::StoreActionStore);
     render_pass_descriptor->depthAttachment()->setClearDepth(1);
 
@@ -910,12 +910,12 @@ static void gfx_metal_update_framebuffer_parameters(int fb_id, uint32_t width, u
         if (msaa_level > 1) {
             fb.render_pass_descriptor->depthAttachment()->setTexture(fb.msaa_depth_texture);
             fb.render_pass_descriptor->depthAttachment()->setResolveTexture(fb.depth_texture);
-            fb.render_pass_descriptor->depthAttachment()->setLoadAction(MTL::LoadActionDontCare);
+            fb.render_pass_descriptor->depthAttachment()->setLoadAction(MTL::LoadActionLoad);
             fb.render_pass_descriptor->depthAttachment()->setStoreAction(MTL::StoreActionMultisampleResolve);
             fb.render_pass_descriptor->depthAttachment()->setClearDepth(1);
         } else {
             fb.render_pass_descriptor->depthAttachment()->setTexture(fb.depth_texture);
-            fb.render_pass_descriptor->depthAttachment()->setLoadAction(MTL::LoadActionDontCare);
+            fb.render_pass_descriptor->depthAttachment()->setLoadAction(MTL::LoadActionLoad);
             fb.render_pass_descriptor->depthAttachment()->setStoreAction(MTL::StoreActionStore);
             fb.render_pass_descriptor->depthAttachment()->setClearDepth(1);
         }
@@ -958,7 +958,58 @@ void gfx_metal_start_draw_to_framebuffer(int fb_id, float noise_scale) {
     memcpy(mctx.frame_uniform_buffer->contents(), &mctx.frame_uniforms, sizeof(FrameUniforms));
 }
 
-void gfx_metal_clear_framebuffer(void) {
+void gfx_metal_clear_framebuffer(bool color, bool depth) {
+    if (!color && !depth) {
+        return;
+    }
+
+    auto& framebuffer = mctx.framebuffers[mctx.current_framebuffer];
+
+    // End the current render encoder
+    framebuffer.command_encoder->endEncoding();
+
+    // Track the original load action and set the next load actions to Load to leverage the blit results
+    MTL::RenderPassColorAttachmentDescriptor* srcColorAttachment =
+        framebuffer.render_pass_descriptor->colorAttachments()->object(0);
+    MTL::LoadAction origLoadAction = srcColorAttachment->loadAction();
+    if (color) {
+        srcColorAttachment->setLoadAction(MTL::LoadActionClear);
+    }
+
+    MTL::RenderPassDepthAttachmentDescriptor* srcDepthAttachment =
+        framebuffer.render_pass_descriptor->depthAttachment();
+    MTL::LoadAction origDepthLoadAction = MTL::LoadActionDontCare;
+    if (depth && framebuffer.has_depth_buffer) {
+        origDepthLoadAction = srcDepthAttachment->loadAction();
+        srcDepthAttachment->setLoadAction(MTL::LoadActionClear);
+    }
+
+    // Create a new render encoder back onto the framebuffer
+    framebuffer.command_encoder = framebuffer.command_buffer->renderCommandEncoder(framebuffer.render_pass_descriptor);
+
+    std::string fbce_label = fmt::format("FrameBuffer {} Command Encoder After Clear", mctx.current_framebuffer);
+    framebuffer.command_encoder->setLabel(NS::String::string(fbce_label.c_str(), NS::UTF8StringEncoding));
+    framebuffer.command_encoder->setDepthClipMode(MTL::DepthClipModeClamp);
+    framebuffer.command_encoder->setViewport(framebuffer.viewport);
+    framebuffer.command_encoder->setScissorRect(framebuffer.scissor_rect);
+
+    // Now that the command encoder is started, we set the original load actions back for the next frame's use
+    srcColorAttachment->setLoadAction(origLoadAction);
+    if (depth && framebuffer.has_depth_buffer) {
+        srcDepthAttachment->setLoadAction(origDepthLoadAction);
+    }
+
+    // Reset the framebuffer so the encoder is setup again when rendering triangles
+    framebuffer.has_bounded_vertex_buffer = false;
+    framebuffer.has_bounded_fragment_buffer = false;
+    framebuffer.last_shader_program = nullptr;
+    for (int i = 0; i < SHADER_MAX_TEXTURES; i++) {
+        framebuffer.last_bound_textures[i] = nullptr;
+        framebuffer.last_bound_samplers[i] = nullptr;
+    }
+    framebuffer.last_depth_test = -1;
+    framebuffer.last_depth_mask = -1;
+    framebuffer.last_zmode_decal = -1;
 }
 
 void gfx_metal_resolve_msaa_color_buffer(int fb_id_target, int fb_id_source) {
@@ -1130,11 +1181,19 @@ void gfx_metal_copy_framebuffer(int fb_dst_id, int fb_src_id, int srcX0, int src
                                   target_origin);
     blit_encoder->endEncoding();
 
-    // Track the original load action and set the next load action to Load to leverage the blit results
+    // Track the original load action and set the next load actions to Load to leverage the blit results
     MTL::RenderPassColorAttachmentDescriptor* srcColorAttachment =
         source_framebuffer.render_pass_descriptor->colorAttachments()->object(0);
     MTL::LoadAction origLoadAction = srcColorAttachment->loadAction();
     srcColorAttachment->setLoadAction(MTL::LoadActionLoad);
+
+    MTL::RenderPassDepthAttachmentDescriptor* srcDepthAttachment =
+        source_framebuffer.render_pass_descriptor->depthAttachment();
+    MTL::LoadAction origDepthLoadAction = MTL::LoadActionDontCare;
+    if (source_framebuffer.has_depth_buffer) {
+        origDepthLoadAction = srcDepthAttachment->loadAction();
+        srcDepthAttachment->setLoadAction(MTL::LoadActionLoad);
+    }
 
     // Create a new render encoder back onto the framebuffer
     source_framebuffer.command_encoder =
@@ -1146,8 +1205,11 @@ void gfx_metal_copy_framebuffer(int fb_dst_id, int fb_src_id, int srcX0, int src
     source_framebuffer.command_encoder->setViewport(source_framebuffer.viewport);
     source_framebuffer.command_encoder->setScissorRect(source_framebuffer.scissor_rect);
 
-    // Now that the command encoder is started, we set the original load action back for the next frame's use
+    // Now that the command encoder is started, we set the original load actions back for the next frame's use
     srcColorAttachment->setLoadAction(origLoadAction);
+    if (source_framebuffer.has_depth_buffer) {
+        srcDepthAttachment->setLoadAction(origDepthLoadAction);
+    }
 
     // Reset the framebuffer so the encoder is setup again when rendering triangles
     source_framebuffer.has_bounded_vertex_buffer = false;

--- a/src/graphic/Fast3D/gfx_opengl.cpp
+++ b/src/graphic/Fast3D/gfx_opengl.cpp
@@ -1056,10 +1056,11 @@ void gfx_opengl_start_draw_to_framebuffer(int fb_id, float noise_scale) {
     current_framebuffer = fb_id;
 }
 
-void gfx_opengl_clear_framebuffer() {
+void gfx_opengl_clear_framebuffer(bool color, bool depth) {
     glDisable(GL_SCISSOR_TEST);
     glDepthMask(GL_TRUE);
-    glClear(GL_DEPTH_BUFFER_BIT);
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear((color ? GL_COLOR_BUFFER_BIT : 0) | (depth ? GL_DEPTH_BUFFER_BIT : 0));
     glDepthMask(current_depth_mask ? GL_TRUE : GL_FALSE);
     glEnable(GL_SCISSOR_TEST);
 }

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -3436,7 +3436,8 @@ bool gfx_set_fb_handler_custom(F3DGfx** cmd0) {
 
 bool gfx_reset_fb_handler_custom(F3DGfx** cmd0) {
     gfx_flush();
-    fbActive = 0;
+    fbActive = false;
+    active_fb = framebuffers.end();
     gfx_rapi->start_draw_to_framebuffer(game_renders_to_framebuffer ? game_framebuffer : 0,
                                         (float)gfx_current_dimensions.height / gfx_native_dimensions.height);
     // Force viewport and scissor to reapply against the main framebuffer, in case a previous smaller
@@ -4165,7 +4166,7 @@ void gfx_run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_replacemen
     gfx_rapi->start_frame();
     gfx_rapi->start_draw_to_framebuffer(game_renders_to_framebuffer ? game_framebuffer : 0,
                                         (float)gfx_current_dimensions.height / gfx_native_dimensions.height);
-    gfx_rapi->clear_framebuffer();
+    gfx_rapi->clear_framebuffer(false, true);
     g_rdp.viewport_or_scissor_changed = true;
     rendering_state.viewport = {};
     rendering_state.scissor = {};
@@ -4198,7 +4199,7 @@ void gfx_run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_replacemen
 
     if (game_renders_to_framebuffer) {
         gfx_rapi->start_draw_to_framebuffer(0, 1);
-        gfx_rapi->clear_framebuffer();
+        gfx_rapi->clear_framebuffer(true, true);
 
         if (gfx_msaa_level > 1) {
             bool different_size = gfx_current_dimensions.width != gfx_current_game_window_viewport.width ||
@@ -4262,7 +4263,6 @@ extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height, uint32_t 
 
 void gfx_set_framebuffer(int fb, float noise_scale) {
     gfx_rapi->start_draw_to_framebuffer(fb, noise_scale);
-    gfx_rapi->clear_framebuffer();
 }
 
 void gfx_copy_framebuffer(int fb_dst_id, int fb_src_id, bool copyOnce, bool* hasCopiedPtr) {
@@ -4310,7 +4310,6 @@ void gfx_copy_framebuffer(int fb_dst_id, int fb_src_id, bool copyOnce, bool* has
 
 void gfx_reset_framebuffer() {
     gfx_rapi->start_draw_to_framebuffer(0, (float)gfx_current_dimensions.height / gfx_native_dimensions.height);
-    gfx_rapi->clear_framebuffer();
 }
 
 static void adjust_pixel_depth_coordinates(float& x, float& y) {

--- a/src/graphic/Fast3D/gfx_rendering_api.h
+++ b/src/graphic/Fast3D/gfx_rendering_api.h
@@ -60,7 +60,7 @@ struct GfxRenderingAPI {
     void (*start_draw_to_framebuffer)(int fb_id, float noise_scale);
     void (*copy_framebuffer)(int fb_dst_id, int fb_src_id, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0,
                              int dstY0, int dstX1, int dstY1);
-    void (*clear_framebuffer)(void);
+    void (*clear_framebuffer)(bool color, bool depth);
     void (*read_framebuffer_to_cpu)(int fb_id, uint32_t width, uint32_t height, uint16_t* rgba16_buf);
     void (*resolve_msaa_color_buffer)(int fb_id_target, int fb_id_source);
     std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff> (*get_pixel_depth)(


### PR DESCRIPTION
This adds the ability to decide whether to clear color or depth data (or both) on a framebuffer.

Prior to #607 we always cleared both. After #607 we only were clearing depth data. This had a negative impact on the "main" framebuffer used for rendering imgui where artifacts were preserved. This would appear whenever the game render space was not identical to the main window (like when using advanced resolution features).

With ability to clear things independently, we can now ensure that the main framebuffer is always cleared if the game is not rendered to it. This should resolve issues with the advanced resolution editor, without reverting anything needed by #607