### PR TITLE
obey app directory for default.sav

### DIFF
--- a/src/public/libultra/os_eeprom.cpp
+++ b/src/public/libultra/os_eeprom.cpp
@@ -10,7 +10,8 @@ int32_t osEepromLongRead(OSMesgQueue* mq, uint8_t address, uint8_t* buffer, int3
     u8 content[512];
     s32 ret = -1;
 
-    FILE* fp = fopen("default.sav", "rb");
+    const std::string save_file = Ship::Context::GetPathRelativeToAppDirectory("default.sav");
+    FILE* fp = fopen(save_file.c_str(), "rb");
     if (fp == NULL) {
         return -1;
     }
@@ -34,7 +35,8 @@ int32_t osEepromLongWrite(OSMesgQueue* mq, uint8_t address, uint8_t* buffer, int
     }
     memcpy(content + address * 8, buffer, length);
 
-    FILE* fp = fopen("default.sav", "wb");
+    const std::string save_file = Ship::Context::GetPathRelativeToAppDirectory("default.sav");
+    FILE* fp = fopen(save_file.c_str(), "wb");
     if (fp == NULL) {
         return -1;
     }


### PR DESCRIPTION
For `osEepromLongRead`/`osEepromLongWrite`; This PR patches the placement of the default save file binary to correct path mostly set to user's data directory (or mostly what `SHIP_HOME` is set to), instead of placing it on current working directory on where the game is executed.