### PR TITLE
Allow ports to configure ImGui Window Docks by overriding DrawMenu

### DIFF
--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -29,7 +29,8 @@ Fast3dWindow::Fast3dWindow(std::shared_ptr<Ship::Gui> gui) : Ship::Window(gui) {
     AddAvailableWindowBackend(Ship::WindowBackend::FAST3D_SDL_OPENGL);
 }
 
-Fast3dWindow::Fast3dWindow(std::vector<std::shared_ptr<Ship::GuiWindow>> guiWindows) : Fast3dWindow(std::make_shared<Ship::Gui>(guiWindows)) {
+Fast3dWindow::Fast3dWindow(std::vector<std::shared_ptr<Ship::GuiWindow>> guiWindows)
+    : Fast3dWindow(std::make_shared<Ship::Gui>(guiWindows)) {
 }
 
 Fast3dWindow::Fast3dWindow() : Fast3dWindow(std::vector<std::shared_ptr<Ship::GuiWindow>>()) {

--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -14,24 +14,6 @@
 #include <fstream>
 
 namespace Fast {
-Fast3dWindow::Fast3dWindow() : Fast3dWindow(std::vector<std::shared_ptr<Ship::GuiWindow>>()) {
-}
-
-Fast3dWindow::Fast3dWindow(std::vector<std::shared_ptr<Ship::GuiWindow>> guiWindows) : Ship::Window(guiWindows) {
-    mWindowManagerApi = nullptr;
-    mRenderingApi = nullptr;
-
-#ifdef _WIN32
-    AddAvailableWindowBackend(Ship::WindowBackend::FAST3D_DXGI_DX11);
-#endif
-#ifdef __APPLE__
-    if (Metal_IsSupported()) {
-        AddAvailableWindowBackend(Ship::WindowBackend::FAST3D_SDL_METAL);
-    }
-#endif
-    AddAvailableWindowBackend(Ship::WindowBackend::FAST3D_SDL_OPENGL);
-}
-
 Fast3dWindow::Fast3dWindow(std::shared_ptr<Ship::Gui> gui) : Ship::Window(gui) {
     mWindowManagerApi = nullptr;
     mRenderingApi = nullptr;
@@ -45,6 +27,12 @@ Fast3dWindow::Fast3dWindow(std::shared_ptr<Ship::Gui> gui) : Ship::Window(gui) {
     }
 #endif
     AddAvailableWindowBackend(Ship::WindowBackend::FAST3D_SDL_OPENGL);
+}
+
+Fast3dWindow::Fast3dWindow(std::vector<std::shared_ptr<Ship::GuiWindow>> guiWindows) : Fast3dWindow(std::make_shared<Ship::Gui>(guiWindows)) {
+}
+
+Fast3dWindow::Fast3dWindow() : Fast3dWindow(std::vector<std::shared_ptr<Ship::GuiWindow>>()) {
 }
 
 Fast3dWindow::~Fast3dWindow() {

--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -32,6 +32,21 @@ Fast3dWindow::Fast3dWindow(std::vector<std::shared_ptr<Ship::GuiWindow>> guiWind
     AddAvailableWindowBackend(Ship::WindowBackend::FAST3D_SDL_OPENGL);
 }
 
+Fast3dWindow::Fast3dWindow(std::shared_ptr<Ship::Gui> gui) {
+    mWindowManagerApi = nullptr;
+    mRenderingApi = nullptr;
+
+#ifdef _WIN32
+    AddAvailableWindowBackend(Ship::WindowBackend::FAST3D_DXGI_DX11);
+#endif
+#ifdef __APPLE__
+    if (Metal_IsSupported()) {
+        AddAvailableWindowBackend(Ship::WindowBackend::FAST3D_SDL_METAL);
+    }
+#endif
+    AddAvailableWindowBackend(Ship::WindowBackend::FAST3D_SDL_OPENGL);
+}
+
 Fast3dWindow::~Fast3dWindow() {
     SPDLOG_DEBUG("destruct fast3dwindow");
     gfx_destroy();

--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -32,7 +32,7 @@ Fast3dWindow::Fast3dWindow(std::vector<std::shared_ptr<Ship::GuiWindow>> guiWind
     AddAvailableWindowBackend(Ship::WindowBackend::FAST3D_SDL_OPENGL);
 }
 
-Fast3dWindow::Fast3dWindow(std::shared_ptr<Ship::Gui> gui) {
+Fast3dWindow::Fast3dWindow(std::shared_ptr<Ship::Gui> gui) : Ship::Window(gui) {
     mWindowManagerApi = nullptr;
     mRenderingApi = nullptr;
 

--- a/src/graphic/Fast3D/Fast3dWindow.h
+++ b/src/graphic/Fast3D/Fast3dWindow.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "window/Window.h"
+#include "window/gui/Gui.h"
 #include "graphic/Fast3D/gfx_window_manager_api.h"
 #include "graphic/Fast3D/gfx_rendering_api.h"
 #include "public/bridge/gfxbridge.h"
@@ -12,6 +13,7 @@ class Fast3dWindow : public Ship::Window {
   public:
     Fast3dWindow();
     Fast3dWindow(std::vector<std::shared_ptr<Ship::GuiWindow>> guiWindows);
+    Fast3dWindow(std::shared_ptr<Ship::Gui> gui);
     ~Fast3dWindow();
 
     void Init() override;

--- a/src/window/Window.cpp
+++ b/src/window/Window.cpp
@@ -12,16 +12,13 @@
 
 namespace Ship {
 
-Window::Window(std::vector<std::shared_ptr<GuiWindow>> guiWindows) {
-    mGui = std::make_shared<Gui>(guiWindows);
-    mAvailableWindowBackends = std::make_shared<std::vector<WindowBackend>>();
-    mConfig = Context::GetInstance()->GetConfig();
-}
-
 Window::Window(std::shared_ptr<Gui> gui) {
     mGui = gui;
     mAvailableWindowBackends = std::make_shared<std::vector<WindowBackend>>();
     mConfig = Context::GetInstance()->GetConfig();
+}
+    
+Window::Window(std::vector<std::shared_ptr<GuiWindow>> guiWindows) : Window(std::make_shared<Gui>(guiWindows)) {
 }
 
 Window::Window() : Window(std::vector<std::shared_ptr<GuiWindow>>()) {

--- a/src/window/Window.cpp
+++ b/src/window/Window.cpp
@@ -17,7 +17,7 @@ Window::Window(std::shared_ptr<Gui> gui) {
     mAvailableWindowBackends = std::make_shared<std::vector<WindowBackend>>();
     mConfig = Context::GetInstance()->GetConfig();
 }
-    
+
 Window::Window(std::vector<std::shared_ptr<GuiWindow>> guiWindows) : Window(std::make_shared<Gui>(guiWindows)) {
 }
 

--- a/src/window/Window.cpp
+++ b/src/window/Window.cpp
@@ -18,6 +18,12 @@ Window::Window(std::vector<std::shared_ptr<GuiWindow>> guiWindows) {
     mConfig = Context::GetInstance()->GetConfig();
 }
 
+Window::Window(std::shared_ptr<Gui> gui) {
+    mGui = gui;
+    mAvailableWindowBackends = std::make_shared<std::vector<WindowBackend>>();
+    mConfig = Context::GetInstance()->GetConfig();
+}
+
 Window::Window() : Window(std::vector<std::shared_ptr<GuiWindow>>()) {
 }
 

--- a/src/window/Window.h
+++ b/src/window/Window.h
@@ -30,6 +30,7 @@ class Window {
   public:
     Window();
     Window(std::vector<std::shared_ptr<GuiWindow>> guiWindows);
+    Window(std::shared_ptr<Gui> gui);
     ~Window();
 
     virtual void Init() = 0;

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -473,6 +473,7 @@ void Gui::DrawMenu() {
     if (!ImGui::DockBuilderGetNode(dockId)) {
         ImGui::DockBuilderRemoveNode(dockId);
         ImGui::DockBuilderAddNode(dockId, ImGuiDockNodeFlags_NoTabBar);
+        ImGui::DockBuilderSetNodeSize(dockId, ImVec2(viewport->Size.x, viewport->Size.y));
 
         ImGui::DockBuilderDockWindow("Main Game", dockId);
 

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -106,7 +106,7 @@ class Gui {
     void StartFrame();
     void EndFrame();
     void DrawFloatingWindows();
-    void DrawMenu();
+    virtual void DrawMenu();
     void DrawGame();
     void CalculateGameViewport();
 

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -121,17 +121,17 @@ class Gui {
     int16_t GetIntegerScaleFactor();
     void CheckSaveCvars();
     void HandleMouseCapture();
+    ImVec2 mTemporaryWindowPos;
+    ImGuiIO* mImGuiIo;
+    std::map<std::string, std::shared_ptr<GuiWindow>> mGuiWindows;
 
   private:
     GuiWindowInitData mImpl;
-    ImGuiIO* mImGuiIo;
     bool mNeedsConsoleVariableSave;
     std::shared_ptr<GameOverlay> mGameOverlay;
     std::shared_ptr<GuiMenuBar> mMenuBar;
     std::shared_ptr<GuiWindow> mMenu;
     std::unordered_map<std::string, GuiTextureMetadata> mGuiTextures;
-    std::map<std::string, std::shared_ptr<GuiWindow>> mGuiWindows;
-    ImVec2 mTemporaryWindowPos;
 };
 } // namespace Ship
 


### PR DESCRIPTION
This allows overriding DrawMenu thus allow ports to setup their own dock builder for docking imgui windows programmatically.

### How To Use
port/Engine.cpp
```cpp
auto gui = std::make_shared<Ship::SpaghettiGui>(std::vector<std::shared_ptr<Ship::GuiWindow>>({}));
auto wnd = std::make_shared<Fast::Fast3dWindow>(gui);
```