### PR TITLE
Always call PSSetSamplers in D3D11

### DIFF
--- a/src/graphic/Fast3D/gfx_direct3d11.cpp
+++ b/src/graphic/Fast3D/gfx_direct3d11.cpp
@@ -761,11 +761,10 @@ static void gfx_d3d11_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_t
 
                 if (d3d.last_sampler_states[i].Get() != d3d.textures[d3d.current_texture_ids[i]].sampler_state.Get()) {
                     d3d.last_sampler_states[i] = d3d.textures[d3d.current_texture_ids[i]].sampler_state.Get();
-                    d3d.context->PSSetSamplers(i, 1,
-                                               d3d.textures[d3d.current_texture_ids[i]].sampler_state.GetAddressOf());
                 }
             }
         }
+        d3d.context->PSSetSamplers(i, 1, d3d.textures[d3d.current_texture_ids[i]].sampler_state.GetAddressOf());
     }
 
     // Set per-draw constant buffer


### PR DESCRIPTION
[2ship2harkinian has texture UV issues on DirectX](https://github.com/HarbourMasters/2ship2harkinian/issues/475), which can vary/flicker with player position and camera angle. This seems to be caused by `d3d.context->PSSetSamplers` only being conditionally called. Always calling it fixes these issues.

Current 2ship behavior on DirectX:
https://github.com/user-attachments/assets/840d8f08-e1f2-4ab7-b827-71bee386785c

2ship behavior on DirectX with this fix:
https://github.com/user-attachments/assets/0067c195-b9fe-47ce-af1e-e558c95c1b54

