### PR TITLE
More Filesize 0 changes

### DIFF
--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -143,6 +143,7 @@ std::shared_ptr<IResource> ResourceManager::LoadResourceProcess(const ResourceId
     auto file = LoadFileProcess(identifier.Path, initData);
     if (file == nullptr) {
         SPDLOG_TRACE("Failed to load resource file at path {}", identifier.Path);
+        return nullptr;
     }
 
     // Transform the raw data into a resource

--- a/src/resource/archive/Archive.cpp
+++ b/src/resource/archive/Archive.cpp
@@ -219,7 +219,7 @@ std::shared_ptr<File> Archive::LoadFile(const std::string& filePath, std::shared
         } else {
             fileToLoad = LoadFileRaw(filePath);
             if (fileToLoad == nullptr) {
-                SPDLOG_ERROR("Failed to load file at path {}.", filePath);
+                SPDLOG_TRACE("Failed to load file at path {}.", filePath);
                 return nullptr;
             }
             fileToLoad->InitData = ReadResourceInitDataLegacy(filePath, fileToLoad);

--- a/src/resource/archive/O2rArchive.cpp
+++ b/src/resource/archive/O2rArchive.cpp
@@ -36,6 +36,12 @@ std::shared_ptr<File> O2rArchive::LoadFileRaw(const std::string& filePath) {
         return nullptr;
     }
 
+    // Filesize 0, no logging needed
+    if (zipEntryStat.size == 0) {
+        SPDLOG_TRACE("({}) Failed to read file {} from mpq archive {}; filesize == 0", GetLastError(), filePath, GetPath());
+        return nullptr;
+    }
+
     struct zip_file* zipEntryFile = zip_fopen_index(mZipArchive, zipEntryIndex, 0);
     if (!zipEntryFile) {
         SPDLOG_TRACE("Failed to open file {} in zip archive  {}.", filePath, GetPath());

--- a/src/resource/archive/O2rArchive.cpp
+++ b/src/resource/archive/O2rArchive.cpp
@@ -38,7 +38,7 @@ std::shared_ptr<File> O2rArchive::LoadFileRaw(const std::string& filePath) {
 
     // Filesize 0, no logging needed
     if (zipEntryStat.size == 0) {
-        SPDLOG_TRACE("({}) Failed to read file {} from mpq archive {}; filesize == 0", GetLastError(), filePath, GetPath());
+        SPDLOG_TRACE("({}) Failed to load file {}; filesize 0", GetLastError(), filePath, GetPath());
         return nullptr;
     }
 

--- a/src/resource/archive/OtrArchive.cpp
+++ b/src/resource/archive/OtrArchive.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<File> OtrArchive::LoadFileRaw(const std::string& filePath) {
     auto fileToLoad = std::make_shared<File>();
     DWORD fileSize = SFileGetFileSize(fileHandle, 0);
     if (fileSize == 0) {
-        SPDLOG_TRACE("({}) Failed to read file {} from mpq archive {}; filesize == 0", GetLastError(), filePath, GetPath());
+        SPDLOG_TRACE("({}) Failed to load file {}; filesize 0", GetLastError(), filePath, GetPath());
         return nullptr;
     }
     DWORD readBytes;
@@ -46,7 +46,7 @@ std::shared_ptr<File> OtrArchive::LoadFileRaw(const std::string& filePath) {
         bool closeFileSuccess = SFileCloseFile(fileHandle);
         if (!closeFileSuccess) {
             SPDLOG_ERROR("({}) Failed to close file {} from mpq after read failure in archive {}", GetLastError(),
-                            filePath, GetPath());
+                         filePath, GetPath());
         }
         return nullptr;
     }

--- a/src/resource/archive/OtrArchive.cpp
+++ b/src/resource/archive/OtrArchive.cpp
@@ -33,6 +33,10 @@ std::shared_ptr<File> OtrArchive::LoadFileRaw(const std::string& filePath) {
 
     auto fileToLoad = std::make_shared<File>();
     DWORD fileSize = SFileGetFileSize(fileHandle, 0);
+    if (fileSize == 0) {
+        SPDLOG_TRACE("({}) Failed to read file {} from mpq archive {}; filesize == 0", GetLastError(), filePath, GetPath());
+        return nullptr;
+    }
     DWORD readBytes;
     fileToLoad->Buffer = std::make_shared<std::vector<char>>(fileSize);
     bool readFileSuccess = SFileReadFile(fileHandle, fileToLoad->Buffer->data(), fileSize, &readBytes, NULL);
@@ -42,7 +46,7 @@ std::shared_ptr<File> OtrArchive::LoadFileRaw(const std::string& filePath) {
         bool closeFileSuccess = SFileCloseFile(fileHandle);
         if (!closeFileSuccess) {
             SPDLOG_ERROR("({}) Failed to close file {} from mpq after read failure in archive {}", GetLastError(),
-                         filePath, GetPath());
+                            filePath, GetPath());
         }
         return nullptr;
     }


### PR DESCRIPTION
Make `OtrArchive` and `O2rArchive` trace on filesize 0 and return nullptr.
Make `LoadResourceProcess` return nullptr from file being nullptr before running `LoadResource`.
Change `fileToLoad == nullptr` log to trace in `Archive::LoadFile`.