### PR TITLE
Revert Addition of sched_yield(); for macOS.

### DIFF
--- a/src/graphic/Fast3D/backends/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/backends/gfx_sdl2.cpp
@@ -653,14 +653,10 @@ void GfxWindowBackendSDL2::SyncFramerateWithTime() const {
 #endif
     }
 
-#if defined(_WIN32) || defined(__APPLE__)
+#ifdef _WIN32
     t = qpc_to_100ns(SDL_GetPerformanceCounter());
     while (t < next) {
-#ifdef _WIN32
-        YieldProcessor();
-#elif defined(__APPLE__)
-        sched_yield();
-#endif
+        YieldProcessor(); // TODO: Find a way for other compilers, OSes and architectures
         t = qpc_to_100ns(SDL_GetPerformanceCounter());
     }
 #endif


### PR DESCRIPTION
This doesn't seem to do anything in testing, even on older (2012) Macs. It's left in for Windows in case it helps lower end PCs, but it's not doing anything for Macs in my testing and, frankly, sched_yield is really not equivalent to YieldProcessor anyway and increases the rate of context switches. Thanks!