### PR TITLE
fix rumble mappings not loading from config

### DIFF
--- a/src/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.cpp
+++ b/src/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.cpp
@@ -26,16 +26,6 @@ std::shared_ptr<ControllerRumbleMapping> RumbleMappingFactory::CreateRumbleMappi
     }
 
     if (mappingClass == "SDLRumbleMapping") {
-        int32_t shipDeviceIndex =
-            CVarGetInteger(StringHelper::Sprintf("%s.ShipDeviceIndex", mappingCvarKey.c_str()).c_str(), -1);
-
-        if (shipDeviceIndex < 0) {
-            // something about this mapping is invalid
-            CVarClear(mappingCvarKey.c_str());
-            CVarSave();
-            return nullptr;
-        }
-
         return std::make_shared<SDLRumbleMapping>(portIndex, lowFrequencyIntensityPercentage,
                                                   highFrequencyIntensityPercentage);
     }


### PR DESCRIPTION
some leftover shipdeviceindex stuff was making it so the factory saw rumble mappings in the config as invalid. this PR removes that as it's no longer used