### PR TITLE
Assume 60Hz if SDL reports 0Hz

### DIFF
--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -271,7 +271,7 @@ static void gfx_sdl_get_active_window_refresh_rate(uint32_t* refresh_rate) {
 
     SDL_DisplayMode mode;
     SDL_GetCurrentDisplayMode(display_in_use, &mode);
-    *refresh_rate = mode.refresh_rate;
+    *refresh_rate = mode.refresh_rate != 0 ? mode.refresh_rate : 60;
 }
 
 static uint64_t previous_time;


### PR DESCRIPTION
This fixes a crash on MacOS, where SDL sometimes outputs 0Hz for secondary displays on startup.
[Discord: Ticking "match refresh rate" crashes SoH on start up](https://discord.com/channels/808039310850130000/1343494463456018442)
