### PR TITLE
Fix cache record for file load errors in resource manager

### DIFF
--- a/src/resource/ResourceManager.cpp
+++ b/src/resource/ResourceManager.cpp
@@ -143,6 +143,7 @@ std::shared_ptr<IResource> ResourceManager::LoadResourceProcess(const ResourceId
     auto file = LoadFileProcess(identifier.Path, initData);
     if (file == nullptr) {
         SPDLOG_TRACE("Failed to load resource file at path {}", identifier.Path);
+        mResourceCache[identifier] = ResourceLoadError::NotFound;
         return nullptr;
     }
 


### PR DESCRIPTION
An early return in the load resource process was added by #803 but that skipped the logic of setting a cache record of NotFound, to prevent future lookups from trying to load that file again. This just adds an additional cache record set before the early return.