### PR TITLE
Texture Scrolling Interpolation

### DIFF
--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -3224,7 +3224,7 @@ typedef union Gfx {
 
 
 
-#define gDPSetTileSizeInterp(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_SETTILESIZE_INTERP, t, uls, ult, lrs, lrt)
+#define __gDPSetTileSizeInterp(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_SETTILESIZE_INTERP, t, uls, ult, lrs, lrt)
 #define gDPSetTileSize(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_SETTILESIZE, t, uls, ult, lrs, lrt)
 #define gsDPSetTileSize(t, uls, ult, lrs, lrt) gsDPLoadTileGeneric(G_SETTILESIZE, t, uls, ult, lrs, lrt)
 #define gDPLoadTile(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_LOADTILE, t, uls, ult, lrs, lrt)

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -191,6 +191,8 @@
 #define G_READFB 0x3e
 #define G_SETINTENSITY 0x40
 #define G_LOAD_SHADER 0x43
+#define G_SETTILESIZE_INTERP 0x44
+#define G_SETTARGETINTERPINDEX 0x45
 
 /*
  * The following commands are the "generated" RDP commands; the user
@@ -3212,6 +3214,17 @@ typedef union Gfx {
             _SHIFTL(tile, 24, 3) | _SHIFTL(lrs, 12, 12) | _SHIFTL(lrt, 0, 12) \
     }
 
+#define gDPSetInterpolation(pkt, index) \
+    _DW({                                                                                 \
+        Gfx* _g = (Gfx*)(pkt);                                                            \
+                                                                                          \
+        _g->words.w0 = G_SETTARGETINTERPINDEX << 24;												\
+        _g->words.w1 = index; \
+    })
+
+
+
+#define gDPSetTileSizeInterp(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_SETTILESIZE_INTERP, t, uls, ult, lrs, lrt)
 #define gDPSetTileSize(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_SETTILESIZE, t, uls, ult, lrs, lrt)
 #define gsDPSetTileSize(t, uls, ult, lrs, lrt) gsDPLoadTileGeneric(G_SETTILESIZE, t, uls, ult, lrs, lrt)
 #define gDPLoadTile(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_LOADTILE, t, uls, ult, lrs, lrt)

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -3214,17 +3214,16 @@ typedef union Gfx {
             _SHIFTL(tile, 24, 3) | _SHIFTL(lrs, 12, 12) | _SHIFTL(lrt, 0, 12) \
     }
 
-#define gDPSetInterpolation(pkt, index) \
-    _DW({                                                                                 \
-        Gfx* _g = (Gfx*)(pkt);                                                            \
-                                                                                          \
-        _g->words.w0 = G_SETTARGETINTERPINDEX << 24;												\
-        _g->words.w1 = index; \
+#define gDPSetInterpolation(pkt, index)              \
+    _DW({                                            \
+        Gfx* _g = (Gfx*)(pkt);                       \
+                                                     \
+        _g->words.w0 = G_SETTARGETINTERPINDEX << 24; \
+        _g->words.w1 = index;                        \
     })
 
-
-
-#define __gDPSetTileSizeInterp(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_SETTILESIZE_INTERP, t, uls, ult, lrs, lrt)
+#define __gDPSetTileSizeInterp(pkt, t, uls, ult, lrs, lrt) \
+    gDPLoadTileGeneric(pkt, G_SETTILESIZE_INTERP, t, uls, ult, lrs, lrt)
 #define gDPSetTileSize(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_SETTILESIZE, t, uls, ult, lrs, lrt)
 #define gsDPSetTileSize(t, uls, ult, lrs, lrt) gsDPLoadTileGeneric(G_SETTILESIZE, t, uls, ult, lrs, lrt)
 #define gDPLoadTile(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_LOADTILE, t, uls, ult, lrs, lrt)

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -125,6 +125,7 @@ static struct GfxRenderingAPI* gfx_rapi;
 static int markerOn;
 uintptr_t gSegmentPointers[MAX_SEGMENT_POINTERS];
 int gInterpolationIndex = 0;
+int gInterpolationIndexTarget = 0;
 
 struct FBInfo {
     uint32_t orig_width, orig_height;       // Original shape
@@ -3626,6 +3627,22 @@ bool gfx_set_tile_size_handler_rdp(F3DGfx** cmd0) {
     return false;
 }
 
+bool gfx_set_tile_size_interp_handler_rdp(F3DGfx** cmd0) {
+	F3DGfx* cmd = *cmd0;
+
+	if (gInterpolationIndex == gInterpolationIndexTarget)
+		gfx_dp_set_tile_size(C1(24, 3), C0(12, 12), C0(0, 12), C1(12, 12), C1(0, 12));
+	
+	return false;
+}
+
+bool gfx_set_interpolation_index_target(F3DGfx** cmd0) {
+	F3DGfx* cmd = *cmd0;
+
+	gInterpolationIndexTarget = cmd->words.w1;
+	return false;
+}
+
 bool gfx_load_tlut_handler_rdp(F3DGfx** cmd0) {
     F3DGfx* cmd = *cmd0;
 
@@ -3869,7 +3886,9 @@ class UcodeHandler {
 };
 
 static constexpr UcodeHandler rdpHandlers = {
-    { RDP_G_TEXRECT, { "G_TEXRECT", gfx_tex_rect_and_flip_handler_rdp } },           // G_TEXRECT (-28)
+	{ RDP_G_SETTARGETINTERPINDEX, { "G_SETTARGETINTERPINDEX", gfx_set_interpolation_index_target } },				// G_SETTARGETINTERPINDEX
+	{ RDP_G_SETTILESIZE_INTERP, { "G_SETTILESIZE_INTERP", gfx_set_tile_size_interp_handler_rdp } },       // G_SETTILESIZE_INTERP
+	{ RDP_G_TEXRECT, { "G_TEXRECT", gfx_tex_rect_and_flip_handler_rdp } },           // G_TEXRECT (-28)
     { RDP_G_TEXRECTFLIP, { "G_TEXRECTFLIP", gfx_tex_rect_and_flip_handler_rdp } },   // G_TEXRECTFLIP (-27)
     { RDP_G_RDPLOADSYNC, { "G_RDPLOADSYNC", gfx_stubbed_command_handler } },         // G_RDPLOADSYNC (-26)
     { RDP_G_RDPPIPESYNC, { "G_RDPPIPESYNC", gfx_stubbed_command_handler } },         // G_RDPPIPESYNC (-25)
@@ -3879,7 +3898,7 @@ static constexpr UcodeHandler rdpHandlers = {
     { RDP_G_SETPRIMDEPTH, { "G_SETPRIMDEPTH", gfx_set_prim_depth_handler_rdp } },    // G_SETPRIMDEPTH (-18)
     { RDP_G_RDPSETOTHERMODE, { "G_RDPSETOTHERMODE", gfx_rdp_set_other_mode_rdp } },  // G_RDPSETOTHERMODE (-17)
     { RDP_G_LOADTLUT, { "G_LOADTLUT", gfx_load_tlut_handler_rdp } },                 // G_LOADTLUT (-16)
-    { RDP_G_SETTILESIZE, { "G_SETTILESIZE", gfx_set_tile_size_handler_rdp } },       // G_SETTILESIZE (-14)
+	{ RDP_G_SETTILESIZE, { "G_SETTILESIZE", gfx_set_tile_size_handler_rdp } },       // G_SETTILESIZE (-14)
     { RDP_G_LOADBLOCK, { "G_LOADBLOCK", gfx_load_block_handler_rdp } },              // G_LOADBLOCK (-13)
     { RDP_G_LOADTILE, { "G_LOADTILE", gfx_load_tile_handler_rdp } },                 // G_LOADTILE (-12)
     { RDP_G_SETTILE, { "G_SETTILE", gfx_set_tile_handler_rdp } },                    // G_SETTILE (-11)

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2682,7 +2682,7 @@ static void gfx_s2dex_rect_copy(F3DuObjSprite* spr) {
     int testY = (realY + (realH / realSH));
 
     gfx_dp_texture_rectangle(realX << 2, realY << 2, testX << 2, testY << 2, G_TX_RENDERTILE,
-                             g_rdp.texture_tile[0].uls << 3, g_rdp.texture_tile[0].ult << 3, (float)(1 << 10) * realSW,
+                             (s32)g_rdp.texture_tile[0].uls << 3, (s32)g_rdp.texture_tile[0].ult << 3, (float)(1 << 10) * realSW,
                              (float)(1 << 10) * realSH, false);
 }
 
@@ -3631,8 +3631,22 @@ bool gfx_set_tile_size_interp_handler_rdp(F3DGfx** cmd0) {
 	F3DGfx* cmd = *cmd0;
 
 	if (gInterpolationIndex == gInterpolationIndexTarget)
+	{
+		int tile = C1(24, 3);
 		gfx_dp_set_tile_size(C1(24, 3), C0(12, 12), C0(0, 12), C1(12, 12), C1(0, 12));
-	
+		++(*cmd0);
+		memcpy(&g_rdp.texture_tile[tile].uls, &(*cmd0)->words.w0, sizeof(float));
+		memcpy(&g_rdp.texture_tile[tile].ult, &(*cmd0)->words.w1, sizeof(float));
+		++(*cmd0);
+		memcpy(&g_rdp.texture_tile[tile].lrs, &(*cmd0)->words.w0, sizeof(float));
+		memcpy(&g_rdp.texture_tile[tile].lrt, &(*cmd0)->words.w1, sizeof(float));
+	}
+	else
+	{
+		++(*cmd0);
+		++(*cmd0);
+	}
+
 	return false;
 }
 

--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2682,8 +2682,8 @@ static void gfx_s2dex_rect_copy(F3DuObjSprite* spr) {
     int testY = (realY + (realH / realSH));
 
     gfx_dp_texture_rectangle(realX << 2, realY << 2, testX << 2, testY << 2, G_TX_RENDERTILE,
-                             (s32)g_rdp.texture_tile[0].uls << 3, (s32)g_rdp.texture_tile[0].ult << 3, (float)(1 << 10) * realSW,
-                             (float)(1 << 10) * realSH, false);
+                             (s32)g_rdp.texture_tile[0].uls << 3, (s32)g_rdp.texture_tile[0].ult << 3,
+                             (float)(1 << 10) * realSW, (float)(1 << 10) * realSH, false);
 }
 
 static inline void* seg_addr(uintptr_t w1) {
@@ -3628,33 +3628,30 @@ bool gfx_set_tile_size_handler_rdp(F3DGfx** cmd0) {
 }
 
 bool gfx_set_tile_size_interp_handler_rdp(F3DGfx** cmd0) {
-	F3DGfx* cmd = *cmd0;
+    F3DGfx* cmd = *cmd0;
 
-	if (gInterpolationIndex == gInterpolationIndexTarget)
-	{
-		int tile = C1(24, 3);
-		gfx_dp_set_tile_size(C1(24, 3), C0(12, 12), C0(0, 12), C1(12, 12), C1(0, 12));
-		++(*cmd0);
-		memcpy(&g_rdp.texture_tile[tile].uls, &(*cmd0)->words.w0, sizeof(float));
-		memcpy(&g_rdp.texture_tile[tile].ult, &(*cmd0)->words.w1, sizeof(float));
-		++(*cmd0);
-		memcpy(&g_rdp.texture_tile[tile].lrs, &(*cmd0)->words.w0, sizeof(float));
-		memcpy(&g_rdp.texture_tile[tile].lrt, &(*cmd0)->words.w1, sizeof(float));
-	}
-	else
-	{
-		++(*cmd0);
-		++(*cmd0);
-	}
+    if (gInterpolationIndex == gInterpolationIndexTarget) {
+        int tile = C1(24, 3);
+        gfx_dp_set_tile_size(C1(24, 3), C0(12, 12), C0(0, 12), C1(12, 12), C1(0, 12));
+        ++(*cmd0);
+        memcpy(&g_rdp.texture_tile[tile].uls, &(*cmd0)->words.w0, sizeof(float));
+        memcpy(&g_rdp.texture_tile[tile].ult, &(*cmd0)->words.w1, sizeof(float));
+        ++(*cmd0);
+        memcpy(&g_rdp.texture_tile[tile].lrs, &(*cmd0)->words.w0, sizeof(float));
+        memcpy(&g_rdp.texture_tile[tile].lrt, &(*cmd0)->words.w1, sizeof(float));
+    } else {
+        ++(*cmd0);
+        ++(*cmd0);
+    }
 
-	return false;
+    return false;
 }
 
 bool gfx_set_interpolation_index_target(F3DGfx** cmd0) {
-	F3DGfx* cmd = *cmd0;
+    F3DGfx* cmd = *cmd0;
 
-	gInterpolationIndexTarget = cmd->words.w1;
-	return false;
+    gInterpolationIndexTarget = cmd->words.w1;
+    return false;
 }
 
 bool gfx_load_tlut_handler_rdp(F3DGfx** cmd0) {
@@ -3900,9 +3897,11 @@ class UcodeHandler {
 };
 
 static constexpr UcodeHandler rdpHandlers = {
-	{ RDP_G_SETTARGETINTERPINDEX, { "G_SETTARGETINTERPINDEX", gfx_set_interpolation_index_target } },				// G_SETTARGETINTERPINDEX
-	{ RDP_G_SETTILESIZE_INTERP, { "G_SETTILESIZE_INTERP", gfx_set_tile_size_interp_handler_rdp } },       // G_SETTILESIZE_INTERP
-	{ RDP_G_TEXRECT, { "G_TEXRECT", gfx_tex_rect_and_flip_handler_rdp } },           // G_TEXRECT (-28)
+    { RDP_G_SETTARGETINTERPINDEX,
+      { "G_SETTARGETINTERPINDEX", gfx_set_interpolation_index_target } }, // G_SETTARGETINTERPINDEX
+    { RDP_G_SETTILESIZE_INTERP,
+      { "G_SETTILESIZE_INTERP", gfx_set_tile_size_interp_handler_rdp } },            // G_SETTILESIZE_INTERP
+    { RDP_G_TEXRECT, { "G_TEXRECT", gfx_tex_rect_and_flip_handler_rdp } },           // G_TEXRECT (-28)
     { RDP_G_TEXRECTFLIP, { "G_TEXRECTFLIP", gfx_tex_rect_and_flip_handler_rdp } },   // G_TEXRECTFLIP (-27)
     { RDP_G_RDPLOADSYNC, { "G_RDPLOADSYNC", gfx_stubbed_command_handler } },         // G_RDPLOADSYNC (-26)
     { RDP_G_RDPPIPESYNC, { "G_RDPPIPESYNC", gfx_stubbed_command_handler } },         // G_RDPPIPESYNC (-25)
@@ -3912,7 +3911,7 @@ static constexpr UcodeHandler rdpHandlers = {
     { RDP_G_SETPRIMDEPTH, { "G_SETPRIMDEPTH", gfx_set_prim_depth_handler_rdp } },    // G_SETPRIMDEPTH (-18)
     { RDP_G_RDPSETOTHERMODE, { "G_RDPSETOTHERMODE", gfx_rdp_set_other_mode_rdp } },  // G_RDPSETOTHERMODE (-17)
     { RDP_G_LOADTLUT, { "G_LOADTLUT", gfx_load_tlut_handler_rdp } },                 // G_LOADTLUT (-16)
-	{ RDP_G_SETTILESIZE, { "G_SETTILESIZE", gfx_set_tile_size_handler_rdp } },       // G_SETTILESIZE (-14)
+    { RDP_G_SETTILESIZE, { "G_SETTILESIZE", gfx_set_tile_size_handler_rdp } },       // G_SETTILESIZE (-14)
     { RDP_G_LOADBLOCK, { "G_LOADBLOCK", gfx_load_block_handler_rdp } },              // G_LOADBLOCK (-13)
     { RDP_G_LOADTILE, { "G_LOADTILE", gfx_load_tile_handler_rdp } },                 // G_LOADTILE (-12)
     { RDP_G_SETTILE, { "G_SETTILE", gfx_set_tile_handler_rdp } },                    // G_SETTILE (-11)

--- a/src/graphic/Fast3D/gfx_pc.h
+++ b/src/graphic/Fast3D/gfx_pc.h
@@ -184,7 +184,7 @@ struct RDP {
         uint8_t cms, cmt;
         uint8_t shifts, shiftt;
         float uls, ult, lrs, lrt; // U10.2
-        uint16_t tmem;               // 0-511, in 64-bit word units
+        uint16_t tmem;            // 0-511, in 64-bit word units
         uint32_t line_size_bytes;
         uint8_t palette;
         uint8_t tmem_index; // 0 or 1 for offset 0 kB or offset 2 kB, respectively

--- a/src/graphic/Fast3D/gfx_pc.h
+++ b/src/graphic/Fast3D/gfx_pc.h
@@ -183,7 +183,7 @@ struct RDP {
         uint8_t siz;
         uint8_t cms, cmt;
         uint8_t shifts, shiftt;
-        uint16_t uls, ult, lrs, lrt; // U10.2
+        float uls, ult, lrs, lrt; // U10.2
         uint16_t tmem;               // 0-511, in 64-bit word units
         uint32_t line_size_bytes;
         uint8_t palette;

--- a/src/graphic/Fast3D/lus_gbi.h
+++ b/src/graphic/Fast3D/lus_gbi.h
@@ -67,6 +67,8 @@ constexpr int8_t OTR_G_REGBLENDEDTEX = OPCODE(0x3f);
 constexpr int8_t OTR_G_SETINTENSITY = OPCODE(0x40);
 constexpr int8_t OTR_G_MOVEMEM_HASH = OPCODE(0x42);
 constexpr int8_t OTR_G_LOAD_SHADER = OPCODE(0x43);
+constexpr int8_t RDP_G_SETTILESIZE_INTERP = OPCODE(0x44);
+constexpr int8_t RDP_G_SETTARGETINTERPINDEX = OPCODE(0x45);
 
 /*
  * The following commands are the "generated" RDP commands; the user


### PR DESCRIPTION
**Note: This should not be merged until #834 is.**

This is used for texture scrolling in Ship and 2Ship. It works very similarly to #834, having the game calculate where texture coordinates will be during interpolated frames and then having Fast3D take advantage of that data.