### PR TITLE
Correct "Fix Vanishing Paths" Options on Metal.

### DIFF
--- a/src/graphic/Fast3D/gfx_metal.cpp
+++ b/src/graphic/Fast3D/gfx_metal.cpp
@@ -592,7 +592,7 @@ static void gfx_metal_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_t
         const int n64modeFactor = 120;
         const int noVanishFactor = 100;
         float SSDB = -2;
-        switch (CVarGetInteger("gZFightingMode", 0)) {
+        switch (CVarGetInteger(CVAR_Z_FIGHTING_MODE, 0)) {
             case 1: // scaled z-fighting (N64 mode like)
                 SSDB = -1.0f * (float)mctx.render_target_height / n64modeFactor;
                 break;


### PR DESCRIPTION
Options controlling "Fix Vanishing Paths" were not working correctly on Metal as "gZFightingMode" was not properly renamed to "CVAR_Z_FIGHTING_MODE" for Metal as was done for OpenGL and DirectX. Thanks to @larsy1995 (Fenrir) for help finding and testing this fix. Thanks!