### PR TITLE
Improve Windows logs for crash handling

### DIFF
--- a/src/debug/CrashHandler.cpp
+++ b/src/debug/CrashHandler.cpp
@@ -213,85 +213,85 @@ static void ShutdownHandler(int sig, siginfo_t* sigInfo, void* data) {
 #endif
 
 void CrashHandler::PrintRegisters(CONTEXT* ctx) {
-    AppendLine("Registers: ");
+    AppendLine("Registers:");
     char regBuff[25];
 #if defined(_M_AMD64)
-    sprintf_s(regBuff, std::size(regBuff), "RAX: 0x%016llX", ctx->Rax);
+    sprintf_s(regBuff, std::size(regBuff), "    RAX: 0x%016llX", ctx->Rax);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "RCX: 0x%016llX", ctx->Rcx);
+    sprintf_s(regBuff, std::size(regBuff), "    RCX: 0x%016llX", ctx->Rcx);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "RDX: 0x%016llX", ctx->Rdx);
+    sprintf_s(regBuff, std::size(regBuff), "    RDX: 0x%016llX", ctx->Rdx);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "RBX: 0x%016llX", ctx->Rbx);
+    sprintf_s(regBuff, std::size(regBuff), "    RBX: 0x%016llX", ctx->Rbx);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "RSP: 0x%016llX", ctx->Rsp);
+    sprintf_s(regBuff, std::size(regBuff), "    RSP: 0x%016llX", ctx->Rsp);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "RBP: 0x%016llX", ctx->Rbp);
+    sprintf_s(regBuff, std::size(regBuff), "    RBP: 0x%016llX", ctx->Rbp);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "RSI: 0x%016llX", ctx->Rsi);
+    sprintf_s(regBuff, std::size(regBuff), "    RSI: 0x%016llX", ctx->Rsi);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "RDI: 0x%016llX", ctx->Rdi);
+    sprintf_s(regBuff, std::size(regBuff), "    RDI: 0x%016llX", ctx->Rdi);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "R9:  0x%016llX", ctx->R9);
+    sprintf_s(regBuff, std::size(regBuff), "    R9:  0x%016llX", ctx->R9);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "R10: 0x%016llX", ctx->R10);
+    sprintf_s(regBuff, std::size(regBuff), "    R10: 0x%016llX", ctx->R10);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "R11: 0x%016llX", ctx->R11);
+    sprintf_s(regBuff, std::size(regBuff), "    R11: 0x%016llX", ctx->R11);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "R12: 0x%016llX", ctx->R12);
+    sprintf_s(regBuff, std::size(regBuff), "    R12: 0x%016llX", ctx->R12);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "R13: 0x%016llX", ctx->R13);
+    sprintf_s(regBuff, std::size(regBuff), "    R13: 0x%016llX", ctx->R13);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "R14: 0x%016llX", ctx->R14);
+    sprintf_s(regBuff, std::size(regBuff), "    R14: 0x%016llX", ctx->R14);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "R15: 0x%016llX", ctx->R15);
+    sprintf_s(regBuff, std::size(regBuff), "    R15: 0x%016llX", ctx->R15);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "RIP: 0x%016llX", ctx->Rip);
+    sprintf_s(regBuff, std::size(regBuff), "    RIP: 0x%016llX", ctx->Rip);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "EFLAGS: 0x%08lX", ctx->EFlags);
+    sprintf_s(regBuff, std::size(regBuff), "    EFLAGS: 0x%08lX", ctx->EFlags);
     AppendLine(regBuff);
 #elif defined(WINDOWS_32_BIT)
-    sprintf_s(regBuff, std::size(regBuff), "EDI: 0x%08lX", ctx->Edi);
+    sprintf_s(regBuff, std::size(regBuff), "    EDI: 0x%08lX", ctx->Edi);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "ESI: 0x%08lX", ctx->Esi);
+    sprintf_s(regBuff, std::size(regBuff), "    ESI: 0x%08lX", ctx->Esi);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "EBX: 0x%08lX", ctx->Ebx);
+    sprintf_s(regBuff, std::size(regBuff), "    EBX: 0x%08lX", ctx->Ebx);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "ECX: 0x%08lX", ctx->Ecx);
+    sprintf_s(regBuff, std::size(regBuff), "    ECX: 0x%08lX", ctx->Ecx);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "EAX: 0x%08lX", ctx->Eax);
+    sprintf_s(regBuff, std::size(regBuff), "    EAX: 0x%08lX", ctx->Eax);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "EBP: 0x%08lX", ctx->Ebp);
+    sprintf_s(regBuff, std::size(regBuff), "    EBP: 0x%08lX", ctx->Ebp);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "ESP: 0x%08lX", ctx->Esp);
+    sprintf_s(regBuff, std::size(regBuff), "    ESP: 0x%08lX", ctx->Esp);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "EFLAGS: 0x%08lX", ctx->EFlags);
+    sprintf_s(regBuff, std::size(regBuff), "    EFLAGS: 0x%08lX", ctx->EFlags);
     AppendLine(regBuff);
 
-    sprintf_s(regBuff, std::size(regBuff), "EIP: 0x%08lX", ctx->Eip);
+    sprintf_s(regBuff, std::size(regBuff), "    EIP: 0x%08lX", ctx->Eip);
     AppendLine(regBuff);
 #endif
 }
@@ -344,6 +344,8 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
         IMAGE_FILE_MACHINE_I386;
 #endif
 
+    AppendLine("Traceback:");
+
     displacement = 0;
     for (frame = 0;; frame++) {
         result = StackWalk(machineType, process, thread, &stack, &ctx2, nullptr, SymFunctionTableAccess,
@@ -362,19 +364,18 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
         line.SizeOfStruct = sizeof(IMAGEHLP_LINE);
 #endif
         if (SymGetLineFromAddr(process, stack.AddrPC.Offset, &disp, &line)) {
-            char lineNumberStr[16];
-            sprintf_s(lineNumberStr, sizeof(lineNumberStr), "Line: %d", line.LineNumber);
+            AppendStr("    ");
             AppendStr(symbol->Name);
             AppendStr(" in ");
             AppendStr(line.FileName);
+            char lineNumberStr[16];
+            sprintf_s(lineNumberStr, sizeof(lineNumberStr), " Line: %d\n", line.LineNumber);
             AppendStr(lineNumberStr);
-            // SPDLOG_CRITICAL("{} in {}: line: {}: ", symbol->Name, line.FileName, line.LineNumber);
         } else {
             char addrString[20];
             sprintf_s(addrString, std::size(addrString), "0x%016llX", symbol->Address);
             WRITE_VAR_M("At ", symbol->Name);
             WRITE_VAR_LINE_M("Addr: ", addrString);
-            // SPDLOG_CRITICAL("at {}, addr 0x{}", symbol->Name, addrString);
             hModule = nullptr;
             GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                               (LPCTSTR)(stack.AddrPC.Offset), &hModule);
@@ -383,7 +384,6 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
                 GetModuleFileNameA(hModule, module, sizeof(module));
             }
             WRITE_VAR_LINE_M("In: ", module);
-            // SPDLOG_CRITICAL("In {}", module);
         }
     }
     PrintCommon();

--- a/src/debug/CrashHandler.cpp
+++ b/src/debug/CrashHandler.cpp
@@ -369,21 +369,24 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
             AppendStr(" in ");
             AppendStr(line.FileName);
             char lineNumberStr[16];
-            sprintf_s(lineNumberStr, sizeof(lineNumberStr), " Line: %d\n", line.LineNumber);
-            AppendStr(lineNumberStr);
+            sprintf_s(lineNumberStr, sizeof(lineNumberStr), " Line: %d", line.LineNumber);
+            AppendLine(lineNumberStr);
         } else {
+            WRITE_VAR_M("    ", symbol->Name);
             char addrString[20];
             sprintf_s(addrString, std::size(addrString), "0x%016llX", symbol->Address);
-            WRITE_VAR_M("At ", symbol->Name);
-            WRITE_VAR_LINE_M("Addr: ", addrString);
+            WRITE_VAR_M("(", addrString);
+            AppendStr(")");
             hModule = nullptr;
             GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                               (LPCTSTR)(stack.AddrPC.Offset), &hModule);
 
             if (hModule != nullptr) {
                 GetModuleFileNameA(hModule, module, sizeof(module));
+                WRITE_VAR_LINE_M(" in ", module);
+            } else {
+                WRITE_VAR_LINE_M(" in ", "???");
             }
-            WRITE_VAR_LINE_M("In: ", module);
         }
     }
     PrintCommon();


### PR DESCRIPTION
Improves the logged information of a crash in windows.
Here's an example of the difference with a crash from SoH:
Before:
```
[20:14:43.150] [CrashHandler.cpp:72] [critical] Exception: 0x80000003
Registers: 
RAX: 0x0000000000000004
RCX: 0x0FA0000000000000
RDX: 0x0000000077695C97
RBX: 0x0000000000000000
RSP: 0x00000061E6EFE160
RBP: 0x00000061E6EFE6F0
RSI: 0x00000061E6EFE7B8
RDI: 0x00000061E6EFE630
R9:  0x0000000000000001
R10: 0x0000000000008000
R11: 0x00000061E6EFDEE0
R12: 0x0000000000000000
R13: 0x0000000000000000
R14: 0x0000000000000000
R15: 0x0000000000000000
RIP: 0x00007FF660C9C015
EFLAGS: 0x00000246
common_assert_to_message_box<wchar_t> in minkernel\crts\ucrt\src\appcrt\startup\assert.cppLine: 388common_assert<wchar_t> in minkernel\crts\ucrt\src\appcrt\startup\assert.cppLine: 424_wassert in minkernel\crts\ucrt\src\appcrt\startup\assert.cppLine: 444Rando::Option::GetValueFromText in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\soh\Enhancements\randomizer\option.cppLine: 167Rando::Settings::ParseJson in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\soh\Enhancements\randomizer\settings.cppLine: 2913Rando::Context::ParseSpoiler in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\soh\Enhancements\randomizer\context.cppLine: 386Randomizer_ParseSpoiler in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\soh\OTRGlobals.cppLine: 2119FileChoose_UpdateRandomizer in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\overlays\gamestates\ovl_file_choose\z_file_choose.cLine: 1075FileChoose_UpdateMainMenu in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\overlays\gamestates\ovl_file_choose\z_file_choose.cLine: 1101FileChoose_ConfigModeUpdate in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\overlays\gamestates\ovl_file_choose\z_file_choose.cLine: 1848FileChoose_Main in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\overlays\gamestates\ovl_file_choose\z_file_choose.cLine: 3718GameState_Update in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\code\game.cLine: 270Graph_Update in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\code\graph.cLine: 297RunFrame in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\code\graph.cLine: 487Graph_ThreadEntry in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\code\graph.cLine: 518Main in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\code\main.cLine: 140SDL_main in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\code\main.cLine: 67main_getcmdline in D:\Users\Pablo\Documents\GitHub\Shipwright\build\x64\vcpkg\buildtrees\sdl2\src\ase-2.30.5-4439cd0809.clean\src\main\windows\SDL_windows_main.cLine: 80WinMain in D:\Users\Pablo\Documents\GitHub\Shipwright\build\x64\vcpkg\buildtrees\sdl2\src\ase-2.30.5-4439cd0809.clean\src\main\windows\SDL_windows_main.cLine: 110invoke_main in D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inlLine: 107__scrt_common_main_seh in D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inlLine: 288__scrt_common_main in D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inlLine: 331WinMainCRTStartup in D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_winmain.cppLine: 17At BaseThreadInitThunkAddr: 0x00007FF9F8427360
In: C:\Windows\System32\KERNEL32.DLL
At RtlUserThreadStartAddr: 0x00007FF9F911CC70
In: C:\Windows\SYSTEM32\ntdll.dll
```
After:
```
[20:14:43.150] [CrashHandler.cpp:72] [critical] Exception: 0x80000003
Registers:
    RAX: 0x0000000000000004
    RCX: 0x0FA0000000000000
    RDX: 0x0000000077695C97
    RBX: 0x0000000000000000
    RSP: 0x00000061E6EFE160
    RBP: 0x00000061E6EFE6F0
    RSI: 0x00000061E6EFE7B8
    RDI: 0x00000061E6EFE630
    R9:  0x0000000000000001
    R10: 0x0000000000008000
    R11: 0x00000061E6EFDEE0
    R12: 0x0000000000000000
    R13: 0x0000000000000000
    R14: 0x0000000000000000
    R15: 0x0000000000000000
    RIP: 0x00007FF660C9C015
    EFLAGS: 0x00000246
Traceback:
    common_assert_to_message_box<wchar_t> in minkernel\crts\ucrt\src\appcrt\startup\assert.cpp Line: 388
    common_assert<wchar_t> in minkernel\crts\ucrt\src\appcrt\startup\assert.cpp Line: 424
    _wassert in minkernel\crts\ucrt\src\appcrt\startup\assert.cpp Line: 444
    Rando::Option::GetValueFromText in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\soh\Enhancements\randomizer\option.cpp Line: 167
    Rando::Settings::ParseJson in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\soh\Enhancements\randomizer\settings.cpp Line: 2913
    Rando::Context::ParseSpoiler in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\soh\Enhancements\randomizer\context.cpp Line: 386
    Randomizer_ParseSpoiler in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\soh\OTRGlobals.cpp Line: 2119
    FileChoose_UpdateRandomizer in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\overlays\gamestates\ovl_file_choose\z_file_choose.c Line: 1075
    FileChoose_UpdateMainMenu in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\overlays\gamestates\ovl_file_choose\z_file_choose.c Line: 1101
    FileChoose_ConfigModeUpdate in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\overlays\gamestates\ovl_file_choose\z_file_choose.c Line: 1848
    FileChoose_Main in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\overlays\gamestates\ovl_file_choose\z_file_choose.c Line: 3718
    GameState_Update in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\code\game.c Line: 270
    Graph_Update in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\code\graph.c Line: 297
    RunFrame in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\code\graph.c Line: 487
    Graph_ThreadEntry in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\code\graph.c Line: 518
    Main in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\code\main.c Line: 140
    SDL_main in D:\Users\Pablo\Documents\GitHub\Shipwright\soh\src\code\main.c Line: 67
    main_getcmdline in D:\Users\Pablo\Documents\GitHub\Shipwright\build\x64\vcpkg\buildtrees\sdl2\src\ase-2.30.5-4439cd0809.clean\src\main\windows\SDL_windows_main.c Line: 80
    WinMain in D:\Users\Pablo\Documents\GitHub\Shipwright\build\x64\vcpkg\buildtrees\sdl2\src\ase-2.30.5-4439cd0809.clean\src\main\windows\SDL_windows_main.c Line: 110
    invoke_main in D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl Line: 107
    __scrt_common_main_seh in D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl Line: 288
    __scrt_common_main in D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl Line: 331
    WinMainCRTStartup in D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_winmain.cpp Line: 17
    BaseThreadInitThunkAddr (0x00007FF9F8427360) in C:\Windows\System32\KERNEL32.DLL
    RtlUserThreadStartAddr (0x00007FF9F911CC70) in C:\Windows\SYSTEM32\ntdll.dll
```