### PR TITLE
O2rArchive::WriteFile() Better Error Checking

### DIFF
--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -140,11 +140,13 @@ void ArchiveManager::ResetVirtualFileSystem() {
     }
 }
 
-bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::string& filename,
+bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::string& filePath,
                                const std::vector<uint8_t>& data) {
     if (archive) {
-        if (archive->WriteFile(filename, data)) {
-            ResetVirtualFileSystem();
+        if (archive->WriteFile(filePath, data)) {
+            IndexFile(filePath);
+            mFileToArchive[CRC64(filePath.c_str())] = archive;
+            LoadFile(filePath);
             return true; // Successfully wrote file
         }
     }

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -155,6 +155,7 @@ bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::stri
     if (archive) {
         if (archive->WriteFile(filePath, data)) {
             archive->IndexFile(filePath);
+            mHashes[filePath] = CRC64(filePath.c_str());
             mFileToArchive[CRC64(filePath.c_str())] = archive;
             return true; // Successfully wrote file
         }

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -154,7 +154,7 @@ bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::stri
                                const std::vector<uint8_t>& data) {
     if (archive) {
         if (archive->WriteFile(filePath, data)) {
-            IndexFile(filePath);
+            archive->IndexFile(filePath);
             mFileToArchive[CRC64(filePath.c_str())] = archive;
             LoadFile(filePath);
             return true; // Successfully wrote file

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -156,7 +156,7 @@ bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::stri
         if (archive->WriteFile(filePath, data)) {
             auto hash = CRC64(filePath.c_str());
             archive->IndexFile(filePath);
-            mHashes[filePath] = hash;
+            mHashes[hash] = filePath;
             mFileToArchive[hash] = archive;
             return true; // Successfully wrote file
         }

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -143,10 +143,12 @@ void ArchiveManager::ResetVirtualFileSystem() {
 bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::string& filename,
                                const std::vector<uint8_t>& data) {
     if (archive) {
-        archive->WriteFile(filename, data);
-        return true;
+        if (archive->WriteFile(filename, data)) {
+            ResetVirtualFileSystem();
+            return true; // Successfully wrote file
+        }
     }
-    return false;
+    return false; // Failed to write file
 }
 
 size_t ArchiveManager::RemoveArchive(const std::string& path) {

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -154,9 +154,10 @@ bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::stri
                                const std::vector<uint8_t>& data) {
     if (archive) {
         if (archive->WriteFile(filePath, data)) {
+            auto hash = CRC64(filePath.c_str());
             archive->IndexFile(filePath);
-            mHashes[filePath] = CRC64(filePath.c_str());
-            mFileToArchive[CRC64(filePath.c_str())] = archive;
+            mHashes[filePath] = hash;
+            mFileToArchive[hash] = archive;
             return true; // Successfully wrote file
         }
     }

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -156,7 +156,6 @@ bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::stri
         if (archive->WriteFile(filePath, data)) {
             archive->IndexFile(filePath);
             mFileToArchive[CRC64(filePath.c_str())] = archive;
-            LoadFile(filePath);
             return true; // Successfully wrote file
         }
     }

--- a/src/resource/archive/ArchiveManager.cpp
+++ b/src/resource/archive/ArchiveManager.cpp
@@ -155,7 +155,6 @@ bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::stri
     if (archive) {
         if (archive->WriteFile(filePath, data)) {
             auto hash = CRC64(filePath.c_str());
-            archive->IndexFile(filePath);
             mHashes[hash] = filePath;
             mFileToArchive[hash] = archive;
             return true; // Successfully wrote file

--- a/src/resource/archive/O2rArchive.cpp
+++ b/src/resource/archive/O2rArchive.cpp
@@ -135,6 +135,8 @@ bool O2rArchive::WriteFile(const std::string& filename, const std::vector<uint8_
         return false;
     }
 
+    IndexFile(filePath);
+
     // Success
     return true;
 }

--- a/src/resource/archive/O2rArchive.cpp
+++ b/src/resource/archive/O2rArchive.cpp
@@ -97,7 +97,7 @@ bool O2rArchive::Close() {
     return true;
 }
 
-bool O2rArchive::WriteFile(const std::string& filename, const std::vector<uint8_t>& data) {
+bool O2rArchive::WriteFile(const std::string& filePath, const std::vector<uint8_t>& data) {
     if (!mZipArchive) {
         SPDLOG_ERROR("Cannot write to zip: Archive is not open.");
         return false;
@@ -106,13 +106,13 @@ bool O2rArchive::WriteFile(const std::string& filename, const std::vector<uint8_
     // Create a new zip source from the data buffer
     zip_source_t* source = zip_source_buffer(mZipArchive, data.data(), data.size(), 0);
     if (!source) {
-        SPDLOG_ERROR("Failed to create zip source for file \"{}\"", filename);
+        SPDLOG_ERROR("Failed to create zip source for file \"{}\"", filePath);
         return false;
     }
 
     // Add or replace the file in the zip archive
-    if (zip_file_add(mZipArchive, filename.c_str(), source, ZIP_FL_ENC_UTF_8 | ZIP_FL_OVERWRITE) < 0) {
-        SPDLOG_ERROR("Failed to add file \"{}\" to ZIP", filename);
+    if (zip_file_add(mZipArchive, filePath.c_str(), source, ZIP_FL_ENC_UTF_8 | ZIP_FL_OVERWRITE) < 0) {
+        SPDLOG_ERROR("Failed to add file \"{}\" to ZIP", filePath);
         zip_source_free(source);
         return false;
     }
@@ -126,7 +126,7 @@ bool O2rArchive::WriteFile(const std::string& filename, const std::vector<uint8_
         return false;
     }
 
-    SPDLOG_INFO("Successfully wrote file: {}", filename);
+    SPDLOG_INFO("Successfully wrote file: {}", filePath);
 
     // Reopen the zip file so that it may continued to be used by libultraship
     mZipArchive = zip_open(GetPath().c_str(), ZIP_CREATE, nullptr);

--- a/src/resource/archive/O2rArchive.cpp
+++ b/src/resource/archive/O2rArchive.cpp
@@ -120,9 +120,8 @@ bool O2rArchive::WriteFile(const std::string& filename, const std::vector<uint8_
     // Save changes to disk
     if (zip_close(mZipArchive) < 0) {
         zip_error_t* error = zip_get_error(mZipArchive);
-        SPDLOG_ERROR("Failed to save changes to zip archive: {} ({})",
-                    zip_error_strerror(error),
-                    zip_error_code_zip(error));
+        SPDLOG_ERROR("Failed to save changes to zip archive: {} ({})", zip_error_strerror(error),
+                     zip_error_code_zip(error));
         zip_discard(mZipArchive); // Close zip and discard changes
         return false;
     }

--- a/src/resource/archive/O2rArchive.cpp
+++ b/src/resource/archive/O2rArchive.cpp
@@ -123,7 +123,7 @@ bool O2rArchive::WriteFile(const std::string& filename, const std::vector<uint8_
         SPDLOG_ERROR("Failed to save changes to zip archive: {} ({})",
                     zip_error_strerror(error),
                     zip_error_code_zip(error));
-        zip_discard(mZipArchive); // Optional, if not already discarded
+        zip_discard(mZipArchive); // Close zip and discard changes
         return false;
     }
 


### PR DESCRIPTION
* Adds ResetVirtualFileSystem()

Without this, lus recollection of the files in the archive will be outdated and not include the files that were added to the archive.

The downside of this, is that multiple file writes in a row would result in a refresh that may not be desirable. Feel free to suggest an alternative solution to this. Note that the refresh function is protected (we can't call it outside of the class)

Requires and based on #864 

Resolves https://github.com/Kenix3/libultraship/issues/882