### PR TITLE
bump imgui to `v1.91.9b-docking`

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -9,7 +9,7 @@ set(imgui_apply_patch_command ${CMAKE_COMMAND} -Dpatch_file=${imgui_fixes_and_co
 FetchContent_Declare(
     ImGui
     GIT_REPOSITORY https://github.com/ocornut/imgui.git
-    GIT_TAG v1.91.6-docking
+    GIT_TAG v1.91.9b-docking
     PATCH_COMMAND ${imgui_apply_patch_command}
 )
 FetchContent_MakeAvailable(ImGui)

--- a/cmake/dependencies/patches/imgui-fixes-and-config.patch
+++ b/cmake/dependencies/patches/imgui-fixes-and-config.patch
@@ -1,17 +1,76 @@
-From 7cd9b89560b66b992db9fd0e620c2d28ad9a9645 Mon Sep 17 00:00:00 2001
+From 28c317c55769110b4f83003aa9e868f66157b3fe Mon Sep 17 00:00:00 2001
 From: briaguya <70942617+briaguya-ai@users.noreply.github.com>
-Date: Fri, 10 Jan 2025 04:48:50 -0500
-Subject: [PATCH 1/2] sdl gamepad fix
+Date: Sat, 17 May 2025 04:41:55 -0400
+Subject: [PATCH 1/3] Revert "Backends: Metal: Fixed memory leaks. (#8276,
+ #8166)"
+
+This reverts commit e6a7c7689f57038b2519fe43e55e3d57103ad0f7.
+---
+ backends/imgui_impl_metal.mm | 8 --------
+ docs/CHANGELOG.txt           | 1 -
+ 2 files changed, 9 deletions(-)
+
+diff --git a/backends/imgui_impl_metal.mm b/backends/imgui_impl_metal.mm
+index 9ab4a342adfd..388c4f3984e1 100644
+--- a/backends/imgui_impl_metal.mm
++++ b/backends/imgui_impl_metal.mm
+@@ -18,7 +18,6 @@
+ // (minor and older changes stripped away, please see git history for details)
+ //  2025-XX-XX: Metal: Added support for multiple windows via the ImGuiPlatformIO interface.
+ //  2025-02-03: Metal: Crash fix. (#8367)
+-//  2025-01-08: Metal: Fixed memory leaks when using metal-cpp (#8276, #8166) or when using multiple contexts (#7419).
+ //  2022-08-23: Metal: Update deprecated property 'sampleCount'->'rasterSampleCount'.
+ //  2022-07-05: Metal: Add dispatch synchronization.
+ //  2022-06-30: Metal: Use __bridge for ARC based systems.
+@@ -171,11 +170,7 @@ void ImGui_ImplMetal_NewFrame(MTLRenderPassDescriptor* renderPassDescriptor)
+ {
+     ImGui_ImplMetal_Data* bd = ImGui_ImplMetal_GetBackendData();
+     IM_ASSERT(bd != nil && "Context or backend not initialized! Did you call ImGui_ImplMetal_Init()?");
+-#ifdef IMGUI_IMPL_METAL_CPP
+-    bd->SharedMetalContext.framebufferDescriptor = [[[FramebufferDescriptor alloc] initWithRenderPassDescriptor:renderPassDescriptor]autorelease];
+-#else
+     bd->SharedMetalContext.framebufferDescriptor = [[FramebufferDescriptor alloc] initWithRenderPassDescriptor:renderPassDescriptor];
+-#endif
+     if (bd->SharedMetalContext.depthStencilState == nil)
+         ImGui_ImplMetal_CreateDeviceObjects(bd->SharedMetalContext.device);
+ }
+@@ -383,9 +378,6 @@ bool ImGui_ImplMetal_CreateDeviceObjects(id<MTLDevice> device)
+     depthStencilDescriptor.depthCompareFunction = MTLCompareFunctionAlways;
+     bd->SharedMetalContext.depthStencilState = [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
+     ImGui_ImplMetal_CreateDeviceObjectsForPlatformWindows();
+-#ifdef IMGUI_IMPL_METAL_CPP
+-    [depthStencilDescriptor release];
+-#endif
+     ImGui_ImplMetal_CreateFontsTexture(device);
+     return true;
+ }
+diff --git a/docs/CHANGELOG.txt b/docs/CHANGELOG.txt
+index 6c4f19cfef02..e4a4cbf98ef6 100644
+--- a/docs/CHANGELOG.txt
++++ b/docs/CHANGELOG.txt
+@@ -355,7 +355,6 @@ Other changes:
+   though it is currently not doing anything particular. (#8163, #7998, #7988)
+ - Backends: Allegro5: Avoid calling al_set_mouse_cursor() repeatedly since it appears
+   to leak on on X11 (#8256). [@Helodity]
+-- Backends: Metal: Fixed leaks when using metal-cpp. (#8276, #8166) [@selimsandal]
+ - Backends: Metal: Fixed resource leak when using multiple contexts. (#7419) [@anszom]
+ - Backends: Vulkan: Fixed setting VkSwapchainCreateInfoKHR::preTransform for
+   platforms not supporting VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR. (#8222) [@Zer0xFF]
+
+From 56f5907cf5224e1a2f64289029cc2b46e51d3b6c Mon Sep 17 00:00:00 2001
+From: briaguya <70942617+briaguya-ai@users.noreply.github.com>
+Date: Sat, 17 May 2025 04:42:41 -0400
+Subject: [PATCH 2/3] gamepad fix
 
 ---
  backends/imgui_impl_sdl2.cpp | 3 ---
  1 file changed, 3 deletions(-)
 
 diff --git a/backends/imgui_impl_sdl2.cpp b/backends/imgui_impl_sdl2.cpp
-index 23f12796..a7fef045 100644
+index f3a31c5c3c5e..2e6a1ad9d1f1 100644
 --- a/backends/imgui_impl_sdl2.cpp
 +++ b/backends/imgui_impl_sdl2.cpp
-@@ -816,9 +816,6 @@ static void ImGui_ImplSDL2_UpdateGamepads()
+@@ -845,9 +845,6 @@ static void ImGui_ImplSDL2_UpdateGamepads()
          bd->WantUpdateGamepadsList = false;
      }
  
@@ -21,24 +80,21 @@ index 23f12796..a7fef045 100644
      io.BackendFlags &= ~ImGuiBackendFlags_HasGamepad;
      if (bd->Gamepads.Size == 0)
          return;
--- 
-2.47.1
 
-
-From 635226a311071e80c22e0c58c9cb5c9d950d2e17 Mon Sep 17 00:00:00 2001
+From 90c4297624a0fe993f1ac0e538bccdc80a0fc5f2 Mon Sep 17 00:00:00 2001
 From: briaguya <70942617+briaguya-ai@users.noreply.github.com>
-Date: Fri, 10 Jan 2025 04:52:36 -0500
-Subject: [PATCH 2/2] add config stuff
+Date: Sat, 17 May 2025 04:42:56 -0400
+Subject: [PATCH 3/3] config
 
 ---
  imconfig.h | 5 ++++-
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/imconfig.h b/imconfig.h
-index 8f8bc3b9..cc578e3f 100644
+index a1e29e849bc8..ee64116ff0cf 100644
 --- a/imconfig.h
 +++ b/imconfig.h
-@@ -111,7 +111,7 @@
+@@ -110,7 +110,7 @@
          operator MyVec4() const { return MyVec4(x,y,z,w); }
  */
  //---- ...Or use Dear ImGui's own very basic math operators.
@@ -47,13 +103,10 @@ index 8f8bc3b9..cc578e3f 100644
  
  //---- Use 32-bit vertex indices (default is 16-bit) is one way to allow large meshes with more than 64K vertices.
  // Your renderer backend will need to support it (most example renderer backends support both 16/32-bit indices).
-@@ -140,3 +140,6 @@ namespace ImGui
+@@ -139,3 +139,6 @@ namespace ImGui
      void MyFunction(const char* name, MyMatrix44* mtx);
  }
  */
 +
 +// handle https://github.com/ocornut/imgui/issues/1641 the old way
 +#define ImTextureID void*
--- 
-2.47.1
-


### PR DESCRIPTION
~i verified [the patch](https://github.com/Kenix3/libultraship/blob/main/cmake/dependencies/patches/imgui-fixes-and-config.patch) still works on the new version~

ran into an issue with the mac build, tracked it down to https://github.com/ocornut/imgui/commit/e6a7c7689f57038b2519fe43e55e3d57103ad0f7, added a revert to the patch for now

context on the mac build issue:

me on discord:
> looks like the error is
> ```
> imgui-src/backends/imgui_impl_metal.mm:175:134: error: 'autorelease' is unavailable: not available in automatic reference counting mode
> ```
> 
> which seems to have come from <https://github.com/ocornut/imgui/commit/e6a7c7689f57038b2519fe43e55e3d57103ad0f7>
> 
> i'm not sure what "automatic reference counting mode" is in this context, where it's being set, or if we should be using it

me responding to myself on discord:
> > where it's being set
>
> looks like <https://github.com/Kenix3/libultraship/blob/7135d1494e74c38aa7fca734b92ec50bba543b44/src/CMakeLists.txt#L247-L249> (has been around since <https://github.com/Kenix3/libultraship/pull/80>)
> 
> > if we should be using it
> 
> based on <https://github.com/Kenix3/libultraship/blob/7135d1494e74c38aa7fca734b92ec50bba543b44/src/graphic/Fast3D/backends/gfx_metal.cpp#L74>,  and <https://developer.apple.com/documentation/foundation/nsautoreleasepool> it looks like we're doing at least some things the non ARC way, but my gut feeling is turning it off may cause more harm than good


soh testing pr:
* https://github.com/HarbourMasters/Shipwright/pull/5501