### PR TITLE
imgui 1.90.6 -> 1.91.6

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -16,7 +16,7 @@ set(sdl_apply_patch_if_needed git apply ${sdl_gamepad_patch_file} ${git_hide_out
 FetchContent_Declare(
     ImGui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
-    GIT_TAG v1.90.6-docking
+    GIT_TAG v1.91.6-docking
     PATCH_COMMAND ${sdl_apply_patch_if_needed}
 )
 FetchContent_MakeAvailable(ImGui)

--- a/src/window/gui/ConsoleWindow.cpp
+++ b/src/window/gui/ConsoleWindow.cpp
@@ -387,12 +387,12 @@ void ConsoleWindow::DrawElement() {
     ImGui::PushStyleColor(ImGuiCol_FrameBgActive, ImVec4(.3f, .3f, .3f, 1.0f));
     if (ImGui::BeginTable("History", 1)) {
 
-        if (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_DownArrow))) {
+        if (ImGui::IsKeyPressed(ImGuiKey_DownArrow)) {
             if (mSelectedId < (int32_t)mLog.size() - 1) {
                 ++mSelectedId;
             }
         }
-        if (ImGui::IsKeyPressed(ImGui::GetKeyIndex(ImGuiKey_UpArrow))) {
+        if (ImGui::IsKeyPressed(ImGuiKey_UpArrow)) {
             if (mSelectedId > 0) {
                 --mSelectedId;
             }
@@ -415,7 +415,7 @@ void ConsoleWindow::DrawElement() {
                 std::find(mSelectedEntries.begin(), mSelectedEntries.end(), i) != mSelectedEntries.end();
             ImGui::PushStyleColor(ImGuiCol_Text, mPriorityColours[line.Priority]);
             if (ImGui::Selectable(id.c_str(), isSelected)) {
-                if (ImGui::IsKeyDown(ImGui::GetKeyIndex(ImGuiKey_LeftCtrl)) && !isSelected) {
+                if (ImGui::IsKeyDown(ImGuiKey_LeftCtrl) && !isSelected) {
                     mSelectedEntries.push_back(i);
 
                 } else {

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -626,7 +626,7 @@ void Gui::DrawGame() {
     }
     if (gfxFramebuffer) {
         ImGui::SetCursorPos(pos);
-        ImGui::Image(reinterpret_cast<ImTextureID>(gfxFramebuffer), size);
+        ImGui::Image((ImTextureID)gfxFramebuffer, size);
     }
 
     ImGui::End();
@@ -706,7 +706,7 @@ ImTextureID Gui::GetTextureById(int32_t id) {
     }
 #endif
 
-    return reinterpret_cast<ImTextureID>(id);
+    return (ImTextureID)id;
 }
 
 bool Gui::HasTextureByName(const std::string& name) {
@@ -715,7 +715,7 @@ bool Gui::HasTextureByName(const std::string& name) {
 
 ImTextureID Gui::GetTextureByName(const std::string& name) {
     if (!Gui::HasTextureByName(name)) {
-        return nullptr;
+        return (ImTextureID)nullptr;
     }
     return GetTextureById(mGuiTextures[name].RendererTextureId);
 }


### PR DESCRIPTION
## relevant breaking changes (to get soh to build again)

* ImGuiKey
  * https://github.com/ocornut/imgui/blob/fd932297703c6da24b953f0be8e0733e0db4d9cf/imgui.h#L968
  *  `// - (legacy: before v1.87, we used ImGuiKey to carry native/user indices as defined by each backends. This was obsoleted in 1.87 (2022-02) and completely removed in 1.91.5 (2024-11). See https://github.com/ocornut/imgui/issues/4921`

* The typedef for `ImTextureID` now defaults to `ImU64` instead of `void*`.
  * https://github.com/ocornut/imgui/commit/92b94980c69ff3d3d7f5dc30c1c19abfb72db47e
  * https://github.com/ocornut/imgui/issues/1641

* (BREAKING) Commented out obsolete ImageButton().
  * https://github.com/ocornut/imgui/commit/5de7f69cbb9d52dc2cebb27261dfadcf0da3840d

* Internals: rename ImGuiLastItemData::InFlags -> ItemFlags. ImGuiNextItemData::Flags -> HasFlags to avoid mistakes.
  * https://github.com/ocornut/imgui/commit/e6b5cafe65fd983eb87bf2fd4d7f68e544911fcd

* Internals: removing ImGuiButtonFlags_Repeat (in favor of ImGuiItemFlags_ButtonRepeat), ImGuiButtonFlags_DontClosePopups (unused)
  * https://github.com/ocornut/imgui/commit/97da66209cffd84a6959bced872da06a91213402

## soh testing pr

* https://github.com/HarbourMasters/Shipwright/pull/4738