### PR TITLE
Optimize filtered `ListFiles()` to only iterate once.

### DIFF
--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -67,21 +67,17 @@ bool ArchiveManager::HasFile(uint64_t hash) {
 }
 
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::string& filter) {
-    auto list = ListFiles();
-    auto result = std::make_shared<std::vector<std::string>>();
-
-    std::copy_if(list->begin(), list->end(), std::back_inserter(*result),
-                 [filter](const std::string& filePath) { return glob_match(filter.c_str(), filePath.c_str()); });
-
-    return result;
+    auto list = std::make_shared<std::vector<std::string>>();
+    for (const auto& [hash, path] : mHashes) {
+        if (filter != "" && glob_match(filter.c_str(), path.c_str()) || filter == "") {
+            list->push_back(path);
+        }
+    }
+    return list;
 }
 
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles() {
-    auto list = std::make_shared<std::vector<std::string>>();
-    for (const auto& [hash, path] : mHashes) {
-        list->push_back(path);
-    }
-    return list;
+    return ListFiles("");
 }
 
 std::vector<uint32_t> ArchiveManager::GetGameVersions() {

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -69,15 +69,11 @@ bool ArchiveManager::HasFile(uint64_t hash) {
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::string& filter) {
     auto list = std::make_shared<std::vector<std::string>>();
     for (const auto& [hash, path] : mHashes) {
-        if (filter != "" && glob_match(filter.c_str(), path.c_str()) || filter == "") {
+        if (filter.empty() || glob_match(filter.c_str(), path.c_str())) {
             list->push_back(path);
         }
     }
     return list;
-}
-
-std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles() {
-    return ListFiles("");
 }
 
 std::vector<uint32_t> ArchiveManager::GetGameVersions() {

--- a/src/resource/archive/ArchiveManager.h
+++ b/src/resource/archive/ArchiveManager.h
@@ -31,8 +31,7 @@ class ArchiveManager {
     std::shared_ptr<File> LoadFile(uint64_t hash, std::shared_ptr<ResourceInitData> initData = nullptr);
     bool HasFile(const std::string& filePath);
     bool HasFile(uint64_t hash);
-    std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& filter);
-    std::shared_ptr<std::vector<std::string>> ListFiles();
+    std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& filter = "");
     std::vector<uint32_t> GetGameVersions();
     const std::string* HashToString(uint64_t hash) const;
     bool IsGameVersionValid(uint32_t gameVersion);


### PR DESCRIPTION
Previously, the filtered ListFiles would call the unfiltered ListFiles, which would iterate over the whole of the hash map, then would iterate on the return from the unfiltered one to add matches to a separate list that gets returned. This completely removes the unfiltered function, moves the logic to the filtered function, and adds a check for empty filter to always add something when the unfiltered ListFiles would have been called.