### PR TITLE
declare derived classes not meant to be inherited from with non-virtual destructors final

### DIFF
--- a/src/audio/SDLAudioPlayer.h
+++ b/src/audio/SDLAudioPlayer.h
@@ -3,7 +3,7 @@
 #include <SDL2/SDL.h>
 
 namespace Ship {
-class SDLAudioPlayer : public AudioPlayer {
+class SDLAudioPlayer final : public AudioPlayer {
   public:
     SDLAudioPlayer(AudioSettings settings) : AudioPlayer(settings) {
     }

--- a/src/controller/controldevice/controller/mapping/ControllerAxisDirectionMapping.h
+++ b/src/controller/controldevice/controller/mapping/ControllerAxisDirectionMapping.h
@@ -15,7 +15,7 @@ class ControllerAxisDirectionMapping : virtual public ControllerInputMapping {
   public:
     ControllerAxisDirectionMapping(PhysicalDeviceType physicalDeviceType, uint8_t portIndex, StickIndex stickIndex,
                                    Direction direction);
-    ~ControllerAxisDirectionMapping();
+    virtual ~ControllerAxisDirectionMapping();
     virtual float GetNormalizedAxisDirectionValue() = 0;
     virtual int8_t GetMappingType();
 

--- a/src/controller/controldevice/controller/mapping/ControllerButtonMapping.h
+++ b/src/controller/controldevice/controller/mapping/ControllerButtonMapping.h
@@ -14,7 +14,7 @@ namespace Ship {
 class ControllerButtonMapping : virtual public ControllerInputMapping {
   public:
     ControllerButtonMapping(PhysicalDeviceType physicalDeviceType, uint8_t portIndex, CONTROLLERBUTTONS_T bitmask);
-    ~ControllerButtonMapping();
+    virtual ~ControllerButtonMapping();
 
     virtual std::string GetButtonMappingId() = 0;
 

--- a/src/controller/controldevice/controller/mapping/ControllerGyroMapping.h
+++ b/src/controller/controldevice/controller/mapping/ControllerGyroMapping.h
@@ -11,7 +11,7 @@ namespace Ship {
 class ControllerGyroMapping : virtual public ControllerInputMapping {
   public:
     ControllerGyroMapping(PhysicalDeviceType physicalDeviceType, uint8_t portIndex, float sensitivity);
-    ~ControllerGyroMapping();
+    virtual ~ControllerGyroMapping();
     virtual void UpdatePad(float& x, float& y) = 0;
     virtual void SaveToConfig() = 0;
     virtual void EraseFromConfig() = 0;

--- a/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAnyMapping.h
+++ b/src/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAnyMapping.h
@@ -7,7 +7,7 @@ namespace Ship {
 class KeyboardKeyToAnyMapping : virtual public ControllerInputMapping {
   public:
     KeyboardKeyToAnyMapping(KbScancode scancode);
-    ~KeyboardKeyToAnyMapping();
+    virtual ~KeyboardKeyToAnyMapping();
     std::string GetPhysicalInputName() override;
     bool ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode);
     std::string GetPhysicalDeviceName() override;

--- a/src/controller/controldevice/controller/mapping/mouse/MouseButtonToAnyMapping.h
+++ b/src/controller/controldevice/controller/mapping/mouse/MouseButtonToAnyMapping.h
@@ -7,7 +7,7 @@ namespace Ship {
 class MouseButtonToAnyMapping : virtual public ControllerInputMapping {
   public:
     MouseButtonToAnyMapping(MouseBtn button);
-    ~MouseButtonToAnyMapping();
+    virtual ~MouseButtonToAnyMapping();
     std::string GetPhysicalInputName() override;
     bool ProcessMouseButtonEvent(bool isPressed, MouseBtn button);
     std::string GetPhysicalDeviceName() override;

--- a/src/controller/controldevice/controller/mapping/mouse/MouseWheelToAnyMapping.h
+++ b/src/controller/controldevice/controller/mapping/mouse/MouseWheelToAnyMapping.h
@@ -7,7 +7,7 @@ namespace Ship {
 class MouseWheelToAnyMapping : virtual public ControllerInputMapping {
   public:
     MouseWheelToAnyMapping(WheelDirection wheelDirection);
-    ~MouseWheelToAnyMapping();
+    virtual ~MouseWheelToAnyMapping();
     std::string GetPhysicalInputName() override;
     std::string GetPhysicalDeviceName() override;
 

--- a/src/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAnyMapping.h
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAnyMapping.h
@@ -7,7 +7,7 @@ namespace Ship {
 class SDLAxisDirectionToAnyMapping : virtual public ControllerInputMapping {
   public:
     SDLAxisDirectionToAnyMapping(int32_t sdlControllerAxis, int32_t axisDirection);
-    ~SDLAxisDirectionToAnyMapping();
+    virtual ~SDLAxisDirectionToAnyMapping();
     std::string GetPhysicalInputName() override;
     std::string GetPhysicalDeviceName() override;
     bool AxisIsTrigger();

--- a/src/controller/controldevice/controller/mapping/sdl/SDLButtonToAnyMapping.h
+++ b/src/controller/controldevice/controller/mapping/sdl/SDLButtonToAnyMapping.h
@@ -7,7 +7,7 @@ namespace Ship {
 class SDLButtonToAnyMapping : virtual public ControllerInputMapping {
   public:
     SDLButtonToAnyMapping(int32_t sdlControllerButton);
-    ~SDLButtonToAnyMapping();
+    virtual ~SDLButtonToAnyMapping();
     std::string GetPhysicalInputName() override;
     std::string GetPhysicalDeviceName() override;
 

--- a/src/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.h
+++ b/src/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.h
@@ -7,7 +7,7 @@ namespace Ship {
 class SDLAddRemoveDeviceEventHandler : public GuiWindow {
   public:
     using GuiWindow::GuiWindow;
-    ~SDLAddRemoveDeviceEventHandler();
+    virtual ~SDLAddRemoveDeviceEventHandler();
 
   protected:
     void InitElement() override;

--- a/src/resource/ResourceLoader.h
+++ b/src/resource/ResourceLoader.h
@@ -30,7 +30,7 @@ struct ResourceFactoryKeyHash {
 class ResourceLoader {
   public:
     ResourceLoader();
-    ~ResourceLoader();
+    virtual ~ResourceLoader();
 
     std::shared_ptr<IResource> LoadResource(std::string filePath, std::shared_ptr<File> fileToLoad,
                                             std::shared_ptr<ResourceInitData> initData = nullptr);

--- a/src/resource/archive/FolderArchive.h
+++ b/src/resource/archive/FolderArchive.h
@@ -13,7 +13,7 @@
 namespace Ship {
 struct File;
 
-class FolderArchive : virtual public Archive {
+class FolderArchive final : virtual public Archive {
   public:
     FolderArchive(const std::string& archivePath);
     ~FolderArchive();

--- a/src/resource/archive/O2rArchive.h
+++ b/src/resource/archive/O2rArchive.h
@@ -15,7 +15,7 @@
 namespace Ship {
 struct File;
 
-class O2rArchive : virtual public Archive {
+class O2rArchive final : virtual public Archive {
   public:
     O2rArchive(const std::string& archivePath);
     ~O2rArchive();

--- a/src/resource/archive/OtrArchive.h
+++ b/src/resource/archive/OtrArchive.h
@@ -21,7 +21,7 @@
 namespace Ship {
 struct File;
 
-class OtrArchive : virtual public Archive {
+class OtrArchive final : virtual public Archive {
   public:
     OtrArchive(const std::string& archivePath);
     ~OtrArchive();

--- a/src/resource/factory/BlobFactory.h
+++ b/src/resource/factory/BlobFactory.h
@@ -4,7 +4,7 @@
 #include "resource/ResourceFactoryBinary.h"
 
 namespace Ship {
-class ResourceFactoryBinaryBlobV0 : public Ship::ResourceFactoryBinary {
+class ResourceFactoryBinaryBlobV0 final : public Ship::ResourceFactoryBinary {
   public:
     std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file,
                                                   std::shared_ptr<Ship::ResourceInitData> initData) override;

--- a/src/resource/factory/DisplayListFactory.h
+++ b/src/resource/factory/DisplayListFactory.h
@@ -10,13 +10,13 @@ class ResourceFactoryDisplayList {
     uint32_t GetCombineLERPValue(const char* valStr);
 };
 
-class ResourceFactoryBinaryDisplayListV0 : public ResourceFactoryDisplayList, public Ship::ResourceFactoryBinary {
+class ResourceFactoryBinaryDisplayListV0 final : public ResourceFactoryDisplayList, public Ship::ResourceFactoryBinary {
   public:
     std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file,
                                                   std::shared_ptr<Ship::ResourceInitData> initData) override;
 };
 
-class ResourceFactoryXMLDisplayListV0 : public ResourceFactoryDisplayList, public Ship::ResourceFactoryXML {
+class ResourceFactoryXMLDisplayListV0 final : public ResourceFactoryDisplayList, public Ship::ResourceFactoryXML {
   public:
     std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file,
                                                   std::shared_ptr<Ship::ResourceInitData> initData) override;

--- a/src/resource/factory/JsonFactory.h
+++ b/src/resource/factory/JsonFactory.h
@@ -4,7 +4,7 @@
 #include "resource/ResourceFactoryBinary.h"
 
 namespace Ship {
-class ResourceFactoryBinaryJsonV0 : public ResourceFactoryBinary {
+class ResourceFactoryBinaryJsonV0 final : public ResourceFactoryBinary {
   public:
     std::shared_ptr<IResource> ReadResource(std::shared_ptr<File> file,
                                             std::shared_ptr<Ship::ResourceInitData> initData) override;

--- a/src/resource/factory/LightFactory.h
+++ b/src/resource/factory/LightFactory.h
@@ -4,7 +4,7 @@
 #include "resource/ResourceFactoryBinary.h"
 
 namespace Fast {
-class ResourceFactoryBinaryLightV0 : public Ship::ResourceFactoryBinary {
+class ResourceFactoryBinaryLightV0 final : public Ship::ResourceFactoryBinary {
   public:
     std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file,
                                                   std::shared_ptr<Ship::ResourceInitData> initData) override;

--- a/src/resource/factory/MatrixFactory.h
+++ b/src/resource/factory/MatrixFactory.h
@@ -4,7 +4,7 @@
 #include "resource/ResourceFactoryBinary.h"
 
 namespace Fast {
-class ResourceFactoryBinaryMatrixV0 : public Ship::ResourceFactoryBinary {
+class ResourceFactoryBinaryMatrixV0 final : public Ship::ResourceFactoryBinary {
   public:
     std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file,
                                                   std::shared_ptr<Ship::ResourceInitData> initData) override;

--- a/src/resource/factory/ShaderFactory.h
+++ b/src/resource/factory/ShaderFactory.h
@@ -5,7 +5,7 @@
 #include "resource/ResourceFactoryBinary.h"
 
 namespace Ship {
-class ResourceFactoryBinaryShaderV0 : public ResourceFactoryBinary {
+class ResourceFactoryBinaryShaderV0 final : public ResourceFactoryBinary {
   public:
     std::shared_ptr<IResource> ReadResource(std::shared_ptr<File> file,
                                             std::shared_ptr<Ship::ResourceInitData> initData) override;

--- a/src/resource/factory/TextureFactory.h
+++ b/src/resource/factory/TextureFactory.h
@@ -4,13 +4,13 @@
 #include "resource/ResourceFactoryBinary.h"
 
 namespace Fast {
-class ResourceFactoryBinaryTextureV0 : public Ship::ResourceFactoryBinary {
+class ResourceFactoryBinaryTextureV0 final : public Ship::ResourceFactoryBinary {
   public:
     std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file,
                                                   std::shared_ptr<Ship::ResourceInitData> initData) override;
 };
 
-class ResourceFactoryBinaryTextureV1 : public Ship::ResourceFactoryBinary {
+class ResourceFactoryBinaryTextureV1 final : public Ship::ResourceFactoryBinary {
   public:
     std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file,
                                                   std::shared_ptr<Ship::ResourceInitData> initData) override;

--- a/src/resource/factory/VertexFactory.h
+++ b/src/resource/factory/VertexFactory.h
@@ -5,13 +5,13 @@
 #include "resource/ResourceFactoryXML.h"
 
 namespace Fast {
-class ResourceFactoryBinaryVertexV0 : public Ship::ResourceFactoryBinary {
+class ResourceFactoryBinaryVertexV0 final : public Ship::ResourceFactoryBinary {
   public:
     std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file,
                                                   std::shared_ptr<Ship::ResourceInitData> initData) override;
 };
 
-class ResourceFactoryXMLVertexV0 : public Ship::ResourceFactoryXML {
+class ResourceFactoryXMLVertexV0 final : public Ship::ResourceFactoryXML {
   public:
     std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file,
                                                   std::shared_ptr<Ship::ResourceInitData> initData) override;

--- a/src/window/Window.h
+++ b/src/window/Window.h
@@ -31,7 +31,7 @@ class Window {
     Window();
     Window(std::vector<std::shared_ptr<GuiWindow>> guiWindows);
     Window(std::shared_ptr<Gui> gui);
-    ~Window();
+    virtual ~Window();
 
     virtual void Init() = 0;
     virtual void Close() = 0;

--- a/src/window/gui/ConsoleWindow.h
+++ b/src/window/gui/ConsoleWindow.h
@@ -15,7 +15,7 @@ namespace Ship {
 class ConsoleWindow : public GuiWindow {
   public:
     using GuiWindow::GuiWindow;
-    ~ConsoleWindow();
+    virtual ~ConsoleWindow();
 
     void ClearLogs(std::string channel);
     void ClearLogs();

--- a/src/window/gui/GameOverlay.h
+++ b/src/window/gui/GameOverlay.h
@@ -22,7 +22,7 @@ struct Overlay {
 class GameOverlay {
   public:
     GameOverlay();
-    ~GameOverlay();
+    virtual ~GameOverlay();
 
     void Init();
     void LoadFont(const std::string& name, float fontSize, const ResourceIdentifier& identifier);

--- a/src/window/gui/GfxDebuggerWindow.h
+++ b/src/window/gui/GfxDebuggerWindow.h
@@ -14,7 +14,7 @@ namespace LUS {
 class GfxDebuggerWindow : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
-    ~GfxDebuggerWindow();
+    virtual ~GfxDebuggerWindow();
 
   protected:
     void InitElement() override;

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -69,7 +69,7 @@ class Gui {
   public:
     Gui();
     Gui(std::vector<std::shared_ptr<GuiWindow>> guiWindows);
-    ~Gui();
+    virtual ~Gui();
 
     void Init(GuiWindowInitData windowImpl);
     void StartDraw();

--- a/src/window/gui/InputEditorWindow.h
+++ b/src/window/gui/InputEditorWindow.h
@@ -14,7 +14,7 @@ namespace Ship {
 class InputEditorWindow : public GuiWindow {
   public:
     using GuiWindow::GuiWindow;
-    ~InputEditorWindow();
+    virtual ~InputEditorWindow();
 
     void DrawInputChip(const char* buttonName, ImVec4 color);
     void DrawAnalogPreview(const char* label, ImVec2 stick, float deadzone = 0, bool gyro = false);

--- a/src/window/gui/StatsWindow.h
+++ b/src/window/gui/StatsWindow.h
@@ -6,7 +6,7 @@ namespace Ship {
 class StatsWindow : public GuiWindow {
   public:
     using GuiWindow::GuiWindow;
-    ~StatsWindow();
+    virtual ~StatsWindow();
 
   private:
     void InitElement() override;

--- a/src/window/gui/resource/Font.h
+++ b/src/window/gui/resource/Font.h
@@ -10,7 +10,7 @@ class Font : public Resource<void> {
     using Resource::Resource;
 
     Font();
-    ~Font();
+    virtual ~Font();
 
     void* GetPointer() override;
     size_t GetPointerSize() override;

--- a/src/window/gui/resource/FontFactory.h
+++ b/src/window/gui/resource/FontFactory.h
@@ -4,7 +4,7 @@
 #include "resource/ResourceFactoryBinary.h"
 
 namespace Ship {
-class ResourceFactoryBinaryFontV0 : public ResourceFactoryBinary {
+class ResourceFactoryBinaryFontV0 final : public ResourceFactoryBinary {
   public:
     std::shared_ptr<IResource> ReadResource(std::shared_ptr<File> file,
                                             std::shared_ptr<Ship::ResourceInitData> initData) override;

--- a/src/window/gui/resource/GuiTextureFactory.h
+++ b/src/window/gui/resource/GuiTextureFactory.h
@@ -4,7 +4,7 @@
 #include "resource/ResourceFactoryBinary.h"
 
 namespace Ship {
-class ResourceFactoryBinaryGuiTextureV0 : public ResourceFactoryBinary {
+class ResourceFactoryBinaryGuiTextureV0 final : public ResourceFactoryBinary {
   public:
     std::shared_ptr<IResource> ReadResource(std::shared_ptr<File> file,
                                             std::shared_ptr<Ship::ResourceInitData> initData) override;


### PR DESCRIPTION
classes which are intended to be inherited from updated to have virtual destructors

it's suggested destructors should either be public & virtual, or protected & nonvirtual

avoids very noisy warnings seen in https://github.com/HarbourMasters/Shipwright/pull/5443