### PR TITLE
add `GameControllerDB` mappings before initializing the SDL gamecontroller subsystem

### DIFF
--- a/src/public/libultra/os.cpp
+++ b/src/public/libultra/os.cpp
@@ -14,18 +14,18 @@ int32_t osContInit(OSMesgQueue* mq, uint8_t* controllerBits, OSContStatus* statu
     *controllerBits = 0;
     status->status |= 1;
 
-    SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
-    if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {
-        SPDLOG_ERROR("Failed to initialize SDL game controllers ({})", SDL_GetError());
-        exit(EXIT_FAILURE);
-    }
-
     std::string controllerDb = Ship::Context::LocateFileAcrossAppDirs("gamecontrollerdb.txt");
     int mappingsAdded = SDL_GameControllerAddMappingsFromFile(controllerDb.c_str());
     if (mappingsAdded >= 0) {
         SPDLOG_INFO("Added SDL game controllers from \"{}\" ({})", controllerDb, mappingsAdded);
     } else {
         SPDLOG_ERROR("Failed add SDL game controller mappings from \"{}\" ({})", controllerDb, SDL_GetError());
+    }
+
+    SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
+    if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {
+        SPDLOG_ERROR("Failed to initialize SDL game controllers ({})", SDL_GetError());
+        exit(EXIT_FAILURE);
     }
 
     Ship::Context::GetInstance()->GetControlDeck()->Init(controllerBits);


### PR DESCRIPTION
controllers that don't have built in mappings and rely on `gamecontrollerdb.txt` mappings were firing `SDL_JOYDEVICEADDED` events at boot but not `SDL_CONTROLLERDEVICEADDED` events

The [documentation for `SDL_ControllerDeviceEvent`](https://wiki.libsdl.org/SDL2/SDL_ControllerDeviceEvent) states:
> Joysticks that are supported game controllers receive both an [SDL_JoyDeviceEvent](https://wiki.libsdl.org/SDL2/SDL_JoyDeviceEvent) and an [SDL_ControllerDeviceEvent](https://wiki.libsdl.org/SDL2/SDL_ControllerDeviceEvent).
> 
> SDL will send CONTROLLERDEVICEADDED events for joysticks that are already plugged in during [SDL_Init](https://wiki.libsdl.org/SDL2/SDL_Init)() and are recognized as game controllers.

i looked a bit and found we weren't loading `gamecontrollerdb.txt` until *after* initializing the game controller subsystem, so the "already plugged in" events were firing when the devices weren't recognized as game controllers yet.

this PR ensures `SDL_GameControllerAddMappingsFromFile` happens *before* the subsystem is initialized. i have verified this makes it so we get `SDL_CONTROLLERDEVICEADDED` events on boot.

relevant discourse post from someone with a similar issue: https://discourse.libsdl.org/t/deviced-added-events-for-devices-plugged-in-at-game-start/55039