### PR TITLE
Use SHADER_MAX_TEXTURES for OGL mCurrentTextureIds

### DIFF
--- a/src/graphic/Fast3D/backends/gfx_opengl.h
+++ b/src/graphic/Fast3D/backends/gfx_opengl.h
@@ -106,7 +106,7 @@ class GfxRenderingAPIOGL final : public GfxRenderingAPI {
         uint16_t filtering;
     } textures[1024];
 
-    GLuint mCurrentTextureIds[2];
+    GLuint mCurrentTextureIds[SHADER_MAX_TEXTURES];
     uint8_t mCurrentTile;
 
     std::map<std::pair<uint64_t, uint32_t>, ShaderProgram> mShaderProgramPool;


### PR DESCRIPTION
`mCurrentTextureIds` has a size of `SHADER_MAX_TEXTURES` for Metal and D3D11, but OpenGL only has a size of 2. This seems like an oversight, as the following code will access mCurrentTextureIds with a minimum index of 4:

https://github.com/Kenix3/libultraship/blob/5e33d3e7cd0396f847923cd6c471eaf324e90351/src/graphic/Fast3D/interpreter.cpp#L1581-L1584

I believe this is the cause of https://github.com/HarbourMasters/Shipwright/issues/5613. I'd see accesses for tiles 2 and 4, which are OOB, followed by a crash when opening the pause menu. With this change, I no longer get that crash.