### PR TITLE
Make GuiElement's destructor virtual

### DIFF
--- a/src/window/gui/GuiElement.h
+++ b/src/window/gui/GuiElement.h
@@ -7,7 +7,7 @@ class GuiElement {
   public:
     GuiElement(bool isVisible);
     GuiElement();
-    ~GuiElement();
+    virtual ~GuiElement();
 
     void Init();
     virtual void Draw() = 0;


### PR DESCRIPTION
I noticed this when working on a task for SoH. This was causing warnings: see https://github.com/HarbourMasters/Shipwright/pull/5443 (`warning: destructor called on non-final 'SohGui::SohMenu' that has virtual functions but non-virtual destructor`). It was fixed in a different way there, but it did not address the underlying issue.