### PR TITLE
Add method to call for shutting down the ResourceManager thread pool

### DIFF
--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -410,4 +410,10 @@ void ResourceManager::SetAltAssetsEnabled(bool isEnabled) {
     mAltAssetsEnabled = isEnabled;
 }
 
+void ResourceManager::ShutDownThreadPool() {
+    mThreadPool->pause();
+    mThreadPool->wait_for(std::chrono::duration<double>(2));
+    mThreadPool->purge();
+}
+
 } // namespace Ship

--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -291,14 +291,14 @@ ResourceManager::GetCachedResource(std::variant<ResourceLoadError, std::shared_p
 }
 
 std::shared_ptr<std::vector<std::shared_ptr<IResource>>>
-ResourceManager::LoadResourcesProcess(const ResourceFilter& filter) {
+ResourceManager::LoadResourcesProcess(const ResourceFilter& filter, bool exact) {
     auto loadedList = std::make_shared<std::vector<std::shared_ptr<IResource>>>();
     auto fileList = GetArchiveManager()->ListFiles(filter.IncludeMasks, filter.ExcludeMasks);
     loadedList->reserve(fileList->size());
 
     for (size_t i = 0; i < fileList->size(); i++) {
         auto fileName = std::string(fileList->operator[](i));
-        auto resource = LoadResource({ fileName, filter.Owner, filter.Parent });
+        auto resource = LoadResource({ fileName, filter.Owner, filter.Parent }, exact);
         loadedList->push_back(resource);
     }
 
@@ -306,25 +306,25 @@ ResourceManager::LoadResourcesProcess(const ResourceFilter& filter) {
 }
 
 std::shared_future<std::shared_ptr<std::vector<std::shared_ptr<IResource>>>>
-ResourceManager::LoadResourcesAsync(const ResourceFilter& filter, BS::priority_t priority) {
+ResourceManager::LoadResourcesAsync(const ResourceFilter& filter, BS::priority_t priority, bool exact) {
     return mThreadPool->submit_task(
-        [this, filter]() -> std::shared_ptr<std::vector<std::shared_ptr<IResource>>> {
-            return LoadResourcesProcess(filter);
+        [this, filter, exact]() -> std::shared_ptr<std::vector<std::shared_ptr<IResource>>> {
+            return LoadResourcesProcess(filter, exact);
         },
         priority);
 }
 
 std::shared_future<std::shared_ptr<std::vector<std::shared_ptr<IResource>>>>
-ResourceManager::LoadResourcesAsync(const std::string& searchMask, BS::priority_t priority) {
-    return LoadResourcesAsync({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive }, priority);
+ResourceManager::LoadResourcesAsync(const std::string& searchMask, BS::priority_t priority, bool exact) {
+    return LoadResourcesAsync({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive }, priority, exact);
 }
 
-std::shared_ptr<std::vector<std::shared_ptr<IResource>>> ResourceManager::LoadResources(const std::string& searchMask) {
-    return LoadResources({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive });
+std::shared_ptr<std::vector<std::shared_ptr<IResource>>> ResourceManager::LoadResources(const std::string& searchMask, bool exact) {
+    return LoadResources({ { searchMask }, {}, mDefaultCacheOwner, mDefaultCacheArchive }, exact);
 }
 
-std::shared_ptr<std::vector<std::shared_ptr<IResource>>> ResourceManager::LoadResources(const ResourceFilter& filter) {
-    return LoadResourcesAsync(filter, BS::pr::highest).get();
+std::shared_ptr<std::vector<std::shared_ptr<IResource>>> ResourceManager::LoadResources(const ResourceFilter& filter, bool exact) {
+    return LoadResourcesAsync(filter, BS::pr::highest, exact).get();
 }
 
 void ResourceManager::DirtyResources(const ResourceFilter& filter) {
@@ -415,6 +415,10 @@ void ResourceManager::ShutDownThreadPool() {
     mThreadPool->pause();
     mThreadPool->wait_for(std::chrono::duration<double>(2));
     mThreadPool->purge();
+}
+
+void ResourceManager::ThreadPoolWait(std::chrono::duration<double> interval) {
+    mThreadPool->wait_for(interval);
 }
 
 } // namespace Ship

--- a/src/resource/ResourceManager.h
+++ b/src/resource/ResourceManager.h
@@ -101,6 +101,7 @@ class ResourceManager {
     bool OtrSignatureCheck(const char* fileName);
     bool IsAltAssetsEnabled();
     void SetAltAssetsEnabled(bool isEnabled);
+    void ShutDownThreadPool();
 
   protected:
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResourcesProcess(const ResourceFilter& filter);

--- a/src/resource/ResourceManager.h
+++ b/src/resource/ResourceManager.h
@@ -84,12 +84,12 @@ class ResourceManager {
     size_t UnloadResource(const ResourceIdentifier& identifier);
     size_t UnloadResource(const std::string& filePath);
 
-    std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResources(const std::string& searchMask);
-    std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResources(const ResourceFilter& filter);
+    std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResources(const std::string& searchMask, bool exact = false);
+    std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResources(const ResourceFilter& filter, bool exact = false);
     std::shared_future<std::shared_ptr<std::vector<std::shared_ptr<IResource>>>>
-    LoadResourcesAsync(const std::string& searchMask, BS::priority_t priority = BS::pr::normal);
+    LoadResourcesAsync(const std::string& searchMask, BS::priority_t priority = BS::pr::normal, bool exact = false);
     std::shared_future<std::shared_ptr<std::vector<std::shared_ptr<IResource>>>>
-    LoadResourcesAsync(const ResourceFilter& filter, BS::priority_t priority = BS::pr::normal);
+    LoadResourcesAsync(const ResourceFilter& filter, BS::priority_t priority = BS::pr::normal, bool exact = false);
 
     void DirtyResources(const std::string& searchMask);
     void DirtyResources(const ResourceFilter& filter);
@@ -102,9 +102,10 @@ class ResourceManager {
     bool IsAltAssetsEnabled();
     void SetAltAssetsEnabled(bool isEnabled);
     void ShutDownThreadPool();
+    void ThreadPoolWait(std::chrono::duration<double> interval);
 
   protected:
-    std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResourcesProcess(const ResourceFilter& filter);
+    std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResourcesProcess(const ResourceFilter& filter, bool exact = false);
     void UnloadResourcesProcess(const ResourceFilter& filter);
     std::variant<ResourceLoadError, std::shared_ptr<IResource>> CheckCache(const ResourceIdentifier& identifier,
                                                                            bool loadExact = false);


### PR DESCRIPTION
This adds a method in `ResourceManager` to allow for setting up a thread pool shutdown to prevent crashes when exiting while still loading assets. I have a wait time of 2 seconds here between pausing and purging to prevent deadlocks, more than that is unnecessary (especially if it's only for resource threads, as I think it should be). Unfortunately, because of the way shutdowns work, this has to be called manually from the port before nulling `Context`. This is demonstrated in the asset preload PR: https://github.com/HarbourMasters/Shipwright/pull/4652

The reasoning for this PR is that I needed to be able to shut down the resource thread pool because of the way preloading would queue up a lot of loads at the start, and would crash if you tried to exit while in the opening sequence. This does not do any of the work of exposing the `ResourceManager` thread pool because there's still some ambiguity around the scope of that work (should only be used for non-critical tasks in my opinion; no save or config writing). The reason I needed to do it on the preload PR is because I couldn't get the crash to happen on latest develop. It's easiest to recreate with the 4K Reloaded pack. To let it trigger, comment the line `OTRGlobals::Instance->context->GetResourceManager()->ShutDownThreadPool();` in OTRGlobals (should be line 1248), and close the program as soon as you see the Nintendo logo. Uncomment it to see it not crash under the same circumstances. I *think* it still happens in release mode, but you'll get the stack trace in debug in VS.