### PR TITLE
Missing namespace for some instances of (std::)static_pointer_cast.

### DIFF
--- a/src/public/bridge/resourcebridge.cpp
+++ b/src/public/bridge/resourcebridge.cpp
@@ -81,7 +81,7 @@ void* ResourceGetDataByCrc(uint64_t crc) {
 }
 
 uint16_t ResourceGetTexWidthByName(const char* name) {
-    const auto res = static_pointer_cast<Fast::Texture>(ResourceLoad(name));
+    const auto res = std::static_pointer_cast<Fast::Texture>(ResourceLoad(name));
 
     if (res != nullptr) {
         return res->Width;
@@ -92,7 +92,7 @@ uint16_t ResourceGetTexWidthByName(const char* name) {
 }
 
 uint16_t ResourceGetTexWidthByCrc(uint64_t crc) {
-    const auto res = static_pointer_cast<Fast::Texture>(ResourceLoad(crc));
+    const auto res = std::static_pointer_cast<Fast::Texture>(ResourceLoad(crc));
 
     if (res != nullptr) {
         return res->Width;
@@ -103,7 +103,7 @@ uint16_t ResourceGetTexWidthByCrc(uint64_t crc) {
 }
 
 uint16_t ResourceGetTexHeightByName(const char* name) {
-    const auto res = static_pointer_cast<Fast::Texture>(ResourceLoad(name));
+    const auto res = std::static_pointer_cast<Fast::Texture>(ResourceLoad(name));
 
     if (res != nullptr) {
         return res->Height;
@@ -114,7 +114,7 @@ uint16_t ResourceGetTexHeightByName(const char* name) {
 }
 
 uint16_t ResourceGetTexHeightByCrc(uint64_t crc) {
-    const auto res = static_pointer_cast<Fast::Texture>(ResourceLoad(crc));
+    const auto res = std::static_pointer_cast<Fast::Texture>(ResourceLoad(crc));
 
     if (res != nullptr) {
         return res->Height;
@@ -125,7 +125,7 @@ uint16_t ResourceGetTexHeightByCrc(uint64_t crc) {
 }
 
 size_t ResourceGetTexSizeByName(const char* name) {
-    const auto res = static_pointer_cast<Fast::Texture>(ResourceLoad(name));
+    const auto res = std::static_pointer_cast<Fast::Texture>(ResourceLoad(name));
 
     if (res != nullptr) {
         return res->ImageDataSize;
@@ -136,7 +136,7 @@ size_t ResourceGetTexSizeByName(const char* name) {
 }
 
 size_t ResourceGetTexSizeByCrc(uint64_t crc) {
-    const auto res = static_pointer_cast<Fast::Texture>(ResourceLoad(crc));
+    const auto res = std::static_pointer_cast<Fast::Texture>(ResourceLoad(crc));
 
     if (res != nullptr) {
         return res->ImageDataSize;

--- a/src/public/bridge/resourcebridge.h
+++ b/src/public/bridge/resourcebridge.h
@@ -10,7 +10,6 @@
 #include "resource/Resource.h"
 #include <memory>
 
-
 std::shared_ptr<Ship::IResource> ResourceLoad(const char* name);
 std::shared_ptr<Ship::IResource> ResourceLoad(uint64_t crc);
 template <class T> std::shared_ptr<T> ResourceLoad(const char* name) {

--- a/src/public/bridge/resourcebridge.h
+++ b/src/public/bridge/resourcebridge.h
@@ -12,10 +12,10 @@
 std::shared_ptr<Ship::IResource> ResourceLoad(const char* name);
 std::shared_ptr<Ship::IResource> ResourceLoad(uint64_t crc);
 template <class T> std::shared_ptr<T> ResourceLoad(const char* name) {
-    return static_pointer_cast<T>(ResourceLoad(name));
+    return std::static_pointer_cast<T>(ResourceLoad(name));
 }
 template <class T> std::shared_ptr<T> ResourceLoad(uint64_t crc) {
-    return static_pointer_cast<T>(ResourceLoad(crc));
+    return std::static_pointer_cast<T>(ResourceLoad(crc));
 }
 
 extern "C" {

--- a/src/public/bridge/resourcebridge.h
+++ b/src/public/bridge/resourcebridge.h
@@ -8,6 +8,8 @@
 #ifdef __cplusplus
 #include "resource/type/Texture.h"
 #include "resource/Resource.h"
+#include <memory>
+
 
 std::shared_ptr<Ship::IResource> ResourceLoad(const char* name);
 std::shared_ptr<Ship::IResource> ResourceLoad(uint64_t crc);


### PR DESCRIPTION
Had to add std:: in front of the static_pointer_cast to prevent problems. Every other presence of static_pointer_cast in the project seems to be std::static_pointer_cast, so i think this is the right thing to do. 
I had linux g++/gcc and clang/clang++ failing to compile for me because of it (may have just been a me thing, specific distro problems, bad compiler settings, etc). Now it also matches the rest of the project.

---AI PR SUMMARY BELOW---

This pull request includes changes to the `src/public/bridge/resourcebridge.cpp` and `src/public/bridge/resourcebridge.h` files to ensure the correct usage of `std::static_pointer_cast` for type casting shared pointers.

The most important changes include:

### Code Consistency and Correctness:

* [`src/public/bridge/resourcebridge.cpp`](diffhunk://#diff-2bb3dfc02a92d5eef11b00270b622fe0facf73c5a059fe3e9c8e3f405e67bd41L84-R84): Replaced `static_pointer_cast` with `std::static_pointer_cast` in multiple functions to ensure proper namespace usage. [[1]](diffhunk://#diff-2bb3dfc02a92d5eef11b00270b622fe0facf73c5a059fe3e9c8e3f405e67bd41L84-R84) [[2]](diffhunk://#diff-2bb3dfc02a92d5eef11b00270b622fe0facf73c5a059fe3e9c8e3f405e67bd41L95-R95) [[3]](diffhunk://#diff-2bb3dfc02a92d5eef11b00270b622fe0facf73c5a059fe3e9c8e3f405e67bd41L106-R106) [[4]](diffhunk://#diff-2bb3dfc02a92d5eef11b00270b622fe0facf73c5a059fe3e9c8e3f405e67bd41L117-R117) [[5]](diffhunk://#diff-2bb3dfc02a92d5eef11b00270b622fe0facf73c5a059fe3e9c8e3f405e67bd41L128-R128) [[6]](diffhunk://#diff-2bb3dfc02a92d5eef11b00270b622fe0facf73c5a059fe3e9c8e3f405e67bd41L139-R139)

* [`src/public/bridge/resourcebridge.h`](diffhunk://#diff-ccc691e4c260221375530ddca3fc4188fd2661c03ab6ce885b548b47f1a0d822R11-R19): Updated template functions to use `std::static_pointer_cast` instead of `static_pointer_cast` for consistency and correctness.

### Dependency Management:

* [`src/public/bridge/resourcebridge.h`](diffhunk://#diff-ccc691e4c260221375530ddca3fc4188fd2661c03ab6ce885b548b47f1a0d822R11-R19): Added the `<memory>` header to include the definition of `std::static_pointer_cast`.