### PR TITLE
Fix set texture image width calculations

### DIFF
--- a/src/graphic/Fast3D/gfx_pc.cpp
+++ b/src/graphic/Fast3D/gfx_pc.cpp
@@ -2175,7 +2175,7 @@ static void gfx_dp_load_tile(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t 
     uint32_t offset_y = ult >> G_TEXTURE_IMAGE_FRAC;
     uint32_t tile_width = ((lrs - uls) >> G_TEXTURE_IMAGE_FRAC) + 1;
     uint32_t tile_height = ((lrt - ult) >> G_TEXTURE_IMAGE_FRAC) + 1;
-    uint32_t full_image_width = g_rdp.texture_to_load.width + 1;
+    uint32_t full_image_width = g_rdp.texture_to_load.width;
 
     uint32_t offset_x_in_bytes = offset_x << word_size_shift;
     uint32_t tile_line_size_bytes = tile_width << word_size_shift;
@@ -3376,7 +3376,7 @@ bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
         }
     }
 
-    gfx_dp_set_texture_image(C0(21, 3), C0(19, 2), C0(0, 10), imgData, texFlags, rawTexMetdata, (void*)i);
+    gfx_dp_set_texture_image(C0(21, 3), C0(19, 2), C0(0, 12) + 1, imgData, texFlags, rawTexMetdata, (void*)i);
 
     return false;
 }
@@ -3438,7 +3438,7 @@ bool gfx_set_timg_otr_hash_handler_custom(F3DGfx** cmd0) {
         F3DGfx* cmd = (*cmd0);
         uint32_t fmt = C0(21, 3);
         uint32_t size = C0(19, 2);
-        uint32_t width = C0(0, 10);
+        uint32_t width = C0(0, 12) + 1;
 
         if (tex != NULL) {
             gfx_dp_set_texture_image(fmt, size, width, fileName, texFlags, rawTexMetadata, tex);
@@ -3471,7 +3471,7 @@ bool gfx_set_timg_otr_filepath_handler_custom(F3DGfx** cmd0) {
 
         uint32_t fmt = C0(21, 3);
         uint32_t size = C0(19, 2);
-        uint32_t width = C0(0, 10);
+        uint32_t width = C0(0, 12) + 1;
 
         gfx_dp_set_texture_image(fmt, size, width, fileName, texFlags, rawTexMetadata,
                                  reinterpret_cast<char*>(texture->ImageData));

--- a/src/resource/factory/DisplayListFactory.cpp
+++ b/src/resource/factory/DisplayListFactory.cpp
@@ -503,9 +503,9 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
 
             if (fName[0] == '>' && fName[1] == '0' && (fName[2] == 'x' || fName[2] == 'X')) {
                 uint32_t seg = std::stoul(fName.substr(1), nullptr, 16);
-                g = { gsDPSetTextureImage(fmtVal, sizVal, width + 1, seg | 1) };
+                g = { gsDPSetTextureImage(fmtVal, sizVal, width, seg | 1) };
             } else {
-                g = { gsDPSetTextureImage(fmtVal, sizVal, width + 1, 0) };
+                g = { gsDPSetTextureImage(fmtVal, sizVal, width, 0) };
                 g.words.w0 &= 0x00FFFFFF;
                 g.words.w0 += (G_SETTIMG_OTR_FILEPATH << 24);
                 char* str = (char*)malloc(fName.size() + 1);
@@ -950,7 +950,7 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
                 memcpy(g2, g3, 7 * sizeof(Gfx));
             }
 
-            g = { gsDPSetTextureImage(fmt, siz, width + 1, 0) };
+            g = { gsDPSetTextureImage(fmt, siz, width, 0) };
             g.words.w0 &= 0x00FFFFFF;
             g.words.w0 += (G_SETTIMG_OTR_FILEPATH << 24);
             char* str = (char*)malloc(fName.size() + 1);


### PR DESCRIPTION
This corrects a longstanding issue that recently exposed itself after some of the more recent gfx pc refactors.
The definition of `gDPSetTextureImage` looks like the following:
```c
_g->words.w0 = _SHIFTL(cmd, 24, 8) | _SHIFTL(fmt, 21, 3) | _SHIFTL(siz, 19, 2) | _SHIFTL((width)-1, 0, 12);
```
This means that the stored width value in the instruction is 12 bits and is pre-subtracted by 1. When reading the instruction back, we should be adding back this subtracted 1 to get the original width value. Instead we were adding the 1 later during the load operation, but only sometimes (for tile load).

The other issue was that we were adding a `+1` to the width for XML based DL resources, before passing the width into `gDPSetTextureImage`, leading to a double increment later and having some custom DL mods get incorrect texture data coordinates.

To fix this, I've changed the `+1` correction to happen directly in the set texture img handlers so that the values tracked in the rdp are accurate, and the later `+1` in the load_tile handler is removed. We also weren't reading the full 12 bits for the width value.

Also removed the `+1` from the XML parser on the DL factory.