### PR TITLE
ResourceFilter, Directory Function Renames, Multifilter Functionality

### DIFF
--- a/src/public/bridge/resourcebridge.cpp
+++ b/src/public/bridge/resourcebridge.cpp
@@ -153,7 +153,7 @@ void ResourceGetGameVersions(uint32_t* versions, size_t versionsSize, size_t* ve
 }
 
 void ResourceLoadDirectoryAsync(const char* name) {
-    Ship::Context::GetInstance()->GetResourceManager()->LoadDirectoryAsync(name);
+    Ship::Context::GetInstance()->GetResourceManager()->LoadResourcesAsync(name);
 }
 
 uint32_t ResourceHasGameVersion(uint32_t hash) {
@@ -162,11 +162,11 @@ uint32_t ResourceHasGameVersion(uint32_t hash) {
 }
 
 void ResourceLoadDirectory(const char* name) {
-    Ship::Context::GetInstance()->GetResourceManager()->LoadDirectory(name);
+    Ship::Context::GetInstance()->GetResourceManager()->LoadResources(name);
 }
 
 void ResourceDirtyDirectory(const char* name) {
-    Ship::Context::GetInstance()->GetResourceManager()->DirtyDirectory(name);
+    Ship::Context::GetInstance()->GetResourceManager()->DirtyResources(name);
 }
 
 void ResourceDirtyByName(const char* name) {
@@ -194,7 +194,7 @@ void ResourceUnloadByCrc(uint64_t crc) {
 }
 
 void ResourceUnloadDirectory(const char* name) {
-    Ship::Context::GetInstance()->GetResourceManager()->UnloadDirectory(name);
+    Ship::Context::GetInstance()->GetResourceManager()->UnloadResources(name);
 }
 
 uint32_t IsResourceManagerLoaded() {

--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -11,7 +11,7 @@
 
 namespace Ship {
 
-ResourceFilter::ResourceFilter(const std::list<std::string> includeMasks, const std::list<std::string> excludeMasks,
+ResourceFilter::ResourceFilter(const std::list<std::string>& includeMasks, const std::list<std::string>& excludeMasks,
                                const uintptr_t owner, const std::shared_ptr<Archive> parent)
     : IncludeMasks(includeMasks), ExcludeMasks(excludeMasks), Owner(owner), Parent(parent) {
 }

--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -13,7 +13,8 @@ namespace Ship {
 
 ResourceFilter::ResourceFilter(const std::list<std::string> includeMasks, const std::list<std::string> excludeMasks,
                                const uintptr_t owner, const std::shared_ptr<Archive> parent)
-    : IncludeMasks(includeMasks), ExcludeMasks(excludeMasks), Owner(owner), Parent(parent) {}
+    : IncludeMasks(includeMasks), ExcludeMasks(excludeMasks), Owner(owner), Parent(parent) {
+}
 
 size_t ResourceIdentifier::GetHash() const {
     return mHash;
@@ -296,7 +297,7 @@ ResourceManager::LoadResourcesProcess(const ResourceFilter& filter) {
 
     for (size_t i = 0; i < fileList->size(); i++) {
         auto fileName = std::string(fileList->operator[](i));
-        auto resource = LoadResource({fileName, filter.Owner, filter.Parent});
+        auto resource = LoadResource({ fileName, filter.Owner, filter.Parent });
         loadedList->push_back(resource);
     }
 
@@ -314,11 +315,11 @@ ResourceManager::LoadResourcesAsync(const ResourceFilter& filter, BS::priority_t
 
 std::shared_future<std::shared_ptr<std::vector<std::shared_ptr<IResource>>>>
 ResourceManager::LoadResourcesAsync(const std::string& searchMask, BS::priority_t priority) {
-    return LoadResourcesAsync({ {searchMask}, {}, mDefaultCacheOwner, mDefaultCacheArchive}, priority);
+    return LoadResourcesAsync({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive }, priority);
 }
 
 std::shared_ptr<std::vector<std::shared_ptr<IResource>>> ResourceManager::LoadResources(const std::string& searchMask) {
-    return LoadResources({ {searchMask}, {}, mDefaultCacheOwner, mDefaultCacheArchive});
+    return LoadResources({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive });
 }
 
 std::shared_ptr<std::vector<std::shared_ptr<IResource>>> ResourceManager::LoadResources(const ResourceFilter& filter) {
@@ -326,39 +327,37 @@ std::shared_ptr<std::vector<std::shared_ptr<IResource>>> ResourceManager::LoadRe
 }
 
 void ResourceManager::DirtyResources(const ResourceFilter& filter) {
-    mThreadPool->submit_task(
-        [this, filter]() -> void {
-            auto list = GetArchiveManager()->ListFiles(filter.IncludeMasks, filter.ExcludeMasks);
+    mThreadPool->submit_task([this, filter]() -> void {
+        auto list = GetArchiveManager()->ListFiles(filter.IncludeMasks, filter.ExcludeMasks);
 
-            for (const auto& key : *list.get()) {
-                auto resource = GetCachedResource({ key, filter.Owner, filter.Parent });
-                // If it's a resource, we will set the dirty flag, else we will just unload it.
-                if (resource != nullptr) {
-                    resource->Dirty();
-                } else {
-                    UnloadResource({ key, filter.Owner, filter.Parent });
-                }
+        for (const auto& key : *list.get()) {
+            auto resource = GetCachedResource({ key, filter.Owner, filter.Parent });
+            // If it's a resource, we will set the dirty flag, else we will just unload it.
+            if (resource != nullptr) {
+                resource->Dirty();
+            } else {
+                UnloadResource({ key, filter.Owner, filter.Parent });
             }
-        });
+        }
+    });
 }
 
 void ResourceManager::UnloadResources(const ResourceFilter& filter) {
-    mThreadPool->submit_task(
-        [this, filter]() -> void {
-            auto list = GetArchiveManager()->ListFiles(filter.IncludeMasks, filter.ExcludeMasks);
+    mThreadPool->submit_task([this, filter]() -> void {
+        auto list = GetArchiveManager()->ListFiles(filter.IncludeMasks, filter.ExcludeMasks);
 
-            for (const auto& key : *list.get()) {
-                UnloadResource({ key, mDefaultCacheOwner, mDefaultCacheArchive });
-            }
-        });
+        for (const auto& key : *list.get()) {
+            UnloadResource({ key, mDefaultCacheOwner, mDefaultCacheArchive });
+        }
+    });
 }
 
 void ResourceManager::DirtyResources(const std::string& searchMask) {
-    DirtyResources({ {searchMask}, {}, mDefaultCacheOwner, mDefaultCacheArchive});
+    DirtyResources({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive });
 }
 
 void ResourceManager::UnloadResources(const std::string& searchMask) {
-    UnloadResources({ {searchMask}, {}, mDefaultCacheOwner, mDefaultCacheArchive});
+    UnloadResources({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive });
 }
 
 std::shared_ptr<ArchiveManager> ResourceManager::GetArchiveManager() {

--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -286,7 +286,7 @@ ResourceManager::GetCachedResource(std::variant<ResourceLoadError, std::shared_p
 
 std::shared_ptr<std::vector<std::shared_future<std::shared_ptr<IResource>>>>
 ResourceManager::LoadDirectoryAsyncWithExclude(const std::vector<std::string>& includeMasks,
-                                               const std::vector<std::string>& excludeMasks, uintptr_t owner,
+                                               const std::vector<std::string>& excludeMasks,
                                                BS::priority_t priority) {
     auto loadedList = std::make_shared<std::vector<std::shared_future<std::shared_ptr<IResource>>>>();
     auto fileList = GetArchiveManager()->ListFilesWithExclude(includeMasks, excludeMasks);
@@ -294,7 +294,7 @@ ResourceManager::LoadDirectoryAsyncWithExclude(const std::vector<std::string>& i
 
     for (size_t i = 0; i < fileList->size(); i++) {
         auto fileName = std::string(fileList->operator[](i));
-        auto future = LoadResourceAsync(fileName, owner, false, priority);
+        auto future = LoadResourceAsync(fileName, priority);
         loadedList->push_back(future);
     }
 
@@ -319,7 +319,7 @@ ResourceManager::LoadDirectoryAsync(const ResourceIdentifier& identifier, BS::pr
 std::shared_ptr<std::vector<std::shared_ptr<IResource>>>
 ResourceManager::LoadDirectoryWithExclude(const std::vector<std::string>& includeMasks,
                                           const std::vector<std::string>& excludeMasks, uintptr_t owner) {
-    auto futureList = LoadDirectoryAsyncWithExclude(includeMasks, excludeMasks, owner, true);
+    auto futureList = LoadDirectoryAsyncWithExclude(includeMasks, excludeMasks);
     auto loadedList = std::make_shared<std::vector<std::shared_ptr<IResource>>>();
 
     for (size_t i = 0; i < futureList->size(); i++) {
@@ -369,11 +369,11 @@ void ResourceManager::DirtyDirectory(const ResourceIdentifier& identifier) {
 }
 
 void ResourceManager::UnloadDirectoryWithExclude(const std::vector<std::string>& includeMasks,
-                                                 const std::vector<std::string>& excludeMasks, uintptr_t owner) {
+                                                 const std::vector<std::string>& excludeMasks) {
     auto list = GetArchiveManager()->ListFilesWithExclude(includeMasks, excludeMasks);
 
     for (const auto& key : *list.get()) {
-        UnloadResource(key, owner);
+        UnloadResource({ key, mDefaultCacheOwner, mDefaultCacheArchive });
     }
 }
 

--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -286,8 +286,7 @@ ResourceManager::GetCachedResource(std::variant<ResourceLoadError, std::shared_p
 
 std::shared_ptr<std::vector<std::shared_future<std::shared_ptr<IResource>>>>
 ResourceManager::LoadDirectoryAsyncWithExclude(const std::vector<std::string>& includeMasks,
-                                               const std::vector<std::string>& excludeMasks,
-                                               BS::priority_t priority) {
+                                               const std::vector<std::string>& excludeMasks, BS::priority_t priority) {
     auto loadedList = std::make_shared<std::vector<std::shared_future<std::shared_ptr<IResource>>>>();
     auto fileList = GetArchiveManager()->ListFilesWithExclude(includeMasks, excludeMasks);
     loadedList->reserve(fileList->size());

--- a/src/resource/ResourceManager.h
+++ b/src/resource/ResourceManager.h
@@ -85,11 +85,11 @@ class ResourceManager {
     LoadDirectoryAsync(const std::string& searchMask, BS::priority_t priority = BS::pr::normal);
     std::shared_ptr<std::vector<std::shared_future<std::shared_ptr<IResource>>>>
     LoadDirectoryAsyncWithExclude(const std::vector<std::string>& includeMasks,
-                                  const std::vector<std::string>& excludeMasks, uintptr_t owner = 0,
+                                  const std::vector<std::string>& excludeMasks,
                                   BS::priority_t priority = BS::pr::normal);
     void DirtyDirectory(const std::string& searchMask);
     void UnloadDirectoryWithExclude(const std::vector<std::string>& includeMasks,
-                                    const std::vector<std::string>& excludeMasks, uintptr_t owner);
+                                    const std::vector<std::string>& excludeMasks);
     void UnloadDirectory(const std::string& searchMask);
 
     bool OtrSignatureCheck(const char* fileName);

--- a/src/resource/ResourceManager.h
+++ b/src/resource/ResourceManager.h
@@ -21,7 +21,7 @@ namespace Ship {
 struct File;
 
 struct ResourceFilter {
-    ResourceFilter(const std::list<std::string> includeMasks, const std::list<std::string> excludeMasks,
+    ResourceFilter(const std::list<std::string>& includeMasks, const std::list<std::string>& excludeMasks,
                    const uintptr_t owner, const std::shared_ptr<Archive> parent);
 
     const std::list<std::string> IncludeMasks;

--- a/src/resource/ResourceManager.h
+++ b/src/resource/ResourceManager.h
@@ -3,6 +3,8 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <string>
+#include <list>
+#include <vector>
 #include <mutex>
 #include <queue>
 #include <variant>

--- a/src/resource/ResourceManager.h
+++ b/src/resource/ResourceManager.h
@@ -20,7 +20,7 @@ struct File;
 
 struct ResourceFilter {
     ResourceFilter(const std::list<std::string> includeMasks, const std::list<std::string> excludeMasks,
-        const uintptr_t owner, const std::shared_ptr<Archive> parent);
+                   const uintptr_t owner, const std::shared_ptr<Archive> parent);
 
     const std::list<std::string> IncludeMasks;
     const std::list<std::string> ExcludeMasks;
@@ -83,8 +83,7 @@ class ResourceManager {
     size_t UnloadResource(const std::string& filePath);
 
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResources(const std::string& searchMask);
-    std::shared_ptr<std::vector<std::shared_ptr<IResource>>>
-    LoadResources(const ResourceFilter& filter);
+    std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResources(const ResourceFilter& filter);
     std::shared_future<std::shared_ptr<std::vector<std::shared_ptr<IResource>>>>
     LoadResourcesAsync(const std::string& searchMask, BS::priority_t priority = BS::pr::normal);
     std::shared_future<std::shared_ptr<std::vector<std::shared_ptr<IResource>>>>
@@ -100,8 +99,7 @@ class ResourceManager {
     void SetAltAssetsEnabled(bool isEnabled);
 
   protected:
-    std::shared_ptr<std::vector<std::shared_ptr<IResource>>>
-    LoadResourcesProcess(const ResourceFilter& filter);
+    std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResourcesProcess(const ResourceFilter& filter);
     std::variant<ResourceLoadError, std::shared_ptr<IResource>> CheckCache(const ResourceIdentifier& identifier,
                                                                            bool loadExact = false);
     std::shared_ptr<File> LoadFileProcess(const ResourceIdentifier& identifier,

--- a/src/resource/ResourceManager.h
+++ b/src/resource/ResourceManager.h
@@ -62,6 +62,9 @@ class ResourceManager {
     std::shared_future<std::shared_ptr<IResource>>
     LoadResourceAsync(const ResourceIdentifier& identifier, bool loadExact = false,
                       BS::priority_t priority = BS::pr::normal, std::shared_ptr<ResourceInitData> initData = nullptr);
+    std::shared_ptr<std::vector<std::shared_ptr<IResource>>>
+    LoadDirectoryWithExclude(const std::vector<std::string>& includeMasks, const std::vector<std::string>& excludeMasks,
+                             uintptr_t owner);
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadDirectory(const ResourceIdentifier& identifier);
     std::shared_ptr<std::vector<std::shared_future<std::shared_ptr<IResource>>>>
     LoadDirectoryAsync(const ResourceIdentifier& identifier, BS::priority_t priority = BS::pr::normal);
@@ -80,7 +83,13 @@ class ResourceManager {
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadDirectory(const std::string& searchMask);
     std::shared_ptr<std::vector<std::shared_future<std::shared_ptr<IResource>>>>
     LoadDirectoryAsync(const std::string& searchMask, BS::priority_t priority = BS::pr::normal);
+    std::shared_ptr<std::vector<std::shared_future<std::shared_ptr<IResource>>>>
+    LoadDirectoryAsyncWithExclude(const std::vector<std::string>& includeMasks,
+                                  const std::vector<std::string>& excludeMasks, uintptr_t owner = 0,
+                                  BS::priority_t priority = BS::pr::normal);
     void DirtyDirectory(const std::string& searchMask);
+    void UnloadDirectoryWithExclude(const std::vector<std::string>& includeMasks,
+                                    const std::vector<std::string>& excludeMasks, uintptr_t owner);
     void UnloadDirectory(const std::string& searchMask);
 
     bool OtrSignatureCheck(const char* fileName);

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -65,7 +65,7 @@ bool ArchiveManager::HasFile(uint64_t hash) {
 }
 
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles() {
-    return ListFiles({ "*" }, {});
+    return ListFiles({}, {});
 }
 
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::string& searchMask) {

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -65,16 +65,27 @@ bool ArchiveManager::HasFile(uint64_t hash) {
 }
 
 std::shared_ptr<std::vector<std::string>>
-ArchiveManager::ListFilesWithExclude(const std::vector<std::string>& include, const std::vector<std::string>& exclude) {
+ArchiveManager::ListFiles() {
+    return ListFiles({ "*" }, {});
+}
+
+std::shared_ptr<std::vector<std::string>>
+ArchiveManager::ListFiles(const std::string& searchMask) {
+    return ListFiles({ searchMask }, {});
+}
+
+std::shared_ptr<std::vector<std::string>>
+ArchiveManager::ListFiles(const std::list<std::string>& includes,
+                          const std::list<std::string>& excludes) {
     auto list = std::make_shared<std::vector<std::string>>();
     for (const auto& [hash, path] : mHashes) {
-        if (include.empty() && exclude.empty()) {
+        if (includes.empty() && excludes.empty()) {
             list->push_back(path);
             continue;
         }
-        bool includeMatch = include.empty();
-        if (!include.empty()) {
-            for (std::string filter : include) {
+        bool includeMatch = includes.empty();
+        if (!includes.empty()) {
+            for (std::string filter : includes) {
                 if (glob_match(filter.c_str(), path.c_str())) {
                     includeMatch = true;
                     break;
@@ -82,8 +93,8 @@ ArchiveManager::ListFilesWithExclude(const std::vector<std::string>& include, co
             }
         }
         bool excludeMatch = false;
-        if (!include.empty()) {
-            for (std::string filter : exclude) {
+        if (!excludes.empty()) {
+            for (std::string filter : excludes) {
                 if (glob_match(filter.c_str(), path.c_str())) {
                     excludeMatch = true;
                     break;
@@ -91,16 +102,6 @@ ArchiveManager::ListFilesWithExclude(const std::vector<std::string>& include, co
             }
         }
         if (includeMatch && !excludeMatch) {
-            list->push_back(path);
-        }
-    }
-    return list;
-}
-
-std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::string& filter) {
-    auto list = std::make_shared<std::vector<std::string>>();
-    for (const auto& [hash, path] : mHashes) {
-        if (filter.empty() || glob_match(filter.c_str(), path.c_str())) {
             list->push_back(path);
         }
     }

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -64,19 +64,16 @@ bool ArchiveManager::HasFile(uint64_t hash) {
     return mFileToArchive.count(hash) > 0;
 }
 
-std::shared_ptr<std::vector<std::string>>
-ArchiveManager::ListFiles() {
+std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles() {
     return ListFiles({ "*" }, {});
 }
 
-std::shared_ptr<std::vector<std::string>>
-ArchiveManager::ListFiles(const std::string& searchMask) {
+std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::string& searchMask) {
     return ListFiles({ searchMask }, {});
 }
 
-std::shared_ptr<std::vector<std::string>>
-ArchiveManager::ListFiles(const std::list<std::string>& includes,
-                          const std::list<std::string>& excludes) {
+std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::list<std::string>& includes,
+                                                                    const std::list<std::string>& excludes) {
     auto list = std::make_shared<std::vector<std::string>>();
     for (const auto& [hash, path] : mHashes) {
         if (includes.empty() && excludes.empty()) {

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -64,6 +64,39 @@ bool ArchiveManager::HasFile(uint64_t hash) {
     return mFileToArchive.count(hash) > 0;
 }
 
+std::shared_ptr<std::vector<std::string>>
+ArchiveManager::ListFilesWithExclude(const std::vector<std::string>& include, const std::vector<std::string>& exclude) {
+    auto list = std::make_shared<std::vector<std::string>>();
+    for (const auto& [hash, path] : mHashes) {
+        if (include.empty() && exclude.empty()) {
+            list->push_back(path);
+            continue;
+        }
+        bool includeMatch = include.empty();
+        if (!include.empty()) {
+            for (std::string filter : include) {
+                if (glob_match(filter.c_str(), path.c_str())) {
+                    includeMatch = true;
+                    break;
+                }
+            }
+        }
+        bool excludeMatch = false;
+        if (!include.empty()) {
+            for (std::string filter : exclude) {
+                if (glob_match(filter.c_str(), path.c_str())) {
+                    excludeMatch = true;
+                    break;
+                }
+            }
+        }
+        if (includeMatch && !excludeMatch) {
+            list->push_back(path);
+        }
+    }
+    return list;
+}
+
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::string& filter) {
     auto list = std::make_shared<std::vector<std::string>>();
     for (const auto& [hash, path] : mHashes) {

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -64,11 +64,11 @@ bool ArchiveManager::HasFile(uint64_t hash) {
     return mFileToArchive.count(hash) > 0;
 }
 
-std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles() {
-    return ListFiles({}, {});
-}
-
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::string& searchMask) {
+    std::list<std::string> includes = {};
+    if (searchMask.size() > 0) {
+        includes.push_back(searchMask);
+    }
     return ListFiles({ searchMask }, {});
 }
 

--- a/src/resource/archive/ArchiveManager.h
+++ b/src/resource/archive/ArchiveManager.h
@@ -32,8 +32,7 @@ class ArchiveManager {
     std::shared_ptr<File> LoadFile(uint64_t hash, std::shared_ptr<ResourceInitData> initData = nullptr);
     bool HasFile(const std::string& filePath);
     bool HasFile(uint64_t hash);
-    std::shared_ptr<std::vector<std::string>> ListFiles();
-    std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& searchMask);
+    std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& searchMask = "");
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::list<std::string>& includes,
                                                         const std::list<std::string>& excludes);
     std::vector<uint32_t> GetGameVersions();

--- a/src/resource/archive/ArchiveManager.h
+++ b/src/resource/archive/ArchiveManager.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <memory>
 #include <vector>
+#include <list>
 #include <unordered_map>
 #include <unordered_set>
 #include <stdint.h>

--- a/src/resource/archive/ArchiveManager.h
+++ b/src/resource/archive/ArchiveManager.h
@@ -31,9 +31,10 @@ class ArchiveManager {
     std::shared_ptr<File> LoadFile(uint64_t hash, std::shared_ptr<ResourceInitData> initData = nullptr);
     bool HasFile(const std::string& filePath);
     bool HasFile(uint64_t hash);
-    std::shared_ptr<std::vector<std::string>> ListFilesWithExclude(const std::vector<std::string>& include = {},
-                                                                   const std::vector<std::string>& exclude = {});
-    std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& filter = "");
+    std::shared_ptr<std::vector<std::string>> ListFiles();
+    std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& searchMask);
+    std::shared_ptr<std::vector<std::string>> ListFiles(const std::list<std::string>& includes,
+                                                        const std::list<std::string>& excludes);
     std::vector<uint32_t> GetGameVersions();
     const std::string* HashToString(uint64_t hash) const;
     bool IsGameVersionValid(uint32_t gameVersion);

--- a/src/resource/archive/ArchiveManager.h
+++ b/src/resource/archive/ArchiveManager.h
@@ -31,6 +31,8 @@ class ArchiveManager {
     std::shared_ptr<File> LoadFile(uint64_t hash, std::shared_ptr<ResourceInitData> initData = nullptr);
     bool HasFile(const std::string& filePath);
     bool HasFile(uint64_t hash);
+    std::shared_ptr<std::vector<std::string>> ListFilesWithExclude(const std::vector<std::string>& include = {},
+                                                                   const std::vector<std::string>& exclude = {});
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& filter = "");
     std::vector<uint32_t> GetGameVersions();
     const std::string* HashToString(uint64_t hash) const;


### PR DESCRIPTION
This PR creates a new struct, `ResourceFilter`, which holds include and exclude lists as well as owner and parent options to be passed to `LoadResource` as part of the `ResourceIdentifier`. It also renames and fleshes out all Directory commands to be named with Resources instead, and threads all Resources functionality to also encapsulate `ListFiles` calls, which addresses #736. `ListFiles` calls are unified now, eventually passing a ResourceFilter to the base function.