### PR TITLE
set `SDL_HINT_JOYSTICK_WGI` to `0` to address some controller duping issues 

### DIFF
--- a/src/controller/deviceindex/ShipDeviceIndexMappingManager.cpp
+++ b/src/controller/deviceindex/ShipDeviceIndexMappingManager.cpp
@@ -13,7 +13,9 @@
 
 namespace Ship {
 ShipDeviceIndexMappingManager::ShipDeviceIndexMappingManager() : mIsInitialized(false) {
+#if _WIN32
     SDL_SetHintWithPriority(SDL_HINT_JOYSTICK_WGI, "0", SDL_HINT_DEFAULT);
+#endif
     UpdateControllerNamesFromConfig();
 }
 

--- a/src/controller/deviceindex/ShipDeviceIndexMappingManager.cpp
+++ b/src/controller/deviceindex/ShipDeviceIndexMappingManager.cpp
@@ -13,6 +13,7 @@
 
 namespace Ship {
 ShipDeviceIndexMappingManager::ShipDeviceIndexMappingManager() : mIsInitialized(false) {
+    SDL_SetHintWithPriority(SDL_HINT_JOYSTICK_WGI, "0", SDL_HINT_DEFAULT);
     UpdateControllerNamesFromConfig();
 }
 


### PR DESCRIPTION
did some digging into duping issues and found https://github.com/libsdl-org/SDL/issues/7948

was able to reproduce wired xbox controller duping on latest soh dev

wasn't able to reproduce wired xbox controller duping with this change

soh testing pr: https://github.com/HarbourMasters/Shipwright/pull/4805