### PR TITLE
rename `Stick` -> `StickIndex`

### DIFF
--- a/src/controller/controldevice/controller/Controller.cpp
+++ b/src/controller/controldevice/controller/Controller.cpp
@@ -236,7 +236,7 @@ void Controller::MoveMappingsToDifferentController(std::shared_ptr<Controller> n
 
     for (auto stick : { GetLeftStick(), GetRightStick() }) {
         auto newControllerStick =
-            stick->LeftOrRightStick() == LEFT_STICK ? newController->GetLeftStick() : newController->GetRightStick();
+            stick->GetStickIndex() == LEFT_STICK ? newController->GetLeftStick() : newController->GetRightStick();
         for (auto [direction, mappings] : stick->GetAllAxisDirectionMappings()) {
             std::vector<std::string> axisDirectionMappingIdsToRemove;
             for (auto [id, mapping] : mappings) {

--- a/src/controller/controldevice/controller/ControllerStick.h
+++ b/src/controller/controldevice/controller/ControllerStick.h
@@ -14,7 +14,7 @@ namespace Ship {
 
 class ControllerStick {
   public:
-    ControllerStick(uint8_t portIndex, Stick stick);
+    ControllerStick(uint8_t portIndex, StickIndex stickIndex);
     ~ControllerStick();
 
     void ReloadAllMappingsFromConfig();
@@ -54,7 +54,7 @@ class ControllerStick {
     bool ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode);
 
     bool HasMappingsForShipDeviceIndex(ShipDeviceIndex lusIndex);
-    Stick LeftOrRightStick();
+    StickIndex GetStickIndex();
 
   private:
     double GetClosestNotch(double angle, double approximationThreshold);
@@ -62,7 +62,7 @@ class ControllerStick {
     float GetAxisDirectionValue(Direction direction);
 
     uint8_t mPortIndex;
-    Stick mStick;
+    StickIndex mStickIndex;
 
     uint8_t mSensitivityPercentage;
     float mSensitivity;

--- a/src/controller/controldevice/controller/mapping/ControllerAxisDirectionMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/ControllerAxisDirectionMapping.cpp
@@ -5,8 +5,8 @@
 
 namespace Ship {
 ControllerAxisDirectionMapping::ControllerAxisDirectionMapping(ShipDeviceIndex shipDeviceIndex, uint8_t portIndex,
-                                                               Stick stick, Direction direction)
-    : ControllerInputMapping(shipDeviceIndex), mPortIndex(portIndex), mStick(stick), mDirection(direction) {
+                                                               StickIndex stickIndex, Direction direction)
+    : ControllerInputMapping(shipDeviceIndex), mPortIndex(portIndex), mStickIndex(stickIndex), mDirection(direction) {
 }
 
 ControllerAxisDirectionMapping::~ControllerAxisDirectionMapping() {

--- a/src/controller/controldevice/controller/mapping/ControllerAxisDirectionMapping.h
+++ b/src/controller/controldevice/controller/mapping/ControllerAxisDirectionMapping.h
@@ -8,12 +8,12 @@
 #define MAX_AXIS_RANGE 85.0f
 
 namespace Ship {
-enum Stick { LEFT_STICK, RIGHT_STICK };
+enum StickIndex { LEFT_STICK, RIGHT_STICK };
 enum Direction { LEFT, RIGHT, UP, DOWN };
 
 class ControllerAxisDirectionMapping : virtual public ControllerInputMapping {
   public:
-    ControllerAxisDirectionMapping(ShipDeviceIndex shipDeviceIndex, uint8_t portIndex, Stick stick,
+    ControllerAxisDirectionMapping(ShipDeviceIndex shipDeviceIndex, uint8_t portIndex, StickIndex stickIndex,
                                    Direction direction);
     ~ControllerAxisDirectionMapping();
     virtual float GetNormalizedAxisDirectionValue() = 0;
@@ -28,7 +28,7 @@ class ControllerAxisDirectionMapping : virtual public ControllerInputMapping {
 
   protected:
     uint8_t mPortIndex;
-    Stick mStick;
+    StickIndex mStickIndex;
     Direction mDirection;
 };
 } // namespace Ship

--- a/src/controller/controldevice/controller/mapping/factories/AxisDirectionMappingFactory.cpp
+++ b/src/controller/controldevice/controller/mapping/factories/AxisDirectionMappingFactory.cpp
@@ -11,7 +11,8 @@
 
 namespace Ship {
 std::shared_ptr<ControllerAxisDirectionMapping>
-AxisDirectionMappingFactory::CreateAxisDirectionMappingFromConfig(uint8_t portIndex, Stick stick, std::string id) {
+AxisDirectionMappingFactory::CreateAxisDirectionMappingFromConfig(uint8_t portIndex, StickIndex stickIndex,
+                                                                  std::string id) {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + id;
     const std::string mappingClass =
         CVarGetString(StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str(), "");
@@ -34,7 +35,7 @@ AxisDirectionMappingFactory::CreateAxisDirectionMappingFromConfig(uint8_t portIn
         }
 
         return std::make_shared<SDLAxisDirectionToAxisDirectionMapping>(
-            static_cast<ShipDeviceIndex>(shipDeviceIndex), portIndex, stick, static_cast<Direction>(direction),
+            static_cast<ShipDeviceIndex>(shipDeviceIndex), portIndex, stickIndex, static_cast<Direction>(direction),
             sdlControllerAxis, axisDirection);
     }
 
@@ -53,9 +54,9 @@ AxisDirectionMappingFactory::CreateAxisDirectionMappingFromConfig(uint8_t portIn
             return nullptr;
         }
 
-        return std::make_shared<SDLButtonToAxisDirectionMapping>(static_cast<ShipDeviceIndex>(shipDeviceIndex),
-                                                                 portIndex, stick, static_cast<Direction>(direction),
-                                                                 sdlControllerButton);
+        return std::make_shared<SDLButtonToAxisDirectionMapping>(
+            static_cast<ShipDeviceIndex>(shipDeviceIndex), portIndex, stickIndex, static_cast<Direction>(direction),
+            sdlControllerButton);
     }
 
     if (mappingClass == "KeyboardKeyToAxisDirectionMapping") {
@@ -70,20 +71,23 @@ AxisDirectionMappingFactory::CreateAxisDirectionMappingFromConfig(uint8_t portIn
             return nullptr;
         }
 
-        return std::make_shared<KeyboardKeyToAxisDirectionMapping>(portIndex, stick, static_cast<Direction>(direction),
-                                                                   static_cast<KbScancode>(scancode));
+        return std::make_shared<KeyboardKeyToAxisDirectionMapping>(
+            portIndex, stickIndex, static_cast<Direction>(direction), static_cast<KbScancode>(scancode));
     }
 
     return nullptr;
 }
 
 std::vector<std::shared_ptr<ControllerAxisDirectionMapping>>
-AxisDirectionMappingFactory::CreateDefaultKeyboardAxisDirectionMappings(uint8_t portIndex, Stick stick) {
+AxisDirectionMappingFactory::CreateDefaultKeyboardAxisDirectionMappings(uint8_t portIndex, StickIndex stickIndex) {
     std::vector<std::shared_ptr<ControllerAxisDirectionMapping>> mappings = {
-        std::make_shared<KeyboardKeyToAxisDirectionMapping>(portIndex, stick, LEFT, LUS_DEFAULT_KB_MAPPING_STICKLEFT),
-        std::make_shared<KeyboardKeyToAxisDirectionMapping>(portIndex, stick, RIGHT, LUS_DEFAULT_KB_MAPPING_STICKRIGHT),
-        std::make_shared<KeyboardKeyToAxisDirectionMapping>(portIndex, stick, UP, LUS_DEFAULT_KB_MAPPING_STICKUP),
-        std::make_shared<KeyboardKeyToAxisDirectionMapping>(portIndex, stick, DOWN, LUS_DEFAULT_KB_MAPPING_STICKDOWN)
+        std::make_shared<KeyboardKeyToAxisDirectionMapping>(portIndex, stickIndex, LEFT,
+                                                            LUS_DEFAULT_KB_MAPPING_STICKLEFT),
+        std::make_shared<KeyboardKeyToAxisDirectionMapping>(portIndex, stickIndex, RIGHT,
+                                                            LUS_DEFAULT_KB_MAPPING_STICKRIGHT),
+        std::make_shared<KeyboardKeyToAxisDirectionMapping>(portIndex, stickIndex, UP, LUS_DEFAULT_KB_MAPPING_STICKUP),
+        std::make_shared<KeyboardKeyToAxisDirectionMapping>(portIndex, stickIndex, DOWN,
+                                                            LUS_DEFAULT_KB_MAPPING_STICKDOWN)
     };
 
     return mappings;
@@ -91,7 +95,7 @@ AxisDirectionMappingFactory::CreateDefaultKeyboardAxisDirectionMappings(uint8_t 
 
 std::vector<std::shared_ptr<ControllerAxisDirectionMapping>>
 AxisDirectionMappingFactory::CreateDefaultSDLAxisDirectionMappings(ShipDeviceIndex shipDeviceIndex, uint8_t portIndex,
-                                                                   Stick stick) {
+                                                                   StickIndex stickIndex) {
     auto sdlIndexMapping = std::dynamic_pointer_cast<ShipDeviceIndexToSDLDeviceIndexMapping>(
         Context::GetInstance()
             ->GetControlDeck()
@@ -102,21 +106,21 @@ AxisDirectionMappingFactory::CreateDefaultSDLAxisDirectionMappings(ShipDeviceInd
     }
 
     std::vector<std::shared_ptr<ControllerAxisDirectionMapping>> mappings = {
-        std::make_shared<SDLAxisDirectionToAxisDirectionMapping>(shipDeviceIndex, portIndex, stick, LEFT,
-                                                                 stick == LEFT_STICK ? 0 : 2, -1),
-        std::make_shared<SDLAxisDirectionToAxisDirectionMapping>(shipDeviceIndex, portIndex, stick, RIGHT,
-                                                                 stick == LEFT_STICK ? 0 : 2, 1),
-        std::make_shared<SDLAxisDirectionToAxisDirectionMapping>(shipDeviceIndex, portIndex, stick, UP,
-                                                                 stick == LEFT_STICK ? 1 : 3, -1),
-        std::make_shared<SDLAxisDirectionToAxisDirectionMapping>(shipDeviceIndex, portIndex, stick, DOWN,
-                                                                 stick == LEFT_STICK ? 1 : 3, 1)
+        std::make_shared<SDLAxisDirectionToAxisDirectionMapping>(shipDeviceIndex, portIndex, stickIndex, LEFT,
+                                                                 stickIndex == LEFT_STICK ? 0 : 2, -1),
+        std::make_shared<SDLAxisDirectionToAxisDirectionMapping>(shipDeviceIndex, portIndex, stickIndex, RIGHT,
+                                                                 stickIndex == LEFT_STICK ? 0 : 2, 1),
+        std::make_shared<SDLAxisDirectionToAxisDirectionMapping>(shipDeviceIndex, portIndex, stickIndex, UP,
+                                                                 stickIndex == LEFT_STICK ? 1 : 3, -1),
+        std::make_shared<SDLAxisDirectionToAxisDirectionMapping>(shipDeviceIndex, portIndex, stickIndex, DOWN,
+                                                                 stickIndex == LEFT_STICK ? 1 : 3, 1)
     };
 
     return mappings;
 }
 
 std::shared_ptr<ControllerAxisDirectionMapping>
-AxisDirectionMappingFactory::CreateAxisDirectionMappingFromSDLInput(uint8_t portIndex, Stick stick,
+AxisDirectionMappingFactory::CreateAxisDirectionMappingFromSDLInput(uint8_t portIndex, StickIndex stickIndex,
                                                                     Direction direction) {
     std::unordered_map<ShipDeviceIndex, SDL_GameController*> sdlControllers;
     std::shared_ptr<ControllerAxisDirectionMapping> mapping = nullptr;
@@ -142,8 +146,8 @@ AxisDirectionMappingFactory::CreateAxisDirectionMappingFromSDLInput(uint8_t port
     for (auto [lusIndex, controller] : sdlControllers) {
         for (int32_t button = SDL_CONTROLLER_BUTTON_A; button < SDL_CONTROLLER_BUTTON_MAX; button++) {
             if (SDL_GameControllerGetButton(controller, static_cast<SDL_GameControllerButton>(button))) {
-                mapping =
-                    std::make_shared<SDLButtonToAxisDirectionMapping>(lusIndex, portIndex, stick, direction, button);
+                mapping = std::make_shared<SDLButtonToAxisDirectionMapping>(lusIndex, portIndex, stickIndex, direction,
+                                                                            button);
                 break;
             }
         }
@@ -166,8 +170,8 @@ AxisDirectionMappingFactory::CreateAxisDirectionMappingFromSDLInput(uint8_t port
                 continue;
             }
 
-            mapping = std::make_shared<SDLAxisDirectionToAxisDirectionMapping>(lusIndex, portIndex, stick, direction,
-                                                                               axis, axisDirection);
+            mapping = std::make_shared<SDLAxisDirectionToAxisDirectionMapping>(lusIndex, portIndex, stickIndex,
+                                                                               direction, axis, axisDirection);
             break;
         }
     }

--- a/src/controller/controldevice/controller/mapping/factories/AxisDirectionMappingFactory.h
+++ b/src/controller/controldevice/controller/mapping/factories/AxisDirectionMappingFactory.h
@@ -9,15 +9,15 @@ namespace Ship {
 class AxisDirectionMappingFactory {
   public:
     static std::shared_ptr<ControllerAxisDirectionMapping>
-    CreateAxisDirectionMappingFromConfig(uint8_t portIndex, Stick stick, std::string id);
+    CreateAxisDirectionMappingFromConfig(uint8_t portIndex, StickIndex stickIndex, std::string id);
 
     static std::vector<std::shared_ptr<ControllerAxisDirectionMapping>>
-    CreateDefaultKeyboardAxisDirectionMappings(uint8_t portIndex, Stick stick);
+    CreateDefaultKeyboardAxisDirectionMappings(uint8_t portIndex, StickIndex stickIndex);
 
     static std::vector<std::shared_ptr<ControllerAxisDirectionMapping>>
-    CreateDefaultSDLAxisDirectionMappings(ShipDeviceIndex shipDeviceIndex, uint8_t portIndex, Stick stick);
+    CreateDefaultSDLAxisDirectionMappings(ShipDeviceIndex shipDeviceIndex, uint8_t portIndex, StickIndex stickIndex);
 
     static std::shared_ptr<ControllerAxisDirectionMapping>
-    CreateAxisDirectionMappingFromSDLInput(uint8_t portIndex, Stick stick, Direction direction);
+    CreateAxisDirectionMappingFromSDLInput(uint8_t portIndex, StickIndex stickIndex, Direction direction);
 };
 } // namespace Ship

--- a/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAxisDirectionMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAxisDirectionMapping.cpp
@@ -6,10 +6,10 @@
 #include "Context.h"
 
 namespace Ship {
-KeyboardKeyToAxisDirectionMapping::KeyboardKeyToAxisDirectionMapping(uint8_t portIndex, Stick stick,
+KeyboardKeyToAxisDirectionMapping::KeyboardKeyToAxisDirectionMapping(uint8_t portIndex, StickIndex stickIndex,
                                                                      Direction direction, KbScancode scancode)
     : ControllerInputMapping(ShipDeviceIndex::Keyboard), KeyboardKeyToAnyMapping(scancode),
-      ControllerAxisDirectionMapping(ShipDeviceIndex::Keyboard, portIndex, stick, direction) {
+      ControllerAxisDirectionMapping(ShipDeviceIndex::Keyboard, portIndex, stickIndex, direction) {
 }
 
 float KeyboardKeyToAxisDirectionMapping::GetNormalizedAxisDirectionValue() {
@@ -21,14 +21,14 @@ float KeyboardKeyToAxisDirectionMapping::GetNormalizedAxisDirectionValue() {
 }
 
 std::string KeyboardKeyToAxisDirectionMapping::GetAxisDirectionMappingId() {
-    return StringHelper::Sprintf("P%d-S%d-D%d-KB%d", mPortIndex, mStick, mDirection, mKeyboardScancode);
+    return StringHelper::Sprintf("P%d-S%d-D%d-KB%d", mPortIndex, mStickIndex, mDirection, mKeyboardScancode);
 }
 
 void KeyboardKeyToAxisDirectionMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
     CVarSetString(StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str(),
                   "KeyboardKeyToAxisDirectionMapping");
-    CVarSetInteger(StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str(), mStick);
+    CVarSetInteger(StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str(), mStickIndex);
     CVarSetInteger(StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), mDirection);
     CVarSetInteger(StringHelper::Sprintf("%s.KeyboardScancode", mappingCvarKey.c_str()).c_str(), mKeyboardScancode);
     CVarSave();

--- a/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAxisDirectionMapping.h
+++ b/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAxisDirectionMapping.h
@@ -4,7 +4,8 @@
 namespace Ship {
 class KeyboardKeyToAxisDirectionMapping final : public KeyboardKeyToAnyMapping, public ControllerAxisDirectionMapping {
   public:
-    KeyboardKeyToAxisDirectionMapping(uint8_t portIndex, Stick stick, Direction direction, KbScancode scancode);
+    KeyboardKeyToAxisDirectionMapping(uint8_t portIndex, StickIndex stickIndex, Direction direction,
+                                      KbScancode scancode);
     float GetNormalizedAxisDirectionValue() override;
     std::string GetAxisDirectionMappingId() override;
     uint8_t GetMappingType() override;

--- a/src/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAxisDirectionMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAxisDirectionMapping.cpp
@@ -9,12 +9,12 @@
 
 namespace Ship {
 SDLAxisDirectionToAxisDirectionMapping::SDLAxisDirectionToAxisDirectionMapping(ShipDeviceIndex shipDeviceIndex,
-                                                                               uint8_t portIndex, Stick stick,
+                                                                               uint8_t portIndex, StickIndex stickIndex,
                                                                                Direction direction,
                                                                                int32_t sdlControllerAxis,
                                                                                int32_t axisDirection)
     : ControllerInputMapping(shipDeviceIndex),
-      ControllerAxisDirectionMapping(shipDeviceIndex, portIndex, stick, direction),
+      ControllerAxisDirectionMapping(shipDeviceIndex, portIndex, stickIndex, direction),
       SDLAxisDirectionToAnyMapping(shipDeviceIndex, sdlControllerAxis, axisDirection) {
 }
 
@@ -39,7 +39,7 @@ float SDLAxisDirectionToAxisDirectionMapping::GetNormalizedAxisDirectionValue() 
 }
 
 std::string SDLAxisDirectionToAxisDirectionMapping::GetAxisDirectionMappingId() {
-    return StringHelper::Sprintf("P%d-S%d-D%d-LUSI%d-SDLA%d-AD%s", mPortIndex, mStick, mDirection,
+    return StringHelper::Sprintf("P%d-S%d-D%d-LUSI%d-SDLA%d-AD%s", mPortIndex, mStickIndex, mDirection,
                                  ControllerInputMapping::mShipDeviceIndex, mControllerAxis,
                                  mAxisDirection == 1 ? "P" : "N");
 }
@@ -48,7 +48,7 @@ void SDLAxisDirectionToAxisDirectionMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
     CVarSetString(StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str(),
                   "SDLAxisDirectionToAxisDirectionMapping");
-    CVarSetInteger(StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str(), mStick);
+    CVarSetInteger(StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str(), mStickIndex);
     CVarSetInteger(StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), mDirection);
     CVarSetInteger(StringHelper::Sprintf("%s.ShipDeviceIndex", mappingCvarKey.c_str()).c_str(),
                    ControllerInputMapping::mShipDeviceIndex);

--- a/src/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAxisDirectionMapping.h
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAxisDirectionMapping.h
@@ -5,7 +5,7 @@ namespace Ship {
 class SDLAxisDirectionToAxisDirectionMapping final : public ControllerAxisDirectionMapping,
                                                      public SDLAxisDirectionToAnyMapping {
   public:
-    SDLAxisDirectionToAxisDirectionMapping(ShipDeviceIndex shipDeviceIndex, uint8_t portIndex, Stick stick,
+    SDLAxisDirectionToAxisDirectionMapping(ShipDeviceIndex shipDeviceIndex, uint8_t portIndex, StickIndex stickIndex,
                                            Direction direction, int32_t sdlControllerAxis, int32_t axisDirection);
     float GetNormalizedAxisDirectionValue() override;
     std::string GetAxisDirectionMappingId() override;

--- a/src/controller/controldevice/controller/mapping/sdl/SDLButtonToAxisDirectionMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLButtonToAxisDirectionMapping.cpp
@@ -9,10 +9,10 @@
 
 namespace Ship {
 SDLButtonToAxisDirectionMapping::SDLButtonToAxisDirectionMapping(ShipDeviceIndex shipDeviceIndex, uint8_t portIndex,
-                                                                 Stick stick, Direction direction,
+                                                                 StickIndex stickIndex, Direction direction,
                                                                  int32_t sdlControllerButton)
     : ControllerInputMapping(shipDeviceIndex),
-      ControllerAxisDirectionMapping(shipDeviceIndex, portIndex, stick, direction),
+      ControllerAxisDirectionMapping(shipDeviceIndex, portIndex, stickIndex, direction),
       SDLButtonToAnyMapping(shipDeviceIndex, sdlControllerButton) {
 }
 
@@ -26,7 +26,7 @@ float SDLButtonToAxisDirectionMapping::GetNormalizedAxisDirectionValue() {
 }
 
 std::string SDLButtonToAxisDirectionMapping::GetAxisDirectionMappingId() {
-    return StringHelper::Sprintf("P%d-S%d-D%d-LUSI%d-SDLB%d", mPortIndex, mStick, mDirection,
+    return StringHelper::Sprintf("P%d-S%d-D%d-LUSI%d-SDLB%d", mPortIndex, mStickIndex, mDirection,
                                  ControllerInputMapping::mShipDeviceIndex, mControllerButton);
 }
 
@@ -34,7 +34,7 @@ void SDLButtonToAxisDirectionMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
     CVarSetString(StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str(),
                   "SDLButtonToAxisDirectionMapping");
-    CVarSetInteger(StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str(), mStick);
+    CVarSetInteger(StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str(), mStickIndex);
     CVarSetInteger(StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), mDirection);
     CVarSetInteger(StringHelper::Sprintf("%s.ShipDeviceIndex", mappingCvarKey.c_str()).c_str(),
                    ControllerInputMapping::mShipDeviceIndex);

--- a/src/controller/controldevice/controller/mapping/sdl/SDLButtonToAxisDirectionMapping.h
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLButtonToAxisDirectionMapping.h
@@ -4,7 +4,7 @@
 namespace Ship {
 class SDLButtonToAxisDirectionMapping final : public ControllerAxisDirectionMapping, public SDLButtonToAnyMapping {
   public:
-    SDLButtonToAxisDirectionMapping(ShipDeviceIndex shipDeviceIndex, uint8_t portIndex, Stick stick,
+    SDLButtonToAxisDirectionMapping(ShipDeviceIndex shipDeviceIndex, uint8_t portIndex, StickIndex stickIndex,
                                     Direction direction, int32_t sdlControllerButton);
     float GetNormalizedAxisDirectionValue() override;
     std::string GetAxisDirectionMappingId() override;

--- a/src/window/gui/InputEditorWindow.cpp
+++ b/src/window/gui/InputEditorWindow.cpp
@@ -1225,7 +1225,7 @@ void InputEditorWindow::DrawButtonDeviceIcons(uint8_t portIndex, std::set<CONTRO
     }
 }
 
-void InputEditorWindow::DrawAnalogStickDeviceIcons(uint8_t portIndex, Stick stick) {
+void InputEditorWindow::DrawAnalogStickDeviceIcons(uint8_t portIndex, StickIndex stickIndex) {
     std::set<ShipDeviceIndex> allLusDeviceIndices;
     allLusDeviceIndices.insert(ShipDeviceIndex::Keyboard);
     for (auto [lusIndex, mapping] : Context::GetInstance()
@@ -1238,7 +1238,7 @@ void InputEditorWindow::DrawAnalogStickDeviceIcons(uint8_t portIndex, Stick stic
     std::vector<std::pair<ShipDeviceIndex, bool>> lusDeviceIndiciesWithMappings;
     for (auto lusIndex : allLusDeviceIndices) {
         auto controllerStick =
-            stick == Stick::LEFT_STICK
+            stickIndex == StickIndex::LEFT_STICK
                 ? Context::GetInstance()->GetControlDeck()->GetControllerByPort(portIndex)->GetLeftStick()
                 : Context::GetInstance()->GetControlDeck()->GetControllerByPort(portIndex)->GetRightStick();
         if (controllerStick->HasMappingsForShipDeviceIndex(lusIndex)) {

--- a/src/window/gui/InputEditorWindow.h
+++ b/src/window/gui/InputEditorWindow.h
@@ -71,7 +71,7 @@ class InputEditorWindow : public GuiWindow {
     std::set<CONTROLLERBUTTONS_T> mButtonsBitmasks;
     std::set<CONTROLLERBUTTONS_T> mDpadBitmasks;
     void DrawButtonDeviceIcons(uint8_t portIndex, std::set<CONTROLLERBUTTONS_T> bitmasks);
-    void DrawAnalogStickDeviceIcons(uint8_t portIndex, Stick stick);
+    void DrawAnalogStickDeviceIcons(uint8_t portIndex, StickIndex stickIndex);
     void DrawRumbleDeviceIcons(uint8_t portIndex);
     void DrawGyroDeviceIcons(uint8_t portIndex);
     void DrawLEDDeviceIcons(uint8_t portIndex);


### PR DESCRIPTION
based on a conversation about https://github.com/Kenix3/libultraship/pull/750 in DMs where I said

> i think the actual move is to rename the `Stick` enum (the one that has `LEFT_STICK`) to `StickIndex` and then have the method change from `Stick LeftOrRightStick();` to `StickIndex GetIndex()`

and @Kenix3 said

> I'm good with that.

I ended up naming it `GetStickIndex()` instead of `GetIndex()`

soh testing PR: https://github.com/HarbourMasters/Shipwright/pull/4683