### PR TITLE
Fix buffered mapping of previous inputs

### DIFF
--- a/src/controller/controldevice/controller/ControllerButton.cpp
+++ b/src/controller/controldevice/controller/ControllerButton.cpp
@@ -207,8 +207,12 @@ bool ControllerButton::AddOrEditButtonMappingFromRawPress(CONTROLLERBUTTONS_T bi
 
 bool ControllerButton::ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode) {
     if (mUseKeydownEventToCreateNewMapping && eventType == LUS_KB_EVENT_KEY_DOWN) {
-        mKeyboardScancodeForNewMapping = scancode;
-        return true;
+        if (eventType == LUS_KB_EVENT_KEY_DOWN) {
+            mKeyboardScancodeForNewMapping = scancode;
+            return true;
+        } else {
+            mKeyboardScancodeForNewMapping = LUS_KB_UNKNOWN;
+        }
     }
 
     bool result = false;

--- a/src/controller/controldevice/controller/ControllerStick.cpp
+++ b/src/controller/controldevice/controller/ControllerStick.cpp
@@ -319,9 +319,13 @@ void ControllerStick::UpdatePad(int8_t& x, int8_t& y) {
 }
 
 bool ControllerStick::ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode) {
-    if (mUseKeydownEventToCreateNewMapping && eventType == LUS_KB_EVENT_KEY_DOWN) {
-        mKeyboardScancodeForNewMapping = scancode;
-        return true;
+    if (mUseKeydownEventToCreateNewMapping) {
+        if (eventType == LUS_KB_EVENT_KEY_DOWN) {
+            mKeyboardScancodeForNewMapping = scancode;
+            return true;
+        } else {
+            mKeyboardScancodeForNewMapping = LUS_KB_UNKNOWN;
+        }
     }
 
     bool result = false;


### PR DESCRIPTION
Issue: Previously pressed key binds after clicking on binding button, if previous binding interrupted.
Steps to reproduce:
1. Press add new mapping button;
2. Reopen menu via `Esc`;
3. Press new mapping button again

https://github.com/user-attachments/assets/1c727c5b-674f-41a3-b82b-520f16c48cad

