### PR TITLE
Edit reset hotkey to support Mac after ImGui 1.91

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -504,21 +504,13 @@ void Gui::DrawMenu() {
         }
     }
 
-#if __APPLE__
-    if ((ImGui::IsKeyDown(ImGuiKey_LeftSuper) || ImGui::IsKeyDown(ImGuiKey_RightSuper)) &&
-        ImGui::IsKeyPressed(ImGuiKey_R, false)) {
-        std::reinterpret_pointer_cast<ConsoleWindow>(
-            Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
-            ->Dispatch("reset");
-    }
-#else
+    // Mac interprets this as cmd+r when io.ConfigMacOSXBehavior is on (on by default)
     if ((ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) &&
         ImGui::IsKeyPressed(ImGuiKey_R, false)) {
         std::reinterpret_pointer_cast<ConsoleWindow>(
             Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
             ->Dispatch("reset");
     }
-#endif
 
     if (GetMenuBar()) {
         GetMenuBar()->Update();


### PR DESCRIPTION
ImGui 1.91 changed behavior of how Super and Ctrl work on MacOS by swapping the keys for various interactions. (e.g. cmd+r for reset), this means we can drop the ifdef for Mac regarding the alternate reset hotkey.