### PR TITLE
Properly fetch app bundle path on windows instead of relying on current directory

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -8,7 +8,9 @@
 #include "graphic/Fast3D/debug/GfxDebugger.h"
 
 #ifdef _WIN32
+#include <libloaderapi.h>
 #include <tchar.h>
+#include <windows.h>
 #endif
 
 #ifdef __APPLE__
@@ -402,6 +404,23 @@ std::string Context::GetAppBundlePath() {
 
         // Find the last '/' and remove everything after it
         long unsigned int lastSlash = progpath.find_last_of("/");
+        if (lastSlash != std::string::npos) {
+            progpath.erase(lastSlash);
+        }
+
+        return progpath;
+    }
+#endif
+
+#ifdef _WIN32
+    std::string progpath(MAX_PATH, '\0');
+
+    int len = GetModuleFileNameA(NULL, &progpath[0], progpath.size());
+    if (len != 0 && len < progpath.size()) {
+        progpath.resize(len);
+
+        // Find the last '\' and remove everything after it
+        long unsigned int lastSlash = progpath.find_last_of("\\");
         if (lastSlash != std::string::npos) {
             progpath.erase(lastSlash);
         }


### PR DESCRIPTION
When running on windows and using the "Start in" shortcut option (or launching via the command line) we can start a program with a different working directory than the one where the executable is.

When doing so SoH fails because it can't find its assets.

This PR adds code to fetch the app bundle path by fetching the executable path on windows similarly to what is done for Linux.

I originally wanted to use `SDL_GetBasePath` but it converts the path into UTF-8 (from UTF-16) which makes the calls to the filesystem API fail when if the path contain special characters.

I tested the changes by building SoH with the changed lib and it gets the app path correctly when running with a different current directory.