### PR TITLE
Update Grayscale8bpp to remove black backgrounds from Digit Textures

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -866,7 +866,7 @@ void Gui::LoadGuiTexture(const std::string& name, const LUS::Texture& res, const
                     texBuffer.push_back(ia);
                     texBuffer.push_back(ia);
                     texBuffer.push_back(ia);
-                    texBuffer.push_back(0xFF);
+                    texBuffer.push_back(ia);
                 }
                 break;
             }

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -878,13 +878,13 @@ void Gui::LoadGuiTexture(const std::string& name, const LUS::Texture& res, const
                     texBuffer.push_back(ia4);
                     texBuffer.push_back(ia4);
                     texBuffer.push_back(ia4);
-                    texBuffer.push_back(0xFF);
+                    texBuffer.push_back(ia4);
 
                     ia4 = ((b & 0xF) * 0xFF) / 0b1111;
                     texBuffer.push_back(ia4);
                     texBuffer.push_back(ia4);
                     texBuffer.push_back(ia4);
-                    texBuffer.push_back(0xFF);
+                    texBuffer.push_back(ia4);
                 }
                 break;
             }


### PR DESCRIPTION
Removes the black backgrounds from the Digit Textures in SoH used by the In-Game Timer.

The game removes these normally but when extracted for use within ImGui the black backgrounds are visible, this corrects that.

Required/Reference: https://github.com/HarbourMasters/Shipwright/pull/4553
