### PR TITLE
UnloadResourceAsync

### DIFF
--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -346,12 +346,12 @@ void ResourceManager::DirtyResources(const std::string& searchMask) {
     DirtyResources({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive });
 }
 
-void ResourceManager::UnloadResourcesAsync(const std::string& searchMask) {
-    UnloadResourcesAsync({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive });
+void ResourceManager::UnloadResourcesAsync(const std::string& searchMask, BS::priority_t priority) {
+    UnloadResourcesAsync({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive }, priority);
 }
 
-void ResourceManager::UnloadResourcesAsync(const ResourceFilter& filter) {
-    mThreadPool->submit_task([this, filter]() -> void { UnloadResourcesProcess(filter); });
+void ResourceManager::UnloadResourcesAsync(const ResourceFilter& filter, BS::priority_t priority) {
+    mThreadPool->submit_task([this, filter]() -> void { UnloadResourcesProcess(filter); }, priority);
 }
 
 void ResourceManager::UnloadResources(const std::string& searchMask) {

--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -351,9 +351,7 @@ void ResourceManager::UnloadResourcesAsync(const std::string& searchMask) {
 }
 
 void ResourceManager::UnloadResourcesAsync(const ResourceFilter& filter) {
-    mThreadPool->submit_task([this, filter]() -> void {
-        UnloadResourcesProcess(filter);
-    });
+    mThreadPool->submit_task([this, filter]() -> void { UnloadResourcesProcess(filter); });
 }
 
 void ResourceManager::UnloadResources(const std::string& searchMask) {

--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -342,22 +342,34 @@ void ResourceManager::DirtyResources(const ResourceFilter& filter) {
     });
 }
 
-void ResourceManager::UnloadResources(const ResourceFilter& filter) {
-    mThreadPool->submit_task([this, filter]() -> void {
-        auto list = GetArchiveManager()->ListFiles(filter.IncludeMasks, filter.ExcludeMasks);
-
-        for (const auto& key : *list.get()) {
-            UnloadResource({ key, mDefaultCacheOwner, mDefaultCacheArchive });
-        }
-    });
-}
-
 void ResourceManager::DirtyResources(const std::string& searchMask) {
     DirtyResources({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive });
 }
 
+void ResourceManager::UnloadResourcesAsync(const std::string& searchMask) {
+    UnloadResourcesAsync({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive });
+}
+
+void ResourceManager::UnloadResourcesAsync(const ResourceFilter& filter) {
+    mThreadPool->submit_task([this, filter]() -> void {
+        UnloadResourcesProcess(filter);
+    });
+}
+
 void ResourceManager::UnloadResources(const std::string& searchMask) {
     UnloadResources({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive });
+}
+
+void ResourceManager::UnloadResources(const ResourceFilter& filter) {
+    UnloadResourcesProcess(filter);
+}
+
+void ResourceManager::UnloadResourcesProcess(const ResourceFilter& filter) {
+    auto list = GetArchiveManager()->ListFiles(filter.IncludeMasks, filter.ExcludeMasks);
+
+    for (const auto& key : *list.get()) {
+        UnloadResource({ key, mDefaultCacheOwner, mDefaultCacheArchive });
+    }
 }
 
 std::shared_ptr<ArchiveManager> ResourceManager::GetArchiveManager() {

--- a/src/resource/ResourceManager.h
+++ b/src/resource/ResourceManager.h
@@ -95,8 +95,8 @@ class ResourceManager {
     void DirtyResources(const ResourceFilter& filter);
     void UnloadResources(const std::string& searchMask);
     void UnloadResources(const ResourceFilter& filter);
-    void UnloadResourcesAsync(const std::string& searchMask);
-    void UnloadResourcesAsync(const ResourceFilter& filter);
+    void UnloadResourcesAsync(const std::string& searchMask, BS::priority_t priority = BS::pr::normal);
+    void UnloadResourcesAsync(const ResourceFilter& filter, BS::priority_t priority = BS::pr::normal);
 
     bool OtrSignatureCheck(const char* fileName);
     bool IsAltAssetsEnabled();

--- a/src/resource/ResourceManager.h
+++ b/src/resource/ResourceManager.h
@@ -95,6 +95,8 @@ class ResourceManager {
     void DirtyResources(const ResourceFilter& filter);
     void UnloadResources(const std::string& searchMask);
     void UnloadResources(const ResourceFilter& filter);
+    void UnloadResourcesAsync(const std::string& searchMask);
+    void UnloadResourcesAsync(const ResourceFilter& filter);
 
     bool OtrSignatureCheck(const char* fileName);
     bool IsAltAssetsEnabled();
@@ -102,6 +104,7 @@ class ResourceManager {
 
   protected:
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResourcesProcess(const ResourceFilter& filter);
+    void UnloadResourcesProcess(const ResourceFilter& filter);
     std::variant<ResourceLoadError, std::shared_ptr<IResource>> CheckCache(const ResourceIdentifier& identifier,
                                                                            bool loadExact = false);
     std::shared_ptr<File> LoadFileProcess(const ResourceIdentifier& identifier,


### PR DESCRIPTION
Add `UnloadResourcesAsync` to handle threading the unload function.
Make `UnloadResources` non-threaded.
Add common `UnloadResourcesProcess` to handle the actual unloading.

Finally fully closes #752