### PR TITLE
Add Writefile and GetArchiveFromFile for Archives

### DIFF
--- a/src/resource/archive/Archive.h
+++ b/src/resource/archive/Archive.h
@@ -38,6 +38,7 @@ class Archive : public std::enable_shared_from_this<Archive> {
 
     virtual bool Open() = 0;
     virtual bool Close() = 0;
+    virtual bool WriteFile(const std::string& filename, const std::vector<uint8_t>& data) = 0;
 
   protected:
     void SetLoaded(bool isLoaded);

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -63,6 +63,10 @@ bool ArchiveManager::HasFile(uint64_t hash) {
     return mFileToArchive.count(hash) > 0;
 }
 
+std::shared_ptr<Archive> ArchiveManager::GetArchiveFromAsset(const std::string& filePath) {
+    return mFileToArchive[CRC64(filePath.c_str())];
+}
+
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::string& searchMask) {
     std::list<std::string> includes = {};
     if (!searchMask.empty()) {
@@ -133,6 +137,14 @@ void ArchiveManager::ResetVirtualFileSystem() {
         archive->Load();
         AddArchive(archive);
     }
+}
+
+bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::string& filename, const std::vector<uint8_t>& data) {
+    if (archive) {
+        archive->WriteFile(filename, data);
+        return true;
+    }
+    return false;
 }
 
 size_t ArchiveManager::RemoveArchive(const std::string& path) {

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -63,7 +63,7 @@ bool ArchiveManager::HasFile(uint64_t hash) {
     return mFileToArchive.count(hash) > 0;
 }
 
-std::shared_ptr<Archive> ArchiveManager::GetArchiveFromAsset(const std::string& filePath) {
+std::shared_ptr<Archive> ArchiveManager::GetArchiveFromFile(const std::string& filePath) {
     return mFileToArchive[CRC64(filePath.c_str())];
 }
 

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -139,7 +139,8 @@ void ArchiveManager::ResetVirtualFileSystem() {
     }
 }
 
-bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::string& filename, const std::vector<uint8_t>& data) {
+bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::string& filename,
+                               const std::vector<uint8_t>& data) {
     if (archive) {
         archive->WriteFile(filename, data);
         return true;

--- a/src/resource/archive/ArchiveManager.h
+++ b/src/resource/archive/ArchiveManager.h
@@ -33,7 +33,7 @@ class ArchiveManager {
     bool WriteFile(std::shared_ptr<Archive> archive, const std::string& filename, const std::vector<uint8_t>& data);
     bool HasFile(const std::string& filePath);
     bool HasFile(uint64_t hash);
-    std::shared_ptr<Archive> GetArchiveFromAsset(const std::string& filePath); // Retrieves a ptr to the archive that the asset is inside of
+    std::shared_ptr<Archive> GetArchiveFromFile(const std::string& filePath); // Retrieves a ptr to the archive that the asset is inside of
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& searchMask = "");
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::list<std::string>& includes,
                                                         const std::list<std::string>& excludes);

--- a/src/resource/archive/ArchiveManager.h
+++ b/src/resource/archive/ArchiveManager.h
@@ -33,7 +33,8 @@ class ArchiveManager {
     bool WriteFile(std::shared_ptr<Archive> archive, const std::string& filename, const std::vector<uint8_t>& data);
     bool HasFile(const std::string& filePath);
     bool HasFile(uint64_t hash);
-    std::shared_ptr<Archive> GetArchiveFromFile(const std::string& filePath); // Retrieves a ptr to the archive that the asset is inside of
+    std::shared_ptr<Archive>
+    GetArchiveFromFile(const std::string& filePath); // Retrieves a ptr to the archive that the asset is inside of
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& searchMask = "");
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::list<std::string>& includes,
                                                         const std::list<std::string>& excludes);

--- a/src/resource/archive/ArchiveManager.h
+++ b/src/resource/archive/ArchiveManager.h
@@ -30,8 +30,10 @@ class ArchiveManager {
     bool IsLoaded();
     std::shared_ptr<File> LoadFile(const std::string& filePath);
     std::shared_ptr<File> LoadFile(uint64_t hash);
+    bool WriteFile(std::shared_ptr<Archive> archive, const std::string& filename, const std::vector<uint8_t>& data);
     bool HasFile(const std::string& filePath);
     bool HasFile(uint64_t hash);
+    std::shared_ptr<Archive> GetArchiveFromAsset(const std::string& filePath); // Retrieves a ptr to the archive that the asset is inside of
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& searchMask = "");
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::list<std::string>& includes,
                                                         const std::list<std::string>& excludes);

--- a/src/resource/archive/O2rArchive.cpp
+++ b/src/resource/archive/O2rArchive.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<File> O2rArchive::LoadFile(const std::string& filePath) {
 }
 
 bool O2rArchive::Open() {
-    mZipArchive = zip_open(GetPath().c_str(), ZIP_RDONLY, nullptr);
+    mZipArchive = zip_open(GetPath().c_str(), ZIP_CREATE, nullptr);
     if (mZipArchive == nullptr) {
         SPDLOG_ERROR("Failed to load zip file \"{}\"", GetPath());
         return false;
@@ -84,6 +84,56 @@ bool O2rArchive::Open() {
         IndexFile(zipEntryName);
     }
 
+    return true;
+}
+
+bool O2rArchive::WriteFile(const std::string& filename, const std::vector<uint8_t>& data) {
+    printf("Writing file\n");
+    if (!mZipArchive) {
+        SPDLOG_ERROR("Cannot write to ZIP: Archive is not open.");
+        return false;
+    }
+
+    // Create a new zip source from the data buffer
+    zip_source_t* source = zip_source_buffer(mZipArchive, data.data(), data.size(), 0);
+    if (!source) {
+        SPDLOG_ERROR("Failed to create zip source for file \"{}\"", filename);
+        return false;
+    }
+
+    // Add or replace the file in the ZIP archive
+    zip_int64_t index = zip_name_locate(mZipArchive, filename.c_str(), 0);
+    if (index >= 0) {
+        // File exists, replace it
+        if (zip_file_replace(mZipArchive, index, source, ZIP_FL_OVERWRITE) < 0) {
+            SPDLOG_ERROR("Failed to replace file \"{}\" in ZIP", filename);
+            zip_source_free(source);
+            return false;
+        }
+    } else {
+        // File doesn't exist, add it
+        if (zip_file_add(mZipArchive, filename.c_str(), source, ZIP_FL_ENC_UTF_8) < 0) {
+            SPDLOG_ERROR("Failed to add file \"{}\" to ZIP", filename);
+            zip_source_free(source);
+            return false;
+        }
+    }
+    printf("Success wrote file\n");
+
+    // Save changes to disk
+    if (zip_close(mZipArchive) < 0) {
+        SPDLOG_ERROR("Failed to save changes to ZIP archive.");
+        return false;
+    }
+
+    // Reopen the zip file for reading
+    mZipArchive = zip_open(GetPath().c_str(), ZIP_CREATE, nullptr);
+    if (mZipArchive == nullptr) {
+        SPDLOG_ERROR("Failed to reopen ZIP file after writing.");
+        return false;
+    }
+
+    // Success
     return true;
 }
 

--- a/src/resource/archive/O2rArchive.cpp
+++ b/src/resource/archive/O2rArchive.cpp
@@ -87,6 +87,15 @@ bool O2rArchive::Open() {
     return true;
 }
 
+bool O2rArchive::Close() {
+    if (zip_close(mZipArchive) == -1) {
+        SPDLOG_ERROR("Failed to close zip file \"{}\"", GetPath());
+        return false;
+    }
+
+    return true;
+}
+
 bool O2rArchive::WriteFile(const std::string& filename, const std::vector<uint8_t>& data) {
     printf("Writing file\n");
     if (!mZipArchive) {
@@ -137,12 +146,4 @@ bool O2rArchive::WriteFile(const std::string& filename, const std::vector<uint8_
     return true;
 }
 
-bool O2rArchive::Close() {
-    if (zip_close(mZipArchive) == -1) {
-        SPDLOG_ERROR("Failed to close zip file \"{}\"", GetPath());
-        return false;
-    }
-
-    return true;
-}
 } // namespace Ship

--- a/src/resource/archive/O2rArchive.h
+++ b/src/resource/archive/O2rArchive.h
@@ -22,6 +22,7 @@ class O2rArchive : virtual public Archive {
 
     bool Open();
     bool Close();
+    bool WriteFile(const std::string& filename, const std::vector<uint8_t>& data);
 
     std::shared_ptr<File> LoadFile(const std::string& filePath);
     std::shared_ptr<File> LoadFile(uint64_t hash);

--- a/src/resource/archive/OtrArchive.cpp
+++ b/src/resource/archive/OtrArchive.cpp
@@ -105,6 +105,11 @@ bool OtrArchive::Close() {
     return closed;
 }
 
+bool OtrArchive::WriteFile(const std::string& filename, const std::vector<uint8_t>& data) {
+    SPDLOG_INFO("otr does not support WriteFile, please use an o2r instead");
+    return false;
+}
+
 } // namespace Ship
 
 #endif // EXCLUDE_MPQ_SUPPORT

--- a/src/resource/archive/OtrArchive.h
+++ b/src/resource/archive/OtrArchive.h
@@ -28,6 +28,7 @@ class OtrArchive : virtual public Archive {
 
     bool Open();
     bool Close();
+    bool WriteFile(const std::string& filename, const std::vector<uint8_t>& data);
 
     std::shared_ptr<File> LoadFile(const std::string& filePath);
     std::shared_ptr<File> LoadFile(uint64_t hash);


### PR DESCRIPTION
This allows writing files into the o2r file. The purpose is to add some user edited metadata.
GetArchiveFromFile allows retrieving the o2r file to write to using the file string.

The only thing currently missing is adding the new file into the file system. Suggestions?
For my purposes, I can just restart the game. Decent compromise.

Tested and it works

### How To Use
```cpp
auto archive = GameEngine::Instance->context->GetResourceManager()->GetArchiveManager()->GetArchiveFromFile(filePath);

if (archive) {
    GameEngine::Instance->context->GetResourceManager()->GetArchiveManager()->WriteFile(archive, "file_name_to_write", some_data)
}
```