### PR TITLE
After patch update cache fix

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -14,7 +14,8 @@ set(imgui_fixes_and_config_patch_file ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependen
 # Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
 set(imgui_apply_patch_if_needed git apply ${imgui_fixes_and_config_patch_file} ${git_hide_output} || git apply --reverse --check ${imgui_fixes_and_config_patch_file})
 # Resets code and reapply patch, if old (potentially incompatible) patch applied
-set(imgui_apply_patch_if_needed_with_reset ${imgui_apply_patch_if_needed} || git diff --check && (git reset --hard || ${imgui_apply_patch_if_needed}))
+set(imgui_apply_patch_if_needed_with_reset ${imgui_apply_patch_if_needed} || (git status --porcelain && git reset --hard && (${imgui_apply_patch_if_needed})))
+
 FetchContent_Declare(
     ImGui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
@@ -51,7 +52,7 @@ if(NOT EXCLUDE_MPQ_SUPPORT)
     # Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
     set(stormlib_apply_patch_if_needed git apply ${stormlib_patch_file} ${git_hide_output} || git apply --reverse --check ${stormlib_patch_file})
     # Resets code and reapply patch, if old (potentially incompatible) patch applied
-    set(stormlib_apply_patch_if_needed_with_reset ${stormlib_apply_patch_if_needed} || git diff --check && (git reset --hard || ${stormlib_apply_patch_if_needed}))
+    set(stormlib_apply_patch_if_needed_with_reset ${stormlib_apply_patch_if_needed} || (git status --porcelain && git reset --hard && (${stormlib_apply_patch_if_needed})))
 
     FetchContent_Declare(
         StormLib

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -13,11 +13,13 @@ set(imgui_fixes_and_config_patch_file ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependen
 
 # Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
 set(imgui_apply_patch_if_needed git apply ${imgui_fixes_and_config_patch_file} ${git_hide_output} || git apply --reverse --check ${imgui_fixes_and_config_patch_file})
+# Resets code and reapply patch, if old (potentially incompatible) patch applied
+set(imgui_apply_patch_if_needed_with_reset ${imgui_apply_patch_if_needed} || git diff --check && (git reset --hard || ${imgui_apply_patch_if_needed}))
 FetchContent_Declare(
     ImGui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
     GIT_TAG v1.91.6-docking
-    PATCH_COMMAND ${imgui_apply_patch_if_needed}
+    PATCH_COMMAND ${imgui_apply_patch_if_needed_with_reset}
 )
 FetchContent_MakeAvailable(ImGui)
 list(APPEND ADDITIONAL_LIB_INCLUDES ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends)

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -50,12 +50,14 @@ if(NOT EXCLUDE_MPQ_SUPPORT)
 
     # Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
     set(stormlib_apply_patch_if_needed git apply ${stormlib_patch_file} ${git_hide_output} || git apply --reverse --check ${stormlib_patch_file})
+    # Resets code and reapply patch, if old (potentially incompatible) patch applied
+    set(stormlib_apply_patch_if_needed_with_reset ${stormlib_apply_patch_if_needed} || git diff --check && (git reset --hard || ${stormlib_apply_patch_if_needed}))
 
     FetchContent_Declare(
         StormLib
         GIT_REPOSITORY https://github.com/ladislav-zezula/StormLib.git
         GIT_TAG v9.25
-        PATCH_COMMAND ${stormlib_apply_patch_if_needed}
+        PATCH_COMMAND ${stormlib_apply_patch_if_needed_with_reset}
     )
     FetchContent_MakeAvailable(StormLib)
     list(APPEND ADDITIONAL_LIB_INCLUDES ${stormlib_SOURCE_DIR}/src)

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -2,25 +2,15 @@ include(FetchContent)
 
 find_package(OpenGL QUIET)
 
-# When using the Visual Studio generator, it is necessary to suppress stderr output entirely so it does not interrupt the patch command.
-# Redirecting to nul is used here instead of the `--quiet` flag, as that flag was only recently introduced in git 2.25.0 (Jan 2022)
-if (CMAKE_GENERATOR MATCHES "Visual Studio")
-    set(git_hide_output 2> nul)
-endif()
-
 #=================== ImGui ===================
 set(imgui_fixes_and_config_patch_file ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/patches/imgui-fixes-and-config.patch)
-
-# Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
-set(imgui_apply_patch_if_needed git apply ${imgui_fixes_and_config_patch_file} ${git_hide_output} || git apply --reverse --check ${imgui_fixes_and_config_patch_file})
-# Resets code and reapply patch, if old (potentially incompatible) patch applied
-set(imgui_apply_patch_if_needed_with_reset ${imgui_apply_patch_if_needed} || (git status --porcelain && git reset --hard && (${imgui_apply_patch_if_needed})))
+set(imgui_apply_patch_command ${CMAKE_COMMAND} -Dpatch_file=${imgui_fixes_and_config_patch_file} -Dwith_reset=TRUE -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/git-patch.cmake)
 
 FetchContent_Declare(
     ImGui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
     GIT_TAG v1.91.6-docking
-    PATCH_COMMAND ${imgui_apply_patch_if_needed_with_reset}
+    PATCH_COMMAND ${imgui_apply_patch_command}
 )
 FetchContent_MakeAvailable(ImGui)
 list(APPEND ADDITIONAL_LIB_INCLUDES ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends)
@@ -48,17 +38,13 @@ target_include_directories(ImGui PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/
 # ========= StormLib =============
 if(NOT EXCLUDE_MPQ_SUPPORT)
     set(stormlib_patch_file ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/patches/stormlib-optimizations.patch)
-
-    # Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
-    set(stormlib_apply_patch_if_needed git apply ${stormlib_patch_file} ${git_hide_output} || git apply --reverse --check ${stormlib_patch_file})
-    # Resets code and reapply patch, if old (potentially incompatible) patch applied
-    set(stormlib_apply_patch_if_needed_with_reset ${stormlib_apply_patch_if_needed} || (git status --porcelain && git reset --hard && (${stormlib_apply_patch_if_needed})))
+    set(stormlib_apply_patch_command ${CMAKE_COMMAND} -Dpatch_file=${stormlib_patch_file} -Dwith_reset=TRUE -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies/git-patch.cmake)
 
     FetchContent_Declare(
         StormLib
         GIT_REPOSITORY https://github.com/ladislav-zezula/StormLib.git
         GIT_TAG v9.25
-        PATCH_COMMAND ${stormlib_apply_patch_if_needed_with_reset}
+        PATCH_COMMAND ${stormlib_apply_patch_command}
     )
     FetchContent_MakeAvailable(StormLib)
     list(APPEND ADDITIONAL_LIB_INCLUDES ${stormlib_SOURCE_DIR}/src)

--- a/cmake/dependencies/git-patch.cmake
+++ b/cmake/dependencies/git-patch.cmake
@@ -1,0 +1,59 @@
+# In variables: patch_file, with_reset
+
+function(patch)
+    execute_process(
+        COMMAND git apply ${patch_file}
+        RESULT_VARIABLE ret
+        ERROR_QUIET
+    )
+    set(ret ${ret} PARENT_SCOPE)
+endfunction()
+
+function(check_patch)
+    execute_process(
+        COMMAND git apply --reverse --check ${patch_file}
+        RESULT_VARIABLE ret
+        ERROR_QUIET
+    )
+    set(ret ${ret} PARENT_SCOPE)
+endfunction()
+
+function(patch_if_needed)
+    patch()
+    if(NOT ret EQUAL 0)
+        check_patch()
+    endif()
+    set(ret ${ret} PARENT_SCOPE)
+endfunction()
+
+function(patch_if_needed_with_reset)
+    patch_if_needed()
+    if(NOT ret EQUAL 0)
+        message(STATUS "Failed to patch in current state, clearing changes to reapply")
+        execute_process(
+            COMMAND git status --porcelain
+            RESULT_VARIABLE is_changed
+        )
+        if(NOT is_changed EQUAL 0)
+            message(WARNING "Patch inapplyable in clean state")
+            set(ret 1)
+        else()
+            execute_process(COMMAND git reset --hard)
+            patch_if_needed()
+        endif()
+    endif()
+    set(ret ${ret} PARENT_SCOPE)
+endfunction()
+
+message(STATUS "Trying to apply patch ${patch_file}")
+message(STATUS "${CMAKE_CURRENT_LIST_DIR}")
+if(with_reset)
+    patch_if_needed_with_reset()
+else()
+    patch_if_needed()
+endif()
+if(NOT ret EQUAL 0)
+    message(FATAL_ERROR "Failed to apply patch ${patch_file}")
+else()
+    message(STATUS "Successfully patched with ${patch_file}")
+endif()

--- a/cmake/dependencies/git-patch.cmake
+++ b/cmake/dependencies/git-patch.cmake
@@ -18,6 +18,7 @@ function(check_patch)
     set(ret ${ret} PARENT_SCOPE)
 endfunction()
 
+# Applies the patch or checks if it has already been applied successfully previously. Will error otherwise.
 function(patch_if_needed)
     patch()
     if(NOT ret EQUAL 0)
@@ -26,6 +27,7 @@ function(patch_if_needed)
     set(ret ${ret} PARENT_SCOPE)
 endfunction()
 
+# Resets code and reapply patch, if old (potentially incompatible) patch applied
 function(patch_if_needed_with_reset)
     patch_if_needed()
     if(NOT ret EQUAL 0)
@@ -46,12 +48,12 @@ function(patch_if_needed_with_reset)
 endfunction()
 
 message(STATUS "Trying to apply patch ${patch_file}")
-message(STATUS "${CMAKE_CURRENT_LIST_DIR}")
 if(with_reset)
     patch_if_needed_with_reset()
 else()
     patch_if_needed()
 endif()
+
 if(NOT ret EQUAL 0)
     message(FATAL_ERROR "Failed to apply patch ${patch_file}")
 else()


### PR DESCRIPTION
When `FetchContent` updates dependency from git, it simply keeps patched changes as unstaged ones. It is fine in case when patch is compatible with updated patch, but otherwise the build will fail until the cache is cleared from unstaged changes.
Thats why I added additional check to remove unstaged changes and reapply patch, if there is a problem.