### PR TITLE
set `FontDataOwnedByAtlas` in `ImFontConfig` to `false` in `GameOverlay::LoadFont()`

### DIFF
--- a/src/window/gui/GameOverlay.cpp
+++ b/src/window/gui/GameOverlay.cpp
@@ -33,7 +33,13 @@ void GameOverlay::LoadFont(const std::string& name, float fontSize, const Resour
         return;
     }
 
-    mFonts[name] = io.Fonts->AddFontFromMemoryTTF(font->Data, font->DataSize, fontSize);
+    char* fontDataPtr = (char*)malloc(font->DataSize);
+    if (fontDataPtr != NULL) {
+        memcpy(fontDataPtr, font->Data, font->DataSize);
+        mFonts[name] = io.Fonts->AddFontFromMemoryTTF(fontDataPtr, font->DataSize, fontSize);
+    } else {
+        SPDLOG_ERROR("Failed to allocate font: {}", name);
+    }
 }
 
 void GameOverlay::LoadFont(const std::string& name, float fontSize, const std::string& path) {
@@ -51,7 +57,13 @@ void GameOverlay::LoadFont(const std::string& name, float fontSize, const std::s
         return;
     }
 
-    mFonts[name] = io.Fonts->AddFontFromMemoryTTF(font->Data, font->DataSize, fontSize);
+    char* fontDataPtr = (char*)malloc(font->DataSize);
+    if (fontDataPtr != NULL) {
+        memcpy(fontDataPtr, font->Data, font->DataSize);
+        mFonts[name] = io.Fonts->AddFontFromMemoryTTF(fontDataPtr, font->DataSize, fontSize);
+    } else {
+        SPDLOG_ERROR("Failed to allocate font: {}", name);
+    }
 }
 
 void GameOverlay::TextDraw(float x, float y, bool shadow, ImVec4 color, const char* fmt, ...) {

--- a/src/window/gui/GameOverlay.cpp
+++ b/src/window/gui/GameOverlay.cpp
@@ -32,14 +32,9 @@ void GameOverlay::LoadFont(const std::string& name, float fontSize, const Resour
         SPDLOG_ERROR("Failed to load font: {}", name);
         return;
     }
-
-    char* fontDataPtr = (char*)malloc(font->DataSize);
-    if (fontDataPtr != NULL) {
-        memcpy(fontDataPtr, font->Data, font->DataSize);
-        mFonts[name] = io.Fonts->AddFontFromMemoryTTF(fontDataPtr, font->DataSize, fontSize);
-    } else {
-        SPDLOG_ERROR("Failed to allocate font: {}", name);
-    }
+    ImFontConfig fontConf = {};
+    fontConf.FontDataOwnedByAtlas = false;
+    mFonts[name] = io.Fonts->AddFontFromMemoryTTF(font->Data, font->DataSize, fontSize, &fontConf);
 }
 
 void GameOverlay::LoadFont(const std::string& name, float fontSize, const std::string& path) {
@@ -56,14 +51,9 @@ void GameOverlay::LoadFont(const std::string& name, float fontSize, const std::s
         SPDLOG_ERROR("Failed to load font: {}", name);
         return;
     }
-
-    char* fontDataPtr = (char*)malloc(font->DataSize);
-    if (fontDataPtr != NULL) {
-        memcpy(fontDataPtr, font->Data, font->DataSize);
-        mFonts[name] = io.Fonts->AddFontFromMemoryTTF(fontDataPtr, font->DataSize, fontSize);
-    } else {
-        SPDLOG_ERROR("Failed to allocate font: {}", name);
-    }
+    ImFontConfig fontConf = {};
+    fontConf.FontDataOwnedByAtlas = false;
+    mFonts[name] = io.Fonts->AddFontFromMemoryTTF(font->Data, font->DataSize, fontSize, &fontConf);
 }
 
 void GameOverlay::TextDraw(float x, float y, bool shadow, ImVec4 color, const char* fmt, ...) {


### PR DESCRIPTION
Following <https://github.com/Kenix3/libultraship/pull/888#issuecomment-2899476493> when trying to update SoH, I was still seeing crashes on close that looked like the same issue, and realized that the process hadn't been applied to `GameOverlay::LoadFont()`, but after some investigation, I found out that the memcpy method coco outlined was unnecessary. All we needed was to pass an `ImFontConfig` with `FontDataOwnedByAtlas` set to false, which prevents ImGui from trying to free the data in its own shutdown.