### PR TITLE
split windows vcpkg part off from windows cmake deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ endif()
 option(GBI_UCODE "Specify the GBI ucode version" F3DEX_GBI_2)
 
 # =========== Dependencies =============
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    include(cmake/dependencies/windows-vcpkg.cmake)
+endif()
+
 include(cmake/dependencies/common.cmake)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Android")

--- a/cmake/dependencies/windows-vcpkg.cmake
+++ b/cmake/dependencies/windows-vcpkg.cmake
@@ -1,0 +1,14 @@
+if (USE_AUTO_VCPKG)
+	include(cmake/automate-vcpkg.cmake)
+
+	if ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
+		set(VCPKG_TRIPLET x86-windows-static)
+		set(VCPKG_TARGET_TRIPLET x86-windows-static)
+	elseif ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
+		set(VCPKG_TRIPLET x64-windows-static)
+		set(VCPKG_TARGET_TRIPLET x64-windows-static)
+	endif()
+
+	vcpkg_bootstrap()
+	vcpkg_install_packages(zlib bzip2 sdl2 glew libzip nlohmann-json tinyxml2 spdlog)    
+endif()

--- a/cmake/dependencies/windows.cmake
+++ b/cmake/dependencies/windows.cmake
@@ -1,18 +1,3 @@
-if (USE_AUTO_VCPKG)
-	include(cmake/automate-vcpkg.cmake)
-
-	if ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
-		set(VCPKG_TRIPLET x86-windows-static)
-		set(VCPKG_TARGET_TRIPLET x86-windows-static)
-	elseif ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
-		set(VCPKG_TRIPLET x64-windows-static)
-		set(VCPKG_TARGET_TRIPLET x64-windows-static)
-	endif()
-
-	vcpkg_bootstrap()
-	vcpkg_install_packages(zlib bzip2 sdl2 glew libzip nlohmann-json tinyxml2 spdlog)    
-endif()
-
 #=================== ImGui ===================
 target_sources(ImGui
 	PRIVATE


### PR DESCRIPTION
there might be a better way to handle this but this feels like it should make it so we don't run into similar issues in the future and it doesn't feel too messy