### PR TITLE
Fix incorrect DirectX shader condition for texture coordinates

### DIFF
--- a/src/graphic/Fast3D/shaders/directx/default.shader.hlsl
+++ b/src/graphic/Fast3D/shaders/directx/default.shader.hlsl
@@ -186,7 +186,7 @@ float4 PSMain(PSInput input, float4 screenSpace : SV_Position) : SV_TARGET {
             float2 tc@{i} = input.uv@{i};
             @{s = o_clamp[i][0]}
             @{t = o_clamp[i][1]}
-            @if(s && t)
+            @if(s || t)
                 int2 texSize@{i};
                 g_texture@{i}.GetDimensions(texSize@{i}.x, texSize@{i}.y);
                 @if(s && t)


### PR DESCRIPTION
This fixes an incorrect conditional for the S and T coordinate flags in the DirectX shader.

Before prism, the condition used to look like:
```c
if (!s && !t) {
} else {
  ...
}
```
With an empty block and the rest of the logic in the else. This flow is similar to opengl and metal, but those did not have an empty block. The prism shaders appear to have dropped this empty block, but did not invert the condition correctly.

`if (s && t)` is not the inversion of `if (!s && !t)`, instead the correct inversion is `if (s || t)`