### PR TITLE
Move Window and Gui calls to port game loop

### DIFF
--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -154,6 +154,10 @@ void Fast3dWindow::StartFrame() {
 void Fast3dWindow::EndFrame() {
 }
 
+bool Fast3dWindow::IsFrameReady() {
+    return mWindowManagerApi->is_frame_ready();
+}
+
 void Fast3dWindow::SetCursorVisibility(bool visible) {
     mWindowManagerApi->set_cursor_visibility(visible);
 }

--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -159,6 +159,29 @@ bool Fast3dWindow::IsFrameReady() {
     return mWindowManagerApi->is_frame_ready();
 }
 
+bool Fast3dWindow::DrawAndRunGraphicsCommands(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtxReplacements) {
+    std::shared_ptr<Window> wnd = Ship::Context::GetInstance()->GetWindow();
+
+    // Skip dropped frames
+    if (!wnd->IsFrameReady()) {
+        return false;
+    }
+
+    auto gui = wnd->GetGui();
+    // Setup of the backend frames and draw initial Window and GUI menus
+    gui->StartDraw();
+    // Setup game framebuffers to match available window space
+    gfx_start_frame();
+    // Execute the games gfx commands
+    gfx_run(commands, mtxReplacements);
+    // Renders the game frame buffer to the final window and finishes the GUI
+    gui->EndDraw();
+    // Finalize swap buffers
+    gfx_end_frame();
+
+    return true;
+}
+
 void Fast3dWindow::HandleEvents() {
     mWindowManagerApi->handle_events();
 }

--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -152,6 +152,7 @@ void Fast3dWindow::StartFrame() {
 }
 
 void Fast3dWindow::EndFrame() {
+    gfx_end_frame();
 }
 
 bool Fast3dWindow::IsFrameReady() {

--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -159,6 +159,10 @@ bool Fast3dWindow::IsFrameReady() {
     return mWindowManagerApi->is_frame_ready();
 }
 
+void Fast3dWindow::HandleEvents() {
+    mWindowManagerApi->handle_events();
+}
+
 void Fast3dWindow::SetCursorVisibility(bool visible) {
     mWindowManagerApi->set_cursor_visibility(visible);
 }

--- a/src/graphic/Fast3D/Fast3dWindow.h
+++ b/src/graphic/Fast3D/Fast3dWindow.h
@@ -5,6 +5,8 @@
 #include "public/bridge/gfxbridge.h"
 #include "controller/controldevice/controller/mapping/keyboard/KeyboardScancodes.h"
 
+union Gfx;
+
 namespace Fast {
 class Fast3dWindow : public Ship::Window {
   public:
@@ -48,6 +50,7 @@ class Fast3dWindow : public Ship::Window {
     void SetTextureFilter(FilteringMode filteringMode);
     void SetRendererUCode(UcodeHandlers ucode);
     void EnableSRGBMode();
+    bool DrawAndRunGraphicsCommands(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtxReplacements);
 
   protected:
     static bool KeyDown(int32_t scancode);

--- a/src/graphic/Fast3D/Fast3dWindow.h
+++ b/src/graphic/Fast3D/Fast3dWindow.h
@@ -16,6 +16,7 @@ class Fast3dWindow : public Ship::Window {
     void Close() override;
     void StartFrame() override;
     void EndFrame() override;
+    bool IsFrameReady() override;
     void SetCursorVisibility(bool visible) override;
     uint32_t GetWidth() override;
     uint32_t GetHeight() override;

--- a/src/graphic/Fast3D/Fast3dWindow.h
+++ b/src/graphic/Fast3D/Fast3dWindow.h
@@ -17,6 +17,7 @@ class Fast3dWindow : public Ship::Window {
     void StartFrame() override;
     void EndFrame() override;
     bool IsFrameReady() override;
+    void HandleEvents() override;
     void SetCursorVisibility(bool visible) override;
     uint32_t GetWidth() override;
     uint32_t GetHeight() override;

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -664,7 +664,7 @@ static uint64_t qpc_to_100ns(uint64_t qpc) {
            qpc % dxgi.qpc_freq * _100NANOSECONDS_IN_SECOND / dxgi.qpc_freq;
 }
 
-static bool gfx_dxgi_start_frame() {
+static bool gfx_dxgi_is_frame_ready() {
     DXGI_FRAME_STATISTICS stats;
     if (dxgi.swap_chain->GetFrameStatistics(&stats) == S_OK &&
         (stats.SyncRefreshCount != 0 || stats.SyncQPCTime.QuadPart != 0ULL)) {
@@ -1058,7 +1058,7 @@ extern "C" struct GfxWindowManagerAPI gfx_dxgi_api = { gfx_dxgi_init,
                                                        gfx_dxgi_is_mouse_captured,
                                                        gfx_dxgi_get_dimensions,
                                                        gfx_dxgi_handle_events,
-                                                       gfx_dxgi_start_frame,
+                                                       gfx_dxgi_is_frame_ready,
                                                        gfx_dxgi_swap_buffers_begin,
                                                        gfx_dxgi_swap_buffers_end,
                                                        gfx_dxgi_get_time,

--- a/src/graphic/Fast3D/gfx_metal.cpp
+++ b/src/graphic/Fast3D/gfx_metal.cpp
@@ -234,13 +234,11 @@ bool Metal_Init(SDL_Renderer* renderer) {
 
 static void gfx_metal_setup_screen_framebuffer(uint32_t width, uint32_t height);
 
-void Metal_SetupFrame(SDL_Renderer* renderer) {
+void Metal_NewFrame(SDL_Renderer* renderer) {
     int width, height;
     SDL_GetRendererOutputSize(renderer, &width, &height);
     gfx_metal_setup_screen_framebuffer(width, height);
-}
 
-void Metal_NewFrame(SDL_Renderer* renderer) {
     MTL::RenderPassDescriptor* current_render_pass = mctx.framebuffers[0].render_pass_descriptor;
     ImGui_ImplMetal_NewFrame(current_render_pass);
 }

--- a/src/graphic/Fast3D/gfx_metal.h
+++ b/src/graphic/Fast3D/gfx_metal.h
@@ -20,7 +20,6 @@ ImTextureID gfx_metal_get_texture_by_id(int id);
 bool Metal_IsSupported();
 
 bool Metal_Init(SDL_Renderer* renderer);
-void Metal_SetupFrame(SDL_Renderer* renderer);
 void Metal_NewFrame(SDL_Renderer* renderer);
 void Metal_SetupFloatingFrame();
 void Metal_RenderDrawData(ImDrawData* draw_data);

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -4184,8 +4184,6 @@ void gfx_start_frame() {
 GfxExecStack g_exec_stack = {};
 
 void gfx_run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_replacements) {
-    Ship::Context::GetInstance()->GetWindow()->GetGui()->SetupRendererFrame();
-
     gfx_sp_reset();
 
     get_pixel_depth_pending.clear();
@@ -4193,7 +4191,7 @@ void gfx_run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_replacemen
 
     if (!gfx_wapi->start_frame()) {
         dropped_frame = true;
-        Ship::Context::GetInstance()->GetWindow()->GetGui()->Draw();
+        // Ship::Context::GetInstance()->GetWindow()->GetGui()->Draw();
         return;
     }
     dropped_frame = false;
@@ -4261,13 +4259,15 @@ void gfx_run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_replacemen
 
         assert(0 && "active framebuffer was never reset back to original");
     }
-    Ship::Context::GetInstance()->GetWindow()->GetGui()->Draw();
-    gfx_rapi->end_frame();
-    gfx_wapi->swap_buffers_begin();
+    // Ship::Context::GetInstance()->GetWindow()->GetGui()->Draw();
+    // gfx_rapi->end_frame();
+    // gfx_wapi->swap_buffers_begin();
 }
 
 void gfx_end_frame() {
     if (!dropped_frame) {
+        gfx_rapi->end_frame();
+        gfx_wapi->swap_buffers_begin();
         gfx_rapi->finish_render();
         gfx_wapi->swap_buffers_end();
     }

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -4123,6 +4123,10 @@ struct GfxRenderingAPI* gfx_get_current_rendering_api() {
     return gfx_rapi;
 }
 
+bool gfx_is_frame_ready() {
+    return gfx_wapi->is_frame_ready();
+}
+
 void gfx_start_frame() {
     gfx_wapi->handle_events();
     gfx_wapi->get_dimensions(&gfx_current_window_dimensions.width, &gfx_current_window_dimensions.height,
@@ -4189,11 +4193,11 @@ void gfx_run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_replacemen
     get_pixel_depth_pending.clear();
     get_pixel_depth_cached.clear();
 
-    if (!gfx_wapi->start_frame()) {
-        dropped_frame = true;
-        // Ship::Context::GetInstance()->GetWindow()->GetGui()->Draw();
-        return;
-    }
+    // if (!gfx_wapi->start_frame()) {
+    //     dropped_frame = true;
+    //     // Ship::Context::GetInstance()->GetWindow()->GetGui()->Draw();
+    //     return;
+    // }
     dropped_frame = false;
 
     current_mtx_replacements = &mtx_replacements;

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -4123,12 +4123,15 @@ struct GfxRenderingAPI* gfx_get_current_rendering_api() {
     return gfx_rapi;
 }
 
+void gfx_handle_window_events() {
+    gfx_wapi->handle_events();
+}
+
 bool gfx_is_frame_ready() {
     return gfx_wapi->is_frame_ready();
 }
 
 void gfx_start_frame() {
-    gfx_wapi->handle_events();
     gfx_wapi->get_dimensions(&gfx_current_window_dimensions.width, &gfx_current_window_dimensions.height,
                              &gfx_current_window_position_x, &gfx_current_window_position_y);
     if (gfx_current_dimensions.height == 0) {

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -113,8 +113,6 @@ static int game_framebuffer_msaa_resolved;
 
 uint32_t gfx_msaa_level = 1;
 
-static bool dropped_frame;
-
 static const std::unordered_map<Mtx*, MtxF>* current_mtx_replacements;
 
 static float buf_vbo[MAX_BUFFERED * (32 * 3)]; // 3 vertices in a triangle and 32 floats per vtx
@@ -4196,13 +4194,6 @@ void gfx_run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_replacemen
     get_pixel_depth_pending.clear();
     get_pixel_depth_cached.clear();
 
-    // if (!gfx_wapi->start_frame()) {
-    //     dropped_frame = true;
-    //     // Ship::Context::GetInstance()->GetWindow()->GetGui()->Draw();
-    //     return;
-    // }
-    dropped_frame = false;
-
     current_mtx_replacements = &mtx_replacements;
 
     gfx_rapi->update_framebuffer_parameters(0, gfx_current_window_dimensions.width,
@@ -4266,18 +4257,13 @@ void gfx_run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_replacemen
 
         assert(0 && "active framebuffer was never reset back to original");
     }
-    // Ship::Context::GetInstance()->GetWindow()->GetGui()->Draw();
-    // gfx_rapi->end_frame();
-    // gfx_wapi->swap_buffers_begin();
 }
 
 void gfx_end_frame() {
-    if (!dropped_frame) {
-        gfx_rapi->end_frame();
-        gfx_wapi->swap_buffers_begin();
-        gfx_rapi->finish_render();
-        gfx_wapi->swap_buffers_end();
-    }
+    gfx_rapi->end_frame();
+    gfx_wapi->swap_buffers_begin();
+    gfx_rapi->finish_render();
+    gfx_wapi->swap_buffers_end();
 }
 
 void gfx_set_target_ucode(UcodeHandlers ucode) {

--- a/src/graphic/Fast3D/gfx_pc.h
+++ b/src/graphic/Fast3D/gfx_pc.h
@@ -235,6 +235,7 @@ void gfx_start_frame();
 
 // Since this function is "exposted" to the games, it needs to take a normal Gfx
 void gfx_run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_replacements);
+void gfx_handle_window_events();
 bool gfx_is_frame_ready();
 void gfx_end_frame();
 void gfx_set_target_ucode(UcodeHandlers ucode);

--- a/src/graphic/Fast3D/gfx_pc.h
+++ b/src/graphic/Fast3D/gfx_pc.h
@@ -235,6 +235,7 @@ void gfx_start_frame();
 
 // Since this function is "exposted" to the games, it needs to take a normal Gfx
 void gfx_run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_replacements);
+bool gfx_is_frame_ready();
 void gfx_end_frame();
 void gfx_set_target_ucode(UcodeHandlers ucode);
 void gfx_set_target_fps(int);

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -600,7 +600,7 @@ static void gfx_sdl_handle_events() {
     }
 }
 
-static bool gfx_sdl_start_frame() {
+static bool gfx_sdl_is_frame_ready() {
     return true;
 }
 
@@ -709,7 +709,7 @@ struct GfxWindowManagerAPI gfx_sdl = { gfx_sdl_init,
                                        gfx_sdl_is_mouse_captured,
                                        gfx_sdl_get_dimensions,
                                        gfx_sdl_handle_events,
-                                       gfx_sdl_start_frame,
+                                       gfx_sdl_is_frame_ready,
                                        gfx_sdl_swap_buffers_begin,
                                        gfx_sdl_swap_buffers_end,
                                        gfx_sdl_get_time,

--- a/src/graphic/Fast3D/gfx_window_manager_api.h
+++ b/src/graphic/Fast3D/gfx_window_manager_api.h
@@ -24,7 +24,7 @@ struct GfxWindowManagerAPI {
     bool (*is_mouse_captured)();
     void (*get_dimensions)(uint32_t* width, uint32_t* height, int32_t* posX, int32_t* posY);
     void (*handle_events)();
-    bool (*start_frame)();
+    bool (*is_frame_ready)();
     void (*swap_buffers_begin)();
     void (*swap_buffers_end)();
     double (*get_time)(); // For debug

--- a/src/window/Window.h
+++ b/src/window/Window.h
@@ -36,6 +36,7 @@ class Window {
     virtual void Close() = 0;
     virtual void StartFrame() = 0;
     virtual void EndFrame() = 0;
+    virtual bool IsFrameReady() = 0;
     virtual void SetCursorVisibility(bool visible) = 0;
     virtual uint32_t GetWidth() = 0;
     virtual uint32_t GetHeight() = 0;

--- a/src/window/Window.h
+++ b/src/window/Window.h
@@ -37,6 +37,7 @@ class Window {
     virtual void StartFrame() = 0;
     virtual void EndFrame() = 0;
     virtual bool IsFrameReady() = 0;
+    virtual void HandleEvents() = 0;
     virtual void SetCursorVisibility(bool visible) = 0;
     virtual uint32_t GetWidth() = 0;
     virtual uint32_t GetHeight() = 0;

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -710,27 +710,12 @@ void Gui::CheckSaveCvars() {
     }
 }
 
-void Gui::Draw() {
-    // Initialize the frame.
-    StartFrame();
-    // Draw the gui menus
-    DrawMenu();
-    // Draw the game framebuffer into ImGui
-    DrawGame();
-    // End the frame
-    EndFrame();
-    // Draw the ImGui floating windows.
-    DrawFloatingWindows();
-    // Check if the CVars need to be saved, and do it if so.
-    CheckSaveCvars();
-}
-
 void Gui::StartDraw() {
     // Initialize the frame.
     StartFrame();
     // Draw the gui menus
     DrawMenu();
-
+    // Calculate the available space the game can render to
     CalculateGameViewport();
 }
 

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -73,8 +73,9 @@ class Gui {
 
     void Init(GuiWindowInitData windowImpl);
     void Draw();
+    void StartDraw();
+    void EndDraw();
     void HandleWindowEvents(WindowEvent event);
-    void SetupRendererFrame();
     void SaveConsoleVariablesNextFrame();
     bool SupportsViewports();
     ImGuiID GetMainGameWindowID();
@@ -112,6 +113,7 @@ class Gui {
     void DrawFloatingWindows();
     void DrawMenu();
     void DrawGame();
+    void CalculateGameViewport();
 
     void ImGuiBackendNewFrame();
     void ImGuiWMNewFrame();

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -72,7 +72,6 @@ class Gui {
     ~Gui();
 
     void Init(GuiWindowInitData windowImpl);
-    void Draw();
     void StartDraw();
     void EndDraw();
     void HandleWindowEvents(WindowEvent event);


### PR DESCRIPTION
After some of the previous GUI/Window refactors, certain actions where no longer happening in the order that they originally were, leading to some issues happening like:
* Game framebuffer calculation was a frame delayed and would use illegal values which caused garbage data to render in certain regions
* Dropped frames on DirectX was still rendering the whole ImGui flow which would stall and hang certain GPU drivers leading to a crash

To address this, I've pulled out some of the GUI/Window handling out of Fast3D itself (gfx_pc) and created public calls that ports can call instead in the correct order to resolved the issues listed above.

Dropped frame support is pulled out of `gfx_run()` into a dedicated method `Window::IsFrameReady()` which ports can now use to bail out of all rendering.

`Gui::Draw()` was split into two methods `Gui::StartDraw()` and `Gui::EndDraw()` so that `gfx_run()` can be called by ports in-between the Gui calls, ensuring that the initial window is drawn and the Fast3D knows how much space is left for the game to render to.

Removed a previously added temporary fix `Gui::SetupRendererFrame()` now that the Draw calls have been split up.

* Soh PR located here: https://github.com/HarbourMasters/Shipwright/pull/4833