### PR TITLE
remove unordered_map for attr handler

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -148,19 +148,14 @@ static map<string, MaskedTextureEntry> masked_textures;
 
 static UcodeHandlers ucode_handler_index = ucode_f3dex2;
 
-const static std::unordered_map<Attribute, std::any> f3dex2AttrHandler = {
-    { MTX_PROJECTION, F3DEX2_G_MTX_PROJECTION }, { MTX_LOAD, F3DEX2_G_MTX_LOAD },     { MTX_PUSH, F3DEX2_G_MTX_PUSH },
-    { MTX_NOPUSH, F3DEX_G_MTX_NOPUSH },          { CULL_FRONT, F3DEX2_G_CULL_FRONT }, { CULL_BACK, F3DEX2_G_CULL_BACK },
-    { CULL_BOTH, F3DEX2_G_CULL_BOTH },
+const static uint32_t f3dex2AttrHandler[] = {
+    F3DEX2_G_MTX_PROJECTION, F3DEX2_G_MTX_LOAD,  F3DEX2_G_MTX_PUSH,  F3DEX_G_MTX_NOPUSH,
+    F3DEX2_G_CULL_FRONT,     F3DEX2_G_CULL_BACK, F3DEX2_G_CULL_BOTH,
 };
 
-const static std::unordered_map<Attribute, std::any> f3dexAttrHandler = { { MTX_PROJECTION, F3DEX_G_MTX_PROJECTION },
-                                                                          { MTX_LOAD, F3DEX_G_MTX_LOAD },
-                                                                          { MTX_PUSH, F3DEX_G_MTX_PUSH },
-                                                                          { MTX_NOPUSH, F3DEX_G_MTX_NOPUSH },
-                                                                          { CULL_FRONT, F3DEX_G_CULL_FRONT },
-                                                                          { CULL_BACK, F3DEX_G_CULL_BACK },
-                                                                          { CULL_BOTH, F3DEX_G_CULL_BOTH } };
+const static uint32_t f3dexAttrHandler[] = { F3DEX_G_MTX_PROJECTION, F3DEX_G_MTX_LOAD,   F3DEX_G_MTX_PUSH,
+                                             F3DEX_G_MTX_NOPUSH,     F3DEX_G_CULL_FRONT, F3DEX_G_CULL_BACK,
+                                             F3DEX_G_CULL_BOTH };
 
 static constexpr std::array ucode_attr_handlers = {
     &f3dexAttrHandler,  // ucode_f3db
@@ -171,10 +166,10 @@ static constexpr std::array ucode_attr_handlers = {
     &f3dex2AttrHandler, // ucode_s2dex
 };
 
-template <typename T> static constexpr T get_attr(Attribute attr) {
+static constexpr uint32_t get_attr(Attribute attr) {
     const auto ucode_map = ucode_attr_handlers[ucode_handler_index];
-    assert(ucode_map->contains(attr) && "Attribute not found in the current ucode handler");
-    return std::any_cast<T>(ucode_map->at(attr));
+    // assert(ucode_map->contains(attr) && "Attribute not found in the current ucode handler");
+    return (*ucode_map)[attr];
 }
 
 static std::string GetPathWithoutFileName(char* filePath) {
@@ -1145,9 +1140,9 @@ static void gfx_sp_matrix(uint8_t parameters, const int32_t* addr) {
 #endif
     }
 
-    const auto mtx_projection = get_attr<int8_t>(MTX_PROJECTION);
-    const auto mtx_load = get_attr<int8_t>(MTX_LOAD);
-    const auto mtx_push = get_attr<int8_t>(MTX_PUSH);
+    const int8_t mtx_projection = get_attr(MTX_PROJECTION);
+    const int8_t mtx_load = get_attr(MTX_LOAD);
+    const int8_t mtx_push = get_attr(MTX_PUSH);
 
     if (parameters & mtx_projection) {
         if (parameters & mtx_load) {
@@ -1422,9 +1417,9 @@ static void gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx, bo
         return;
     }
 
-    const auto cull_both = get_attr<uint32_t>(CULL_BOTH);
-    const auto cull_front = get_attr<uint32_t>(CULL_FRONT);
-    const auto cull_back = get_attr<uint32_t>(CULL_BACK);
+    const uint32_t cull_both = get_attr(CULL_BOTH);
+    const uint32_t cull_front = get_attr(CULL_FRONT);
+    const uint32_t cull_back = get_attr(CULL_BACK);
 
     if ((g_rsp.geometry_mode & cull_both) != 0) {
         float dx1 = v1->x / (v1->w) - v2->x / (v2->w);

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -166,7 +166,7 @@ static constexpr std::array ucode_attr_handlers = {
     &f3dex2AttrHandler, // ucode_s2dex
 };
 
-static constexpr uint32_t get_attr(Attribute attr) {
+static uint32_t get_attr(Attribute attr) {
     const auto ucode_map = ucode_attr_handlers[ucode_handler_index];
     // assert(ucode_map->contains(attr) && "Attribute not found in the current ucode handler");
     return (*ucode_map)[attr];

--- a/src/graphic/Fast3D/gfx_pc.h
+++ b/src/graphic/Fast3D/gfx_pc.h
@@ -197,7 +197,7 @@ struct RDP {
 };
 
 typedef enum Attribute {
-    MTX_PROJECTION,
+    MTX_PROJECTION = 0,
     MTX_LOAD,
     MTX_PUSH,
     MTX_NOPUSH,


### PR DESCRIPTION
change ucode_attr_handlers to an array of array instead of map to no longer compute hash.
originally the code was just made to make it work without taking in account performance or cost of an hastable.

profile make in debug mode. (profiler make with callgrind use callgrind_annotate or kcachegrind to visualise it)
before: 
[old_bench.txt](https://github.com/user-attachments/files/19096440/old_bench.txt)
![image](https://github.com/user-attachments/assets/2ce7e0d4-5750-4758-b3ab-b50ce31263bf)

after:
[bench.txt](https://github.com/user-attachments/files/19096553/bench.txt)
![image](https://github.com/user-attachments/assets/9870743b-e523-42d9-8a39-663fa28b2536)

