### PR TITLE
Fix ListFiles(string) causing non-matches for calls to list all

### DIFF
--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -66,10 +66,10 @@ bool ArchiveManager::HasFile(uint64_t hash) {
 
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::string& searchMask) {
     std::list<std::string> includes = {};
-    if (searchMask.size() > 0) {
+    if (!searchMask.empty()) {
         includes.push_back(searchMask);
     }
-    return ListFiles({ searchMask }, {});
+    return ListFiles(includes, {});
 }
 
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::list<std::string>& includes,


### PR DESCRIPTION
I made two mistakes with the previous code, where I was checking for .size() > 0 on a blank string instead of !empty(), and passing in an initializer with the original string argument rather than the constructed list that ignores blank strings.