### PR TITLE
Add method for Metal to setup imgui for floating windows

### DIFF
--- a/src/graphic/Fast3D/gfx_metal.cpp
+++ b/src/graphic/Fast3D/gfx_metal.cpp
@@ -245,6 +245,14 @@ void Metal_NewFrame(SDL_Renderer* renderer) {
     ImGui_ImplMetal_NewFrame(current_render_pass);
 }
 
+void Metal_SetupFloatingFrame() {
+    // We need the descriptor for the main framebuffer and to clear the existing depth attachment
+    // so that we can set ImGui up again for our floating windows. Helps avoid Metal API validation issues.
+    MTL::RenderPassDescriptor* current_render_pass = mctx.framebuffers[0].render_pass_descriptor;
+    current_render_pass->setDepthAttachment(nullptr);
+    ImGui_ImplMetal_NewFrame(current_render_pass);
+}
+
 void Metal_RenderDrawData(ImDrawData* draw_data) {
     auto framebuffer = mctx.framebuffers[0];
 

--- a/src/graphic/Fast3D/gfx_metal.h
+++ b/src/graphic/Fast3D/gfx_metal.h
@@ -22,6 +22,7 @@ bool Metal_IsSupported();
 bool Metal_Init(SDL_Renderer* renderer);
 void Metal_SetupFrame(SDL_Renderer* renderer);
 void Metal_NewFrame(SDL_Renderer* renderer);
+void Metal_SetupFloatingFrame(void);
 void Metal_RenderDrawData(ImDrawData* draw_data);
 
 #endif

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -647,6 +647,13 @@ void Gui::DrawFloatingWindows() {
             // Set back the GL context for next frame
             SDL_GL_MakeCurrent(backupCurrentWindow, backupCurrentContext);
         } else {
+#ifdef __APPLE__
+            // Metal requires additional frame setup to get ImGui ready for drawing floating windows
+            if (backend == WindowBackend::FAST3D_SDL_METAL) {
+                Metal_SetupFloatingFrame();
+            }
+#endif
+
             ImGui::UpdatePlatformWindows();
             ImGui::RenderPlatformWindowsDefault();
         }


### PR DESCRIPTION
There is an Metal API validation error which happens when floating windows are rendered. The error points to a missing depth texture when the render descriptor has specified that there should be one.

The depth attachment is originally set when the game is rendered, but is not required for floating windows.

To address this I've exposed a new method after all the game rendering is finished which removes the depth attachment and "re-sets up" ImGui with the render descriptor so that it does not use depth with the floating windows.

This error was not impacting release builds, but ideally should be addressed anyways.