### PR TITLE
Fix Crashes loading file size 0

### DIFF
--- a/src/resource/archive/Archive.cpp
+++ b/src/resource/archive/Archive.cpp
@@ -218,6 +218,10 @@ std::shared_ptr<File> Archive::LoadFile(const std::string& filePath, std::shared
             fileToLoad->InitData = initDataFromMetaFile;
         } else {
             fileToLoad = LoadFileRaw(filePath);
+            if (fileToLoad == nullptr) {
+                SPDLOG_ERROR("Failed to load file at path {}.", filePath);
+                return nullptr;
+            }
             fileToLoad->InitData = ReadResourceInitDataLegacy(filePath, fileToLoad);
         }
     }


### PR DESCRIPTION
Add check to `LoadFile` to evaluate `fileToLoad == nullptr` before calling `ReadResourceInitDataLegacy` to prevent crashes from trying to assign to a null container with files of 0 size. This resolves bulk preloading issues with vanilla assets in SoH.