### PR TITLE
Fix depth not being cleared on secondary framebuffers

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -4304,6 +4304,7 @@ extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height, uint32_t 
 
 void gfx_set_framebuffer(int fb, float noise_scale) {
     gfx_rapi->start_draw_to_framebuffer(fb, noise_scale);
+    gfx_rapi->clear_framebuffer(false, true);
 }
 
 void gfx_copy_framebuffer(int fb_dst_id, int fb_src_id, bool copyOnce, bool* hasCopiedPtr) {


### PR DESCRIPTION
I accidentally removed this framebuffer clear call when switching to a secondary framebufer in #732. The previous behavior was that the depth was cleared, so this restores that behavior.

Fixes https://github.com/HarbourMasters/Shipwright/issues/4696