### PR TITLE
Update gfx_sdl2.cpp to fix macOS Metal Slowdown.

### DIFF
--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -615,7 +615,7 @@ static inline void sync_framerate_with_timer() {
 
     const int64_t next = previous_time + 10 * FRAME_INTERVAL_US_NUMERATOR / FRAME_INTERVAL_US_DENOMINATOR;
     int64_t left = next - t;
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
     // We want to exit a bit early, so we can busy-wait the rest to never miss the deadline
     left -= 15000UL;
 #endif
@@ -632,10 +632,14 @@ static inline void sync_framerate_with_timer() {
 #endif
     }
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
     t = qpc_to_100ns(SDL_GetPerformanceCounter());
     while (t < next) {
-        YieldProcessor(); // TODO: Find a way for other compilers, OSes and architectures
+#ifdef _WIN32
+        YieldProcessor();
+#elif defined(__APPLE__)
+        sched_yield();
+#endif
         t = qpc_to_100ns(SDL_GetPerformanceCounter());
     }
 #endif


### PR DESCRIPTION
Fixes stutter/inability to lock 60 consistently on macOS using Metal. May also provide performance benefits under OpenGL and Linux. This is the weird 57-58 fps issue noticed on Metal graphics on Macs for a long while.

Thanks to @Spodi, @Malkierian, ProxySaw, and Fenrir for their help on Discord getting this figured out! :D

**Note:** This version has been fixed to exclude other operating systems aside from macOS from modification.