### PR TITLE
Fix O2R log statement not compiling

### DIFF
--- a/src/resource/archive/O2rArchive.cpp
+++ b/src/resource/archive/O2rArchive.cpp
@@ -38,7 +38,7 @@ std::shared_ptr<File> O2rArchive::LoadFileRaw(const std::string& filePath) {
 
     // Filesize 0, no logging needed
     if (zipEntryStat.size == 0) {
-        SPDLOG_TRACE("({}) Failed to load file {}; filesize 0", GetLastError(), filePath, GetPath());
+        SPDLOG_TRACE("Failed to load file {}; filesize 0", filePath, GetPath());
         return nullptr;
     }
 


### PR DESCRIPTION
I don't know why the github builds did not complain about this, but the use of `GetLastError()` should not be in the O2RArchive class, as that method is strictly from StormLib and pertains to the OTRArchive class.

Removing the function reference and updating the log statement allowed LUS to build correctly for me.