### PR TITLE
Simplify Mac Fullscreen and improve fullscreen handling

### DIFF
--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -263,8 +263,7 @@ uint32_t Fast3dWindow::GetCurrentRefreshRate() {
 }
 
 bool Fast3dWindow::SupportsWindowedFullscreen() {
-    if (GetWindowBackend() == Ship::WindowBackend::FAST3D_SDL_OPENGL ||
-        GetWindowBackend() == Ship::WindowBackend::FAST3D_SDL_METAL) {
+    if (GetWindowBackend() == Ship::WindowBackend::FAST3D_SDL_OPENGL) {
         return true;
     }
 

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -242,9 +242,7 @@ static void set_fullscreen(bool on, bool call_callback) {
     }
 
 #if defined(__APPLE__)
-    // Current implementation of the fullscreening with native macOS fullscreen.
-    // This code can and will be changed when we upgrade to SDL3 because of the ability to use
-    // SDL_HINT_VIDEO_MAC_FULLSCREEN_MENU_VISIBILITY to get the menubar working instead of this workaround bool
+    // Implement fullscreening with native macOS APIs
     if (on != isNativeMacOSFullscreenActive(wnd)) {
         toggleNativeMacOSFullscreen(wnd);
     }

--- a/src/graphic/Fast3D/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/gfx_sdl2.cpp
@@ -253,28 +253,13 @@ static void set_fullscreen(bool on, bool call_callback) {
         SDL_SetWindowSize(wnd, window_width, window_height);
     }
 #if defined(__APPLE__)
-    // Current implementation of the fullscreening with native macOS fullscreen for Windowed Mode and
-    // SDL for Exclusive Fullscreen. This code can and will be changed when we upgrade to SDL3 because of the
-    // ability to use SDL_HINT_VIDEO_MAC_FULLSCREEN_MENU_VISIBILITY to get the menubar working instead of this
-    // workaround
-    bool useNativeMacOSFullscreen = !CVarGetInteger(CVAR_SDL_WINDOWED_FULLSCREEN, 0);
-
-    if (useNativeMacOSFullscreen && (on || isNativeMacOSFullscreenActive(wnd))) {
+    // Current implementation of the fullscreening with native macOS fullscreen.
+    // This code can and will be changed when we upgrade to SDL3 because of the ability to use
+    // SDL_HINT_VIDEO_MAC_FULLSCREEN_MENU_VISIBILITY to get the menubar working instead of this workaround bool
+    if (on != isNativeMacOSFullscreenActive(wnd)) {
         toggleNativeMacOSFullscreen(wnd);
-        fullscreen_state = on;
-    } else {
-        if (on && isNativeMacOSFullscreenActive(wnd)) {
-            toggleNativeMacOSFullscreen(wnd);
-            return;
-        }
-        int exclusiveFullscreenFlag = on ? SDL_WINDOW_FULLSCREEN : 0;
-        if (SDL_SetWindowFullscreen(wnd, exclusiveFullscreenFlag) >= 0) {
-            fullscreen_state = on;
-        } else {
-            SPDLOG_ERROR("Failed to %s exclusive fullscreen mode.", on ? "switch to" : "exit");
-            SPDLOG_ERROR(SDL_GetError());
-        }
     }
+    fullscreen_state = on;
 #else
     if (SDL_SetWindowFullscreen(wnd,
                                 on ? (CVarGetInteger(CVAR_SDL_WINDOWED_FULLSCREEN, 0) ? SDL_WINDOW_FULLSCREEN_DESKTOP


### PR DESCRIPTION
This aims to add a few fullscreen improvements:
* Drops windowed fullscreen as an option for mac in favor of only using the native fullscreen behavior.
* Supports booting into fullscreen on Mac when using Metal
* Move applying windowed size/position until after the fullscreen change is applied (necessary for mac native behavior)
* Fullscreening and mouse capture was not correctly handling the new modern menu (was checking for a CVar that wasn't used by SoH). This was updated to instead use the exposed visibility method that accounts for menubar or menu at the same time.
* `SaveWindowToConfig` during a fullscreen toggle was saving the fullscreen state before it was toggled, meaning that during runtime the config value would always be opposite. I've added an additional config set in the fullscreen callback to then set the new fullscreen enabled value.
* On Mac, it is possible to fullscreen using the Green traffic light button. To avoid having fullscreen state de-synced with Fast3D, I've added an Apple only check in HandleEvents that checks for the fullscreen state and re-executes the fullscreen callback.

---

Soh Testing PR https://github.com/HarbourMasters/Shipwright/pull/5242