### PR TITLE
Allow ports to configure ImGui Window Docks

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -477,7 +477,7 @@ void Gui::DrawMenu() {
 
         ImGui::DockBuilderDockWindow("Main Game", dockId);
 
-        // This allows ports to configure their own window docking setup.
+        // This allows ports to configure their own window docking setup. See PR #842
         if (nullptr != mDockBuilderImpl) {
             mDockBuilderImpl();
         }

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -476,6 +476,18 @@ void Gui::DrawMenu() {
 
         ImGui::DockBuilderDockWindow("Main Game", dockId);
 
+        ImGuiID rightId = ImGui::DockBuilderSplitNode(dockId, ImGuiDir_Right, 0.25f, nullptr, nullptr);
+        ImGuiID topId = ImGui::DockBuilderSplitNode(dockId, ImGuiDir_Up, 0.25f, nullptr, nullptr);
+        ImGuiID bottomId = ImGui::DockBuilderSplitNode(dockId, ImGuiDir_Down, 0.25f, nullptr, nullptr);
+        ImGui::DockBuilderSetNodeSize(rightId, ImVec2(viewport->Size.x * 0.2f, viewport->Size.y));
+        ImGui::DockBuilderSetNodeSize(topId, ImVec2(viewport->Size.x, viewport->Size.y * 0.1f));
+        ImGui::DockBuilderSetNodeSize(bottomId, ImVec2(viewport->Size.x, viewport->Size.y * 0.1f));
+        
+        ImGui::DockBuilderDockWindow("Scene Explorer", rightId);
+        ImGui::DockBuilderDockWindow("Track Properties", rightId); // Attach as second tab
+        ImGui::DockBuilderDockWindow("Tools", topId);
+        ImGui::DockBuilderDockWindow("Content Browser", bottomId);
+
         ImGui::DockBuilderFinish(dockId);
     }
 

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -473,20 +473,14 @@ void Gui::DrawMenu() {
     if (!ImGui::DockBuilderGetNode(dockId)) {
         ImGui::DockBuilderRemoveNode(dockId);
         ImGui::DockBuilderAddNode(dockId, ImGuiDockNodeFlags_NoTabBar);
+        ImGui::DockBuilderSetNodeSize(dockId, ImVec2(viewport->Size.x, viewport->Size.y));
 
         ImGui::DockBuilderDockWindow("Main Game", dockId);
 
-        ImGuiID rightId = ImGui::DockBuilderSplitNode(dockId, ImGuiDir_Right, 0.25f, nullptr, nullptr);
-        ImGuiID topId = ImGui::DockBuilderSplitNode(dockId, ImGuiDir_Up, 0.25f, nullptr, nullptr);
-        ImGuiID bottomId = ImGui::DockBuilderSplitNode(dockId, ImGuiDir_Down, 0.25f, nullptr, nullptr);
-        ImGui::DockBuilderSetNodeSize(rightId, ImVec2(viewport->Size.x * 0.2f, viewport->Size.y));
-        ImGui::DockBuilderSetNodeSize(topId, ImVec2(viewport->Size.x, viewport->Size.y * 0.1f));
-        ImGui::DockBuilderSetNodeSize(bottomId, ImVec2(viewport->Size.x, viewport->Size.y * 0.1f));
-        
-        ImGui::DockBuilderDockWindow("Scene Explorer", rightId);
-        ImGui::DockBuilderDockWindow("Track Properties", rightId); // Attach as second tab
-        ImGui::DockBuilderDockWindow("Tools", topId);
-        ImGui::DockBuilderDockWindow("Content Browser", bottomId);
+        // This allows ports to configure their own window docking setup.
+        if (nullptr != mDockBuilderImpl) {
+            mDockBuilderImpl();
+        }
 
         ImGui::DockBuilderFinish(dockId);
     }

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -101,6 +101,7 @@ class Gui {
     bool GamepadNavigationEnabled();
     void BlockGamepadNavigation();
     void UnblockGamepadNavigation();
+    std::function<void()> mDockBuilderImpl = nullptr;
 
   protected:
     void StartFrame();


### PR DESCRIPTION
This PR adds the function ptr `mDockBuilderImpl` to Gui.cpp which ports can set and provide their own docking impl.

This is the best worst way that allows users to configure the docks, set the sizing of the windows, and set which windows are to be docked without over-complicating the situation. I could see a sort of overridable function as a possibility. But I did not want to make a new Gui class.

### How To Use
imguiUI.cpp (wherever you setup imgui's window stuff)

```cpp
void SetupGuiElements() {
    auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();

    // Setup Window Docks
    gui->mDockBuilderImpl = []() {
        const ImGuiViewport* viewport = ImGui::GetMainViewport();
        const ImGuiID dockId = ImGui::GetID("main_dock");
        
        ImGuiID topId = ImGui::DockBuilderSplitNode(dockId, ImGuiDir_Up, 0.15f, nullptr, nullptr);
        ImGui::DockBuilderSetNodeSize(topId, ImVec2(viewport->Size.x, 40));
        ImGuiID bottomId = ImGui::DockBuilderSplitNode(dockId, ImGuiDir_Down, 0.25f, nullptr, nullptr);
        ImGui::DockBuilderSetNodeSize(bottomId, ImVec2(viewport->Size.x, viewport->Size.y * 0.1f));
        ImGuiID rightId = ImGui::DockBuilderSplitNode(dockId, ImGuiDir_Right, 0.25f, nullptr, nullptr);
        ImGui::DockBuilderSetNodeSize(rightId, ImVec2(viewport->Size.x * 0.2f, viewport->Size.y));
        ImGuiID rightBottomId = ImGui::DockBuilderSplitNode(rightId, ImGuiDir_Down, 0.25f, nullptr, nullptr);
        ImGui::DockBuilderSetNodeSize(rightBottomId, ImVec2(viewport->Size.x * 0.2f, viewport->Size.y));
        
        ImGui::DockBuilderDockWindow("Scene Explorer", rightId);
        ImGui::DockBuilderDockWindow("Track Properties", rightId); // Attach as second tab
        ImGui::DockBuilderDockWindow("Properties", rightBottomId);
        ImGui::DockBuilderDockWindow("Tools", topId);
        ImGui::DockBuilderDockWindow("Content Browser", bottomId);
    };
}
```