### PR TITLE
fix linux build validation

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -96,8 +96,8 @@ jobs:
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release
         cmake --build build-cmake --config Release --parallel 10
       env:
-        CC: gcc-10
-        CXX: g++-10
+        CC: gcc-12
+        CXX: g++-12
     - name: Upload build
       uses: actions/upload-artifact@v4
       with:

--- a/README.md
+++ b/README.md
@@ -54,5 +54,3 @@ LUS makes use of the following third party libraries and resources:
 - [glew](https://github.com/nigels-com/glew) (modified BSD-3-Clause and MIT) OpenGL extension loading library.
 - [libzip](https://github.com/nih-at/) (BSD-3-Clause) read `.zip` compatible archives
 - [glob_match](https://github.com/torvalds/linux/blob/d1bd5fa07667fcc3e38996ec42aef98761f23039/lib/glob.c) (Dual MIT/GPL) Glob pattern matching.
-
-this is just a readme change, see how the linux build is failing?

--- a/README.md
+++ b/README.md
@@ -54,3 +54,5 @@ LUS makes use of the following third party libraries and resources:
 - [glew](https://github.com/nigels-com/glew) (modified BSD-3-Clause and MIT) OpenGL extension loading library.
 - [libzip](https://github.com/nih-at/) (BSD-3-Clause) read `.zip` compatible archives
 - [glob_match](https://github.com/torvalds/linux/blob/d1bd5fa07667fcc3e38996ec42aef98761f23039/lib/glob.c) (Dual MIT/GPL) Glob pattern matching.
+
+this is just a readme change, see how the linux build is failing?


### PR DESCRIPTION
as of writing, the `ubuntu-latest` gh runner image is now `ubuntu-24.04` https://github.com/actions/runner-images/blob/976232da217887825e7541c2635bf39cbbf22654/README.md?plain=1#L23

gh runners support the latest 3 versions of gcc https://github.com/actions/runner-images/blob/976232da217887825e7541c2635bf39cbbf22654/README.md?plain=1#L124

the latest available in `24.04` is `14`, meaning our options are `12`, `13`, and `14`

i bumped it to `12` - if we'd rather validate builds using `13` or `14` i'm happy to look into that