### PR TITLE
Add `ListDirectories()` and `unordered_set<std::string>::mDirectories` to ArchiveManager

### DIFF
--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -267,6 +267,12 @@ std::shared_ptr<Archive> ArchiveManager::AddArchive(std::shared_ptr<Archive> arc
     for (auto& [hash, filename] : *fileList.get()) {
         mHashes[hash] = filename;
         mFileToArchive[hash] = archive;
+
+        size_t lastSlash = filename.find_last_of('/');
+        if (lastSlash != std::string::npos) {
+            std::string dir = filename.substr(0, lastSlash);
+            mDirectories.insert(dir);
+        }
     }
     return archive;
 }

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -112,7 +112,7 @@ std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::l
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListDirectories(const std::string& searchMask) {
     auto list = std::make_shared<std::vector<std::string>>();
     for (const std::string& dir : mDirectories) {
-        if (glob_match(pattern.c_str(), dir.c_str())) {
+        if (glob_match(searchMask.c_str(), dir.c_str())) {
             list->push_back(dir);
         }
     }

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -109,6 +109,16 @@ std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::l
     return list;
 }
 
+std::shared_ptr<std::vector<std::string>> ArchiveManager::ListDirectories(const std::string& pattern) {
+    auto list = std::make_shared<std::vector<std::string>>();
+    for (const std::string& dir : mDirectories) {
+        if (glob_match(pattern.c_str(), dir.c_str())) {
+            list->push_back(dir);
+        }
+    }
+    return list;
+}
+
 std::vector<uint32_t> ArchiveManager::GetGameVersions() {
     return mGameVersions;
 }

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -109,7 +109,7 @@ std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::l
     return list;
 }
 
-std::shared_ptr<std::vector<std::string>> ArchiveManager::ListDirectories(const std::string& pattern) {
+std::shared_ptr<std::vector<std::string>> ArchiveManager::ListDirectories(const std::string& searchMask) {
     auto list = std::make_shared<std::vector<std::string>>();
     for (const std::string& dir : mDirectories) {
         if (glob_match(pattern.c_str(), dir.c_str())) {

--- a/src/resource/archive/ArchiveManager.h
+++ b/src/resource/archive/ArchiveManager.h
@@ -38,7 +38,7 @@ class ArchiveManager {
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& searchMask = "");
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::list<std::string>& includes,
                                                         const std::list<std::string>& excludes);
-    std::shared_ptr<std::vector<std::string>> ListDirectories(const std::string& pattern = "");
+    std::shared_ptr<std::vector<std::string>> ListDirectories(const std::string& searchMask = "");
     std::vector<uint32_t> GetGameVersions();
     const std::string* HashToString(uint64_t hash) const;
     bool IsGameVersionValid(uint32_t gameVersion);

--- a/src/resource/archive/ArchiveManager.h
+++ b/src/resource/archive/ArchiveManager.h
@@ -38,6 +38,7 @@ class ArchiveManager {
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& searchMask = "");
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::list<std::string>& includes,
                                                         const std::list<std::string>& excludes);
+    std::shared_ptr<std::vector<std::string>> ListDirectories(const std::string& pattern);
     std::vector<uint32_t> GetGameVersions();
     const std::string* HashToString(uint64_t hash) const;
     bool IsGameVersionValid(uint32_t gameVersion);
@@ -52,6 +53,7 @@ class ArchiveManager {
     std::vector<uint32_t> mGameVersions;
     std::unordered_set<uint32_t> mValidGameVersions;
     std::unordered_map<uint64_t, std::string> mHashes;
+    std::unordered_set<std::string> mDirectories;
     std::unordered_map<uint64_t, std::shared_ptr<Archive>> mFileToArchive;
 };
 } // namespace Ship

--- a/src/resource/archive/ArchiveManager.h
+++ b/src/resource/archive/ArchiveManager.h
@@ -38,7 +38,7 @@ class ArchiveManager {
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::string& searchMask = "");
     std::shared_ptr<std::vector<std::string>> ListFiles(const std::list<std::string>& includes,
                                                         const std::list<std::string>& excludes);
-    std::shared_ptr<std::vector<std::string>> ListDirectories(const std::string& pattern);
+    std::shared_ptr<std::vector<std::string>> ListDirectories(const std::string& pattern = "");
     std::vector<uint32_t> GetGameVersions();
     const std::string* HashToString(uint64_t hash) const;
     bool IsGameVersionValid(uint32_t gameVersion);


### PR DESCRIPTION
Purpose:

A way to check if paths exists. For instance checking if a type of mod exists:
actors/some_name
actors/some_other_name
maps/mymapname

Then you can check if certain files exists in those directories like so:
```cpp
void FindMaps() {
    auto manager = GameEngine::Instance->context->GetResourceManager()->GetArchiveManager();

    auto ptr = manager->ListDirectories("maps/*");
    if (ptr) {
        auto dirs = *ptr;
    
        for (const std::string& dir : dirs) {
            if (manager->HasFile(dir+"/scene.json")) {
                printf("MAP: %s HAS SCENE FILE\n", dir.c_str());
            } else {
                printf("MAP: %s MISSING SCENE FILE\n", dir.c_str());
            }
        }
}
```

It is possible to do this without adding this function. But it's not very efficient and requires a lot of string modification.

This results in an easy way to check for valid maps and add them to the map list. And for the invalid maps to be added to the editor for the user to initialize the map.