### PR TITLE
Fix High Mouse Delta On Focus

### DIFF
--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -103,6 +103,7 @@ static struct {
     bool in_focus;
     RAWINPUTDEVICE raw_input_device[1];
     POINT raw_mouse_delta_buf;
+    POINT prev_mouse_cursor_pos;
 
     void (*on_fullscreen_changed)(bool is_now_fullscreen);
     bool (*on_key_down)(int scancode);
@@ -469,6 +470,8 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
             break;
         case WM_SETFOCUS:
             dxgi.in_focus = true;
+            gfx_dxgi_get_mouse_pos(reinterpret_cast<int32_t*>(&dxgi.prev_mouse_cursor_pos.x),
+                                   reinterpret_cast<int32_t*>(&dxgi.prev_mouse_cursor_pos.y));
             if (dxgi.is_mouse_captured) {
                 apply_mouse_capture_clip();
             }
@@ -617,13 +620,10 @@ static void gfx_dxgi_get_mouse_delta(int32_t* x, int32_t* y) {
         dxgi.raw_mouse_delta_buf.x = 0;
         dxgi.raw_mouse_delta_buf.y = 0;
     } else {
-        static int32_t prev_x = 0, prev_y = 0;
         int32_t current_x, current_y;
         gfx_dxgi_get_mouse_pos(&current_x, &current_y);
-        *x = current_x - prev_x;
-        *y = current_y - prev_y;
-        prev_x = current_x;
-        prev_y = current_y;
+        *x = current_x - dxgi.prev_mouse_cursor_pos.x;
+        *y = current_y - dxgi.prev_mouse_cursor_pos.y;
     }
 }
 

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -625,11 +625,11 @@ static void gfx_dxgi_get_mouse_delta(int32_t* x, int32_t* y) {
     }
 
     if (!dxgi.is_mouse_hovered) {
-      *x = 0;
-       *y = 0;
-       gfx_dxgi_get_mouse_pos(&current_x, &current_y);
-       dxgi.prev_mouse_cursor_pos.x = current_x;
-       dxgi.prev_mouse_cursor_pos.y = current_y;
+        *x = 0;
+        *y = 0;
+        gfx_dxgi_get_mouse_pos(&current_x, &current_y);
+        dxgi.prev_mouse_cursor_pos.x = current_x;
+        dxgi.prev_mouse_cursor_pos.y = current_y;
     } else if (dxgi.is_mouse_captured) {
         *x = dxgi.raw_mouse_delta_buf.x;
         *y = dxgi.raw_mouse_delta_buf.y;

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -494,7 +494,7 @@ void gfx_dxgi_init(const char* game_name, const char* gfx_api_name, bool start_i
     dxgi.qpc_freq = qpc_freq.QuadPart;
 
     dxgi.target_fps = 60;
-    dxgi.maximum_frame_latency = 1;
+    dxgi.maximum_frame_latency = 2;
 
     // Use high-resolution timer by default on Windows 10 (so that NtSetTimerResolution (...) hacks are not needed)
     dxgi.timer = CreateWaitableTimerExW(nullptr, nullptr, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -455,8 +455,6 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
             break;
         case WM_MOUSELEAVE:
             dxgi.is_mouse_hovered = false;
-            //gfx_dxgi_get_mouse_pos(reinterpret_cast<int32_t*>(&dxgi.prev_mouse_cursor_pos.x),
-            //reinterpret_cast<int32_t*>(&dxgi.prev_mouse_cursor_pos.y));
             break;
         case WM_DROPFILES:
             DragQueryFileA((HDROP)w_param, 0, fileName, 256);

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -99,6 +99,7 @@ static struct {
     float mouse_wheel[2];
     LARGE_INTEGER previous_present_time;
     bool is_mouse_captured;
+    bool is_mouse_hovered;
     bool in_focus;
     RAWINPUTDEVICE raw_input_device[1];
     POINT raw_mouse_delta_buf;
@@ -428,6 +429,12 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
             on_mouse_button_up(btn);
             break;
         }
+        case WM_MOUSEMOVE:
+            dxgi.is_mouse_hovered = true;
+            break;
+        case WM_MOUSELEAVE:
+            dxgi.is_mouse_hovered = false;
+            break;
         case WM_MOUSEHWHEEL:
             dxgi.mouse_wheel[0] = GET_WHEEL_DELTA_WPARAM(w_param) / WHEEL_DELTA;
             break;
@@ -601,7 +608,7 @@ static void gfx_dxgi_get_mouse_pos(int32_t* x, int32_t* y) {
 }
 
 static void gfx_dxgi_get_mouse_delta(int32_t* x, int32_t* y) {
-    if (!dxgi.in_focus) {
+    if (!dxgi.is_mouse_hovered) {
         *x = 0;
         *y = 0;
     } else if (dxgi.is_mouse_captured) {

--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -857,12 +857,8 @@ static bool gfx_dxgi_is_frame_ready() {
     // dxgi.length_in_vsync_frames is used as present interval. Present interval >1 (aka fractional V-Sync)
     // breaks VRR and introduces even more input lag than capping via normal V-Sync does.
     // Get the present interval the user wants instead (V-Sync toggle).
-    if (dxgi.is_vsync_enabled !=
-        Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1)) {
-        // Make sure only 0 or 1 is set, as present interval technically accepts a range from 0 to 4.
-        dxgi.is_vsync_enabled =
-            !!Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1);
-    }
+    dxgi.is_vsync_enabled =
+        (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1) ? 1 : 0);
     dxgi.length_in_vsync_frames = dxgi.is_vsync_enabled;
     return true;
 }

--- a/src/graphic/Fast3D/gfx_dxgi.h
+++ b/src/graphic/Fast3D/gfx_dxgi.h
@@ -16,6 +16,7 @@ HWND gfx_dxgi_get_h_wnd();
 IDXGISwapChain1* gfx_dxgi_get_swap_chain();
 void ThrowIfFailed(HRESULT res);
 void ThrowIfFailed(HRESULT res, HWND h_wnd, const char* message);
+void gfx_dxgi_get_mouse_pos(int32_t* x, int32_t* y);
 #endif
 
 extern "C" struct GfxWindowManagerAPI gfx_dxgi_api;

--- a/src/graphic/Fast3D/gfx_dxgi.h
+++ b/src/graphic/Fast3D/gfx_dxgi.h
@@ -16,7 +16,6 @@ HWND gfx_dxgi_get_h_wnd();
 IDXGISwapChain1* gfx_dxgi_get_swap_chain();
 void ThrowIfFailed(HRESULT res);
 void ThrowIfFailed(HRESULT res, HWND h_wnd, const char* message);
-void gfx_dxgi_get_mouse_pos(int32_t* x, int32_t* y);
 #endif
 
 extern "C" struct GfxWindowManagerAPI gfx_dxgi_api;


### PR DESCRIPTION
OpenGL/SDL2 only updates mouse delta if the mouse is hovering over the game window. Regardless of which window is focused.

Currently, DX only updates the mouse delta if the window has focus. If you focus another window, then focus back to a HM64 game window, delta will go from zero to a really high value for 1 tick like 800 and then back to zero (presuming the mouse is not moving). This results in the camera snapping around really fast depending on the implementation of the free camera.

This changes DX to instead check if the mouse is hovering over the window regardless of mouse focus. This seems to make the functionality consistent with OpenGL/SDL2

Also, another fix is that prev_mouse must be set to a valid value before calculating delta.