### PR TITLE
NullAudioEngine: replace SDL as fallback

### DIFF
--- a/src/audio/Audio.cpp
+++ b/src/audio/Audio.cpp
@@ -16,18 +16,16 @@ void Audio::InitAudioPlayer() {
             mAudioPlayer = std::make_shared<WasapiAudioPlayer>(this->mAudioSettings);
             break;
 #endif
-        default:
+        case AudioBackend::SDL:
             mAudioPlayer = std::make_shared<SDLAudioPlayer>(this->mAudioSettings);
+        default:
+            mAudioPlayer = std::make_shared<NullAudioPlayer>(this->mAudioSettings);
     }
 
-    if (mAudioPlayer) {
-        if (!mAudioPlayer->Init()) {
-            // Failed to initialize system audio player.
-            // Fallback to SDL if the native system player does not work.
-            SetCurrentAudioBackend(AudioBackend::SDL);
-            mAudioPlayer = std::make_shared<SDLAudioPlayer>(this->mAudioSettings);
-            mAudioPlayer->Init();
-        }
+    if (mAudioPlayer && !mAudioPlayer->Init()) {
+        // Failed to initialize system audio player.
+        // Fallback to Null if the native system player does not work.
+        SetCurrentAudioBackend(AudioBackend::NUL);
     }
 }
 
@@ -37,6 +35,7 @@ void Audio::Init() {
     mAvailableAudioBackends->push_back(AudioBackend::WASAPI);
 #endif
     mAvailableAudioBackends->push_back(AudioBackend::SDL);
+    mAvailableAudioBackends->push_back(AudioBackend::NUL);
 
     SetCurrentAudioBackend(Context::GetInstance()->GetConfig()->GetCurrentAudioBackend());
 }

--- a/src/audio/Audio.h
+++ b/src/audio/Audio.h
@@ -6,7 +6,7 @@
 #include "audio/AudioPlayer.h"
 
 namespace Ship {
-enum class AudioBackend { WASAPI, SDL };
+enum class AudioBackend { WASAPI, SDL, NUL };
 
 class Audio {
   public:

--- a/src/audio/AudioPlayer.h
+++ b/src/audio/AudioPlayer.h
@@ -56,3 +56,4 @@ class AudioPlayer {
 #endif
 
 #include "SDLAudioPlayer.h"
+#include "NullAudioPlayer.h"

--- a/src/audio/NullAudioPlayer.cpp
+++ b/src/audio/NullAudioPlayer.cpp
@@ -1,0 +1,20 @@
+#include "NullAudioPlayer.h"
+#include <spdlog/spdlog.h>
+
+namespace Ship {
+
+NullAudioPlayer::~NullAudioPlayer() {
+    SPDLOG_TRACE("destruct Null audio player");
+}
+
+bool NullAudioPlayer::DoInit() {
+    return true;
+}
+
+int NullAudioPlayer::Buffered() {
+    return 0;
+}
+
+void NullAudioPlayer::Play(const uint8_t* buf, size_t len) {
+}
+} // namespace Ship

--- a/src/audio/NullAudioPlayer.h
+++ b/src/audio/NullAudioPlayer.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "AudioPlayer.h"
+
+namespace Ship {
+class NullAudioPlayer final : public AudioPlayer {
+  public:
+    NullAudioPlayer(AudioSettings settings) : AudioPlayer(settings) {
+    }
+    ~NullAudioPlayer();
+
+    int Buffered();
+    void Play(const uint8_t* buf, size_t len);
+
+  protected:
+    bool DoInit();
+};
+} // namespace Ship

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -249,6 +249,10 @@ AudioBackend Config::GetCurrentAudioBackend() {
         return AudioBackend::SDL;
     }
 
+    if (backendName == "null") {
+        return AudioBackend::NUL;
+    }
+
     SPDLOG_TRACE("Could not find AudioBackend matching value from config file ({}). Returning default AudioBackend.",
                  backendName);
 #ifdef _WIN32
@@ -278,6 +282,9 @@ void Config::SetCurrentAudioBackend(AudioBackend backend) {
             break;
         case AudioBackend::SDL:
             SetString("Window.AudioBackend", "sdl");
+            break;
+        case AudioBackend::NUL:
+            SetString("Window.AudioBackend", "null");
             break;
         default:
             SetString("Window.AudioBackend", "");


### PR DESCRIPTION
Avoids infinite recursion when SDL init fails