### PR TITLE
Fix vsync toggle behavior in SDL

### DIFF
--- a/src/graphic/Fast3D/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/gfx_dxgi.cpp
@@ -833,9 +833,8 @@ static bool gfx_dxgi_is_frame_ready() {
     // dxgi.length_in_vsync_frames is used as present interval. Present interval >1 (aka fractional V-Sync)
     // breaks VRR and introduces even more input lag than capping via normal V-Sync does.
     // Get the present interval the user wants instead (V-Sync toggle).
-    dxgi.is_vsync_enabled =
-        (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1) ? 1 : 0);
-    dxgi.length_in_vsync_frames = dxgi.is_vsync_enabled;
+    dxgi.is_vsync_enabled = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1);
+    dxgi.length_in_vsync_frames = dxgi.is_vsync_enabled ? 1 : 0;
     return true;
 }
 

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -662,12 +662,12 @@ static inline void sync_framerate_with_timer() {
 }
 
 static void gfx_sdl_swap_buffers_begin() {
-    // Make sure only 0 or 1 is set.
-    if (vsync_enabled =
-            !(Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1) ? 1 : 0)) {
-        vsync_enabled = !vsync_enabled;
-        SDL_GL_SetSwapInterval(vsync_enabled);
-        SDL_RenderSetVSync(renderer, vsync_enabled);
+    bool nextVsyncEnabled = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1);
+
+    if (vsync_enabled != nextVsyncEnabled) {
+        vsync_enabled = nextVsyncEnabled;
+        SDL_GL_SetSwapInterval(vsync_enabled ? 1 : 0);
+        SDL_RenderSetVSync(renderer, vsync_enabled ? 1 : 0);
     }
 
     sync_framerate_with_timer();


### PR DESCRIPTION
VSync could not be toggled back on in SDL once previously off due to incorrect if statement using assignment instead of comparison.

This fixes it by using `!=` instead of `=`. I also updated the logic to move the `? 1 : 0` handling off the `vsync_enabled` property as that is a bool and already casts the CVar properly. Instead the `? 1 : 0` should be on the actual vsync methods themselves as they consume ints.