### PR TITLE
Fix OSContPad Bitmask Overflow

### DIFF
--- a/include/libultraship/libultra/controller.h
+++ b/include/libultraship/libultra/controller.h
@@ -57,7 +57,7 @@
 #define PFS_ERR_NOPACK 1
 
 #ifndef CONTROLLERBUTTONS_T
-#define CONTROLLERBUTTONS_T uint16_t
+#define CONTROLLERBUTTONS_T uint32_t
 #endif
 
 /* Buttons */

--- a/src/controller/controldevice/controller/mapping/ControllerButtonMapping.h
+++ b/src/controller/controldevice/controller/mapping/ControllerButtonMapping.h
@@ -8,7 +8,7 @@
 namespace Ship {
 
 #ifndef CONTROLLERBUTTONS_T
-#define CONTROLLERBUTTONS_T uint16_t
+#define CONTROLLERBUTTONS_T uint32_t
 #endif
 
 class ControllerButtonMapping : virtual public ControllerInputMapping {


### PR DESCRIPTION
The stick directions are assigned bit mask values in the uint32_t space