### PR TITLE
Improve compile times

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -6,6 +6,9 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include "install_config.h"
 #include "graphic/Fast3D/debug/GfxDebugger.h"
+#include "config/ConsoleVariable.h"
+#include "controller/controldeck/ControlDeck.h"
+#include "debug/CrashHandler.h"
 
 #ifdef _WIN32
 #include <tchar.h>
@@ -16,6 +19,7 @@
 #include <unistd.h>
 #include <pwd.h>
 #endif
+
 
 namespace Ship {
 std::weak_ptr<Context> Context::mContext;

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -20,7 +20,6 @@
 #include <pwd.h>
 #endif
 
-
 namespace Ship {
 std::weak_ptr<Context> Context::mContext;
 

--- a/src/Context.h
+++ b/src/Context.h
@@ -7,25 +7,23 @@
 #include <unordered_map>
 #include "audio/Audio.h"
 
-namespace spdlog
-{
-	class logger;
+namespace spdlog {
+class logger;
 }
 
-namespace Fast
-{
-	class GfxDebugger;
+namespace Fast {
+class GfxDebugger;
 }
 
 namespace Ship {
 
-	class Console;
-	class ConsoleVariable;
-	class ControlDeck;
-	class CrashHandler;
-	class Window;
-	class Config;
-	class ResourceManager;
+class Console;
+class ConsoleVariable;
+class ControlDeck;
+class CrashHandler;
+class Window;
+class Config;
+class ResourceManager;
 
 class Context {
   public:

--- a/src/Context.h
+++ b/src/Context.h
@@ -5,18 +5,27 @@
 #include <unordered_set>
 #include <vector>
 #include <unordered_map>
-#include <spdlog/spdlog.h>
-#include "config/Config.h"
-#include "resource/ResourceManager.h"
-#include "controller/controldeck/ControlDeck.h"
-#include "debug/CrashHandler.h"
 #include "audio/Audio.h"
-#include "window/Window.h"
-#include "config/ConsoleVariable.h"
-#include "debug/Console.h"
-#include "graphic/Fast3D/debug/GfxDebugger.h"
+
+namespace spdlog
+{
+	class logger;
+}
+
+namespace Fast
+{
+	class GfxDebugger;
+}
 
 namespace Ship {
+
+	class Console;
+	class ConsoleVariable;
+	class ControlDeck;
+	class CrashHandler;
+	class Window;
+	class Config;
+	class ResourceManager;
 
 class Context {
   public:

--- a/src/audio/Audio.cpp
+++ b/src/audio/Audio.cpp
@@ -1,6 +1,7 @@
 #include "Audio.h"
 
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 

--- a/src/controller/controldevice/controller/ControllerButton.cpp
+++ b/src/controller/controldevice/controller/ControllerButton.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 
 #include "Context.h"
+#include "window/Window.h"
 
 namespace Ship {
 ControllerButton::ControllerButton(uint8_t portIndex, CONTROLLERBUTTONS_T bitmask)

--- a/src/controller/controldevice/controller/ControllerStick.cpp
+++ b/src/controller/controldevice/controller/ControllerStick.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 
 #include "Context.h"
+#include "window/Window.h"
 
 // for some reason windows isn't seeing M_PI
 // this is copied from my system's math.h

--- a/src/controller/controldevice/controller/mapping/factories/AxisDirectionMappingFactory.cpp
+++ b/src/controller/controldevice/controller/mapping/factories/AxisDirectionMappingFactory.cpp
@@ -13,6 +13,8 @@
 #include "controller/controldevice/controller/mapping/keyboard/KeyboardScancodes.h"
 #include "controller/controldevice/controller/mapping/mouse/WheelHandler.h"
 
+#include "controller/controldeck/ControlDeck.h"
+
 namespace Ship {
 std::shared_ptr<ControllerAxisDirectionMapping>
 AxisDirectionMappingFactory::CreateAxisDirectionMappingFromConfig(uint8_t portIndex, StickIndex stickIndex,

--- a/src/controller/controldevice/controller/mapping/factories/ButtonMappingFactory.cpp
+++ b/src/controller/controldevice/controller/mapping/factories/ButtonMappingFactory.cpp
@@ -10,6 +10,7 @@
 #include "controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToButtonMapping.h"
 #include "controller/controldevice/controller/mapping/keyboard/KeyboardScancodes.h"
 #include "controller/controldevice/controller/mapping/mouse/WheelHandler.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 std::shared_ptr<ControllerButtonMapping> ButtonMappingFactory::CreateButtonMappingFromConfig(uint8_t portIndex,

--- a/src/controller/controldevice/controller/mapping/factories/GyroMappingFactory.cpp
+++ b/src/controller/controldevice/controller/mapping/factories/GyroMappingFactory.cpp
@@ -4,6 +4,7 @@
 #include "utils/StringHelper.h"
 #include "libultraship/libultra/controller.h"
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 std::shared_ptr<ControllerGyroMapping> GyroMappingFactory::CreateGyroMappingFromConfig(uint8_t portIndex,

--- a/src/controller/controldevice/controller/mapping/factories/LEDMappingFactory.cpp
+++ b/src/controller/controldevice/controller/mapping/factories/LEDMappingFactory.cpp
@@ -3,6 +3,7 @@
 #include "public/bridge/consolevariablebridge.h"
 #include "utils/StringHelper.h"
 #include "libultraship/libultra/controller.h"
+#include "controller/controldeck/ControlDeck.h"
 #include "Context.h"
 
 namespace Ship {

--- a/src/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.cpp
+++ b/src/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.cpp
@@ -4,6 +4,7 @@
 #include "utils/StringHelper.h"
 #include "libultraship/libultra/controller.h"
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 std::shared_ptr<ControllerRumbleMapping> RumbleMappingFactory::CreateRumbleMappingFromConfig(uint8_t portIndex,

--- a/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAnyMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAnyMapping.cpp
@@ -3,6 +3,7 @@
 
 #include "utils/StringHelper.h"
 #include "window/gui/IconsFontAwesome4.h"
+#include "window/Window.h"
 
 namespace Ship {
 KeyboardKeyToAnyMapping::KeyboardKeyToAnyMapping(KbScancode scancode)

--- a/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAxisDirectionMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAxisDirectionMapping.cpp
@@ -4,6 +4,7 @@
 #include "window/gui/IconsFontAwesome4.h"
 #include "public/bridge/consolevariablebridge.h"
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 KeyboardKeyToAxisDirectionMapping::KeyboardKeyToAxisDirectionMapping(uint8_t portIndex, StickIndex stickIndex,

--- a/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToButtonMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToButtonMapping.cpp
@@ -2,6 +2,7 @@
 #include <spdlog/spdlog.h>
 #include "utils/StringHelper.h"
 #include "public/bridge/consolevariablebridge.h"
+#include "controller/controldeck/ControlDeck.h"
 #include "Context.h"
 
 namespace Ship {

--- a/src/controller/controldevice/controller/mapping/mouse/MouseButtonToAxisDirectionMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/mouse/MouseButtonToAxisDirectionMapping.cpp
@@ -4,6 +4,7 @@
 #include "window/gui/IconsFontAwesome4.h"
 #include "public/bridge/consolevariablebridge.h"
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 MouseButtonToAxisDirectionMapping::MouseButtonToAxisDirectionMapping(uint8_t portIndex, StickIndex stickIndex,

--- a/src/controller/controldevice/controller/mapping/mouse/MouseButtonToButtonMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/mouse/MouseButtonToButtonMapping.cpp
@@ -2,6 +2,7 @@
 #include <spdlog/spdlog.h>
 #include "utils/StringHelper.h"
 #include "public/bridge/consolevariablebridge.h"
+#include "controller/controldeck/ControlDeck.h"
 #include "Context.h"
 
 namespace Ship {

--- a/src/controller/controldevice/controller/mapping/mouse/MouseWheelToAxisDirectionMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/mouse/MouseWheelToAxisDirectionMapping.cpp
@@ -6,6 +6,7 @@
 #include "public/bridge/consolevariablebridge.h"
 #include "Context.h"
 #include "WheelHandler.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 MouseWheelToAxisDirectionMapping::MouseWheelToAxisDirectionMapping(uint8_t portIndex, StickIndex stickIndex,

--- a/src/controller/controldevice/controller/mapping/mouse/MouseWheelToButtonMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/mouse/MouseWheelToButtonMapping.cpp
@@ -4,6 +4,7 @@
 #include "public/bridge/consolevariablebridge.h"
 #include "WheelHandler.h"
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 MouseWheelToButtonMapping::MouseWheelToButtonMapping(uint8_t portIndex, CONTROLLERBUTTONS_T bitmask,

--- a/src/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAxisDirectionMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAxisDirectionMapping.cpp
@@ -4,6 +4,7 @@
 #include "window/gui/IconsFontAwesome4.h"
 #include "public/bridge/consolevariablebridge.h"
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 #define MAX_SDL_RANGE (float)INT16_MAX
 

--- a/src/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToButtonMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToButtonMapping.cpp
@@ -4,6 +4,7 @@
 #include "window/gui/IconsFontAwesome4.h"
 #include "public/bridge/consolevariablebridge.h"
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 SDLAxisDirectionToButtonMapping::SDLAxisDirectionToButtonMapping(uint8_t portIndex, CONTROLLERBUTTONS_T bitmask,

--- a/src/controller/controldevice/controller/mapping/sdl/SDLButtonToAxisDirectionMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLButtonToAxisDirectionMapping.cpp
@@ -4,6 +4,7 @@
 #include "window/gui/IconsFontAwesome4.h"
 #include "public/bridge/consolevariablebridge.h"
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 #define MAX_SDL_RANGE (float)INT16_MAX
 

--- a/src/controller/controldevice/controller/mapping/sdl/SDLButtonToButtonMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLButtonToButtonMapping.cpp
@@ -3,6 +3,7 @@
 #include "utils/StringHelper.h"
 #include "window/gui/IconsFontAwesome4.h"
 #include "public/bridge/consolevariablebridge.h"
+#include "controller/controldeck/ControlDeck.h"
 #include "Context.h"
 
 namespace Ship {

--- a/src/controller/controldevice/controller/mapping/sdl/SDLGyroMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLGyroMapping.cpp
@@ -5,6 +5,7 @@
 
 #include "public/bridge/consolevariablebridge.h"
 #include "utils/StringHelper.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 SDLGyroMapping::SDLGyroMapping(uint8_t portIndex, float sensitivity, float neutralPitch, float neutralYaw,

--- a/src/controller/controldevice/controller/mapping/sdl/SDLLEDMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLLEDMapping.cpp
@@ -3,6 +3,7 @@
 #include "public/bridge/consolevariablebridge.h"
 #include "utils/StringHelper.h"
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 SDLLEDMapping::SDLLEDMapping(uint8_t portIndex, uint8_t colorSource, Color_RGB8 savedColor)

--- a/src/controller/controldevice/controller/mapping/sdl/SDLRumbleMapping.cpp
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLRumbleMapping.cpp
@@ -3,6 +3,7 @@
 #include "public/bridge/consolevariablebridge.h"
 #include "utils/StringHelper.h"
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 SDLRumbleMapping::SDLRumbleMapping(uint8_t portIndex, uint8_t lowFrequencyIntensityPercentage,

--- a/src/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.cpp
+++ b/src/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.cpp
@@ -1,6 +1,7 @@
 #include "SDLAddRemoveDeviceEventHandler.h"
 #include <SDL2/SDL.h>
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 namespace Ship {
 

--- a/src/debug/Console.cpp
+++ b/src/debug/Console.cpp
@@ -1,6 +1,7 @@
 #include "Console.h"
 #include "utils/StringHelper.h"
 #include "Context.h"
+#include <spdlog/spdlog.h>
 
 namespace Ship {
 Console::Console() {

--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -1,6 +1,8 @@
 #include "Fast3dWindow.h"
 
 #include "Context.h"
+#include "config/Config.h"
+#include "controller/controldeck/ControlDeck.h"
 #include "public/bridge/consolevariablebridge.h"
 #include "graphic/Fast3D/interpreter.h"
 #include "graphic/Fast3D/gfx_sdl.h"

--- a/src/graphic/Fast3D/gfx_direct3d11.cpp
+++ b/src/graphic/Fast3D/gfx_direct3d11.cpp
@@ -29,6 +29,7 @@
 #include "window/gui/Gui.h"
 #include "Context.h"
 #include "config/ConsoleVariable.h"
+#include "window/Window.h"
 
 #include "gfx_cc.h"
 #include "gfx_rendering_api.h"

--- a/src/graphic/Fast3D/gfx_direct3d_common.cpp
+++ b/src/graphic/Fast3D/gfx_direct3d_common.cpp
@@ -8,6 +8,9 @@
 #include <public/bridge/consolevariablebridge.h>
 #include <resource/factory/ShaderFactory.h>
 #include <Context.h>
+#include <resource/ResourceManager.h>
+#include "spdlog/spdlog.h"
+#include "nlohmann/json.hpp"
 
 #define RAND_NOISE "((random(float3(floor(screenSpace.xy * noise_scale), noise_frame)) + 1.0) / 2.0)"
 

--- a/src/graphic/Fast3D/gfx_metal_shader.cpp
+++ b/src/graphic/Fast3D/gfx_metal_shader.cpp
@@ -18,7 +18,7 @@
 #include <public/bridge/consolevariablebridge.h>
 #include "gfx_metal_shader.h"
 #include <prism/processor.h>
-#include "ResourceManager.h"
+#include "resource/ResourceManager.h"
 
 // MARK: - String Helpers
 

--- a/src/graphic/Fast3D/gfx_metal_shader.cpp
+++ b/src/graphic/Fast3D/gfx_metal_shader.cpp
@@ -19,7 +19,7 @@
 #include "gfx_metal_shader.h"
 #include <prism/processor.h>
 #include "resource/ResourceManager.h"
-
+#include "spdlog/spdlog.h"
 // MARK: - String Helpers
 
 #define RAND_NOISE                                                                                                  \

--- a/src/graphic/Fast3D/gfx_metal_shader.cpp
+++ b/src/graphic/Fast3D/gfx_metal_shader.cpp
@@ -18,6 +18,7 @@
 #include <public/bridge/consolevariablebridge.h>
 #include "gfx_metal_shader.h"
 #include <prism/processor.h>
+#include "ResourceManager.h"
 
 // MARK: - String Helpers
 

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -10,6 +10,7 @@
 
 #include "Context.h"
 #include "config/ConsoleVariable.h"
+#include "controller/controldeck/ControlDeck.h"
 
 #if FOR_WINDOWS
 #include <GL/glew.h>

--- a/src/public/bridge/controllerbridge.cpp
+++ b/src/public/bridge/controllerbridge.cpp
@@ -1,4 +1,5 @@
 #include "public/bridge/controllerbridge.h"
+#include "controller/controldeck/ControlDeck.h"
 #include "Context.h"
 
 extern "C" {

--- a/src/public/bridge/crashhandlerbridge.cpp
+++ b/src/public/bridge/crashhandlerbridge.cpp
@@ -1,5 +1,6 @@
 #include "crashhandlerbridge.h"
 #include "Context.h"
+#include "debug/CrashHandler.h"
 
 void CrashHandlerRegisterCallback(CrashHandlerCallback callback) {
     Ship::Context::GetInstance()->GetCrashHandler()->RegisterCallback(callback);

--- a/src/public/bridge/resourcebridge.cpp
+++ b/src/public/bridge/resourcebridge.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <algorithm>
 #include "utils/StrHash64.h"
+#include "window/Window.h"
 
 std::shared_ptr<Ship::IResource> ResourceLoad(const char* name) {
     return Ship::Context::GetInstance()->GetResourceManager()->LoadResource(name);

--- a/src/resource/File.h
+++ b/src/resource/File.h
@@ -5,9 +5,14 @@
 #include <vector>
 #include <memory>
 #include <stdint.h>
-#include <tinyxml2.h>
 #include "resource/ResourceType.h"
 #include "utils/binarytools/BinaryReader.h"
+
+namespace tinyxml2
+{
+	class XMLDocument;
+	class XMLElement;
+}
 
 namespace Ship {
 class Archive;

--- a/src/resource/File.h
+++ b/src/resource/File.h
@@ -8,11 +8,10 @@
 #include "resource/ResourceType.h"
 #include "utils/binarytools/BinaryReader.h"
 
-namespace tinyxml2
-{
-	class XMLDocument;
-	class XMLElement;
-}
+namespace tinyxml2 {
+class XMLDocument;
+class XMLElement;
+} // namespace tinyxml2
 
 namespace Ship {
 class Archive;

--- a/src/resource/ResourceLoader.cpp
+++ b/src/resource/ResourceLoader.cpp
@@ -8,6 +8,7 @@
 #include "utils/binarytools/BinaryReader.h"
 #include "factory/JsonFactory.h"
 #include "factory/ShaderFactory.h"
+#include <spdlog/spdlog.h>
 
 namespace Ship {
 ResourceLoader::ResourceLoader() {

--- a/src/resource/ResourceLoader.cpp
+++ b/src/resource/ResourceLoader.cpp
@@ -9,6 +9,8 @@
 #include "factory/JsonFactory.h"
 #include "factory/ShaderFactory.h"
 #include <spdlog/spdlog.h>
+#include <tinyxml2.h>
+#include "nlohmann/json.hpp"
 
 namespace Ship {
 ResourceLoader::ResourceLoader() {

--- a/src/resource/archive/Archive.cpp
+++ b/src/resource/archive/Archive.cpp
@@ -9,7 +9,9 @@
 #include "utils/binarytools/MemoryStream.h"
 #include "utils/glob.h"
 #include "utils/StrHash64.h"
+#include "window/Window.h"
 #include <nlohmann/json.hpp>
+#include <tinyxml2.h>
 
 namespace Ship {
 Archive::Archive(const std::string& path)

--- a/src/resource/archive/Archive.h
+++ b/src/resource/archive/Archive.h
@@ -4,8 +4,13 @@
 #include <string>
 #include <unordered_map>
 #include <mutex>
-#include <tinyxml2.h>
 #include "utils/binarytools/BinaryReader.h"
+
+namespace tinyxml2
+{
+	class XMLDocument;
+	class XMLElement;
+}
 
 namespace Ship {
 #define OTR_HEADER_SIZE ((size_t)64)

--- a/src/resource/archive/Archive.h
+++ b/src/resource/archive/Archive.h
@@ -6,11 +6,10 @@
 #include <mutex>
 #include "utils/binarytools/BinaryReader.h"
 
-namespace tinyxml2
-{
-	class XMLDocument;
-	class XMLElement;
-}
+namespace tinyxml2 {
+class XMLDocument;
+class XMLElement;
+} // namespace tinyxml2
 
 namespace Ship {
 #define OTR_HEADER_SIZE ((size_t)64)

--- a/src/resource/archive/FolderArchive.cpp
+++ b/src/resource/archive/FolderArchive.cpp
@@ -7,6 +7,7 @@
 #include "Context.h"
 #include "spdlog/spdlog.h"
 #include "utils/filesystemtools/FileHelper.h"
+#include "resource/ResourceManager.h"
 
 namespace Ship {
 FolderArchive::FolderArchive(const std::string& archivePath) : Archive(archivePath) {

--- a/src/resource/archive/O2rArchive.cpp
+++ b/src/resource/archive/O2rArchive.cpp
@@ -1,6 +1,7 @@
 #include "O2rArchive.h"
 
 #include "Context.h"
+#include "window/Window.h"
 #include "spdlog/spdlog.h"
 
 namespace Ship {

--- a/src/resource/factory/DisplayListFactory.cpp
+++ b/src/resource/factory/DisplayListFactory.cpp
@@ -3,6 +3,7 @@
 #include "spdlog/spdlog.h"
 #include "libultraship/libultra/gbi.h"
 #include "graphic/Fast3D/lus_gbi.h"
+#include <tinyxml2.h>
 
 namespace Fast {
 std::unordered_map<std::string, uint32_t> renderModes = {

--- a/src/resource/factory/VertexFactory.cpp
+++ b/src/resource/factory/VertexFactory.cpp
@@ -2,6 +2,7 @@
 #include "resource/type/Vertex.h"
 #include "spdlog/spdlog.h"
 #include "libultraship/libultra/gbi.h"
+#include <tinyxml2.h>
 
 namespace Fast {
 std::shared_ptr<Ship::IResource>

--- a/src/window/Window.cpp
+++ b/src/window/Window.cpp
@@ -5,6 +5,7 @@
 #include "public/bridge/consolevariablebridge.h"
 #include "controller/controldevice/controller/mapping/keyboard/KeyboardScancodes.h"
 #include "Context.h"
+#include "controller/controldeck/ControlDeck.h"
 
 #ifdef __APPLE__
 #include "utils/AppleFolderManager.h"

--- a/src/window/gui/ConsoleWindow.cpp
+++ b/src/window/gui/ConsoleWindow.cpp
@@ -1,6 +1,7 @@
 #include "ConsoleWindow.h"
 
 #include "public/bridge/consolevariablebridge.h"
+#include "window/Window.h"
 #include "Context.h"
 #include "utils/StringHelper.h"
 #include "utils/Utils.h"

--- a/src/window/gui/GameOverlay.cpp
+++ b/src/window/gui/GameOverlay.cpp
@@ -7,6 +7,7 @@
 #include "resource/archive/Archive.h"
 #include "resource/ResourceManager.h"
 #include "Context.h"
+#include "window/Window.h"
 #include "utils/StringHelper.h"
 
 namespace Ship {

--- a/src/window/gui/InputEditorWindow.cpp
+++ b/src/window/gui/InputEditorWindow.cpp
@@ -4,6 +4,7 @@
 #include "utils/StringHelper.h"
 #include "public/bridge/consolevariablebridge.h"
 #include "controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToButtonMapping.h"
+#include "controller/controldeck/ControlDeck.h"
 
 #define SCALE_IMGUI_SIZE(value) ((value / 13.0f) * ImGui::GetFontSize())
 


### PR DESCRIPTION
This PR improves compile times by making use of forward declarations, as well as moving header-only libraries includes from .h to .cpp files where applicable.

This has, in my testing, reduced compile times by several seconds per .cpp file.