### PR TITLE
set `SDL_HINT_JOYSTICK_THREAD` to address dropped input issues

### DIFF
--- a/src/public/libultra/os.cpp
+++ b/src/public/libultra/os.cpp
@@ -14,6 +14,7 @@ int32_t osContInit(OSMesgQueue* mq, uint8_t* controllerBits, OSContStatus* statu
     *controllerBits = 0;
     status->status |= 1;
 
+    SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
     if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {
         SPDLOG_ERROR("Failed to initialize SDL game controllers ({})", SDL_GetError());
         exit(EXIT_FAILURE);


### PR DESCRIPTION
i was testing the "z-target dropping" issue in soh and added some logging to `SDLAxisDirectionToButtonMapping` where we call `SDL_GameControllerGetAxis`

i found that when reproducing the z-target drop error the value we got from there would occasionally drop from the max (trigger held down) to `0` for a single frame

i searched for issues on the SDL repo related to `SDL_GameControllerGetAxis` and found https://github.com/libsdl-org/SDL/issues/9270

this hint was recommended and the original reporter of that issue said it fixed it for them

i was not able to reproduce the dropped z-target issue after applying this hint

soh testing pr
* https://github.com/HarbourMasters/Shipwright/pull/4946