### PR TITLE
Dxgi: Remove unnecessary flushes and cleanup

### DIFF
--- a/src/graphic/Fast3D/backends/gfx_direct3d11.cpp
+++ b/src/graphic/Fast3D/backends/gfx_direct3d11.cpp
@@ -724,7 +724,6 @@ void GfxRenderingAPIDX11::EndFrame() {
 }
 
 void GfxRenderingAPIDX11::FinishRender() {
-    mContext->Flush();
 }
 
 int GfxRenderingAPIDX11::CreateFramebuffer() {

--- a/src/graphic/Fast3D/backends/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/backends/gfx_dxgi.cpp
@@ -876,19 +876,6 @@ void GfxWindowBackendDXGI::SwapBuffersBegin() {
     mVsyncEnabled = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1) ? 1 : 0;
 
     LARGE_INTEGER t;
-    ComPtr<ID3D11Device> mDevice;
-    mSwapChainDevice.As(&mDevice);
-
-    if (mDevice != nullptr) {
-        ComPtr<ID3D11DeviceContext> dev_ctx;
-        mDevice->GetImmediateContext(&dev_ctx);
-
-        if (dev_ctx != nullptr) {
-            // Always flush the immediate mContext before forcing a CPU-wait, otherwise the GPU might only start
-            // working when the SwapChain is presented.
-            dev_ctx->Flush();
-        }
-    }
     QueryPerformanceCounter(&t);
     int64_t next = qpc_to_100ns(mPreviousPresentTime.QuadPart) +
                    FRAME_INTERVAL_NS_NUMERATOR / (FRAME_INTERVAL_NS_DENOMINATOR * 100);

--- a/src/graphic/Fast3D/backends/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/backends/gfx_dxgi.cpp
@@ -775,8 +775,6 @@ bool GfxWindowBackendDXGI::IsFrameReady() {
         mFrameStats.clear();
     }
 
-    mUseTimer = false;
-
     mFrameTimeStamp += FRAME_INTERVAL_NS_NUMERATOR;
 
     if (mFrameStats.size() >= 2) {
@@ -867,71 +865,60 @@ bool GfxWindowBackendDXGI::IsFrameReady() {
                 return false;
             }
         }
-        // printf("v: %d\n", (int)vsyncs_to_wait);
-        if (vsyncs_to_wait > 4) {
-            // Invalid, so use mTimer based solution
-            vsyncs_to_wait = 4;
-            mUseTimer = true;
-        }
-    } else {
-        mUseTimer = true;
     }
-    // mLengthInVsyncFrames is used as present interval. Present interval >1 (aka fractional V-Sync)
-    // breaks VRR and introduces even more input lag than capping via normal V-Sync does.
-    // Get the present interval the user wants instead (V-Sync toggle).
-    mVsyncEnabled = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1);
-    mLengthInVsyncFrames = mVsyncEnabled ? 1 : 0;
     return true;
 }
 
 void GfxWindowBackendDXGI::SwapBuffersBegin() {
+    // mLengthInVsyncFrames (now mVsyncEnabled) was used as present interval. Present interval >1 (aka fractional
+    // V-Sync) breaks VRR and introduces even more input lag than capping via normal V-Sync does. Get the present
+    // interval the user wants instead (V-Sync toggle).
+    mVsyncEnabled = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1) ? 1 : 0;
+
     LARGE_INTEGER t;
-    mUseTimer = true;
-    if (mUseTimer || (mTearingSupport && !mVsyncEnabled)) {
-        ComPtr<ID3D11Device> mDevice;
-        mSwapChainDevice.As(&mDevice);
+    ComPtr<ID3D11Device> mDevice;
+    mSwapChainDevice.As(&mDevice);
 
-        if (mDevice != nullptr) {
-            ComPtr<ID3D11DeviceContext> dev_ctx;
-            mDevice->GetImmediateContext(&dev_ctx);
+    if (mDevice != nullptr) {
+        ComPtr<ID3D11DeviceContext> dev_ctx;
+        mDevice->GetImmediateContext(&dev_ctx);
 
-            if (dev_ctx != nullptr) {
-                // Always flush the immediate mContext before forcing a CPU-wait, otherwise the GPU might only start
-                // working when the SwapChain is presented.
-                dev_ctx->Flush();
-            }
-        }
-        QueryPerformanceCounter(&t);
-        int64_t next = qpc_to_100ns(mPreviousPresentTime.QuadPart) +
-                       FRAME_INTERVAL_NS_NUMERATOR / (FRAME_INTERVAL_NS_DENOMINATOR * 100);
-        int64_t left = next - qpc_to_100ns(t.QuadPart) - 15000UL;
-        if (left > 0) {
-            LARGE_INTEGER li;
-            li.QuadPart = -left;
-            SetWaitableTimer(mTimer, &li, 0, nullptr, nullptr, false);
-            WaitForSingleObject(mTimer, INFINITE);
-        }
-
-        QueryPerformanceCounter(&t);
-        t.QuadPart = qpc_to_100ns(t.QuadPart);
-        while (t.QuadPart < next) {
-            YieldProcessor();
-            QueryPerformanceCounter(&t);
-            t.QuadPart = qpc_to_100ns(t.QuadPart);
+        if (dev_ctx != nullptr) {
+            // Always flush the immediate mContext before forcing a CPU-wait, otherwise the GPU might only start
+            // working when the SwapChain is presented.
+            dev_ctx->Flush();
         }
     }
     QueryPerformanceCounter(&t);
+    int64_t next = qpc_to_100ns(mPreviousPresentTime.QuadPart) +
+                   FRAME_INTERVAL_NS_NUMERATOR / (FRAME_INTERVAL_NS_DENOMINATOR * 100);
+    int64_t left = next - qpc_to_100ns(t.QuadPart) - 15000UL;
+    if (left > 0) {
+        LARGE_INTEGER li;
+        li.QuadPart = -left;
+        SetWaitableTimer(mTimer, &li, 0, nullptr, nullptr, false);
+        WaitForSingleObject(mTimer, INFINITE);
+    }
+
+    QueryPerformanceCounter(&t);
+    t.QuadPart = qpc_to_100ns(t.QuadPart);
+    while (t.QuadPart < next) {
+        YieldProcessor();
+        QueryPerformanceCounter(&t);
+        t.QuadPart = qpc_to_100ns(t.QuadPart);
+    }
+    QueryPerformanceCounter(&t);
     mPreviousPresentTime = t;
-    if (mTearingSupport && !mLengthInVsyncFrames) {
+    if (mTearingSupport && !mVsyncEnabled) {
         // 512: DXGI_PRESENT_ALLOW_TEARING - allows for true V-Sync off with flip model
-        ThrowIfFailed(swap_chain->Present(mLengthInVsyncFrames, DXGI_PRESENT_ALLOW_TEARING));
+        ThrowIfFailed(swap_chain->Present(mVsyncEnabled, DXGI_PRESENT_ALLOW_TEARING));
     } else {
-        ThrowIfFailed(swap_chain->Present(mLengthInVsyncFrames, 0));
+        ThrowIfFailed(swap_chain->Present(mVsyncEnabled, 0));
     }
 
     UINT this_present_id;
     if (swap_chain->GetLastPresentCount(&this_present_id) == S_OK) {
-        mPendingFrameStats.insert(std::make_pair(this_present_id, mLengthInVsyncFrames));
+        mPendingFrameStats.insert(std::make_pair(this_present_id, mVsyncEnabled));
     }
     mDroppedFrame = false;
 }

--- a/src/graphic/Fast3D/backends/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/backends/gfx_dxgi.cpp
@@ -14,7 +14,6 @@
 #include <dxgi1_4.h>
 #include <dxgi1_5.h>
 #include <versionhelpers.h>
-#include <d3d11.h>
 
 #include <shellscalingapi.h>
 
@@ -52,8 +51,6 @@
 #define HID_USAGE_GENERIC_MOUSE ((unsigned short)0x02)
 #endif
 using QWORD = uint64_t; // For NEXTRAWINPUTBLOCK
-
-using namespace Microsoft::WRL; // For ComPtr
 
 namespace Fast {
 

--- a/src/graphic/Fast3D/backends/gfx_dxgi.h
+++ b/src/graphic/Fast3D/backends/gfx_dxgi.h
@@ -100,11 +100,9 @@ class GfxWindowBackendDXGI final : public GfxWindowBackend {
     std::set<std::pair<UINT, UINT>> mPendingFrameStats;
     bool mDroppedFrame;
     bool mZeroLatency;
-    UINT mLengthInVsyncFrames;
     uint32_t mMaxFrameLatency;
     uint32_t mAppliedMaxFrameLatency;
     HANDLE mTimer;
-    bool mUseTimer;
     bool mTearingSupport;
     bool mMousePressed[5];
     LARGE_INTEGER mPreviousPresentTime;


### PR DESCRIPTION
- Clean up after https://github.com/Kenix3/libultraship/pull/325
Most of that probably got optimized out anyway.

- removes unnecessary flush commands
  - the one I added myself in #325
    there was already one before in `mRapi->EndFrame();` and nothing renders in between.
  - and https://github.com/Kenix3/libultraship/blob/02bb77ef253e2de0969fd2cb36ad2e870677d18d/src/graphic/Fast3D/gfx_direct3d11.cpp#L833-L835
`swap_chain->Present(mVsyncEnabled, DXGI_PRESENT_ALLOW_TEARING)` in `mWapi->SwapBuffersBegin();` is already an implicit `Flush()`; so no need to do it twice in a row, with nothing else in between happening.

Removing the flushes maybe even helps the lower end windows devices. As those flushes can in theory be pretty demanding.
https://learn.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicecontext-flush
> If an application calls this method when not necessary, it incurs a performance penalty. Each call to Flush incurs a significant amount of overhead. 

 

I should have done that ages ago...
Should not change any behavior. But as always: please test before merging.