### PR TITLE
Fix special character paths on Windows

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -15,6 +15,7 @@
 #include <libloaderapi.h>
 #include <tchar.h>
 #include <windows.h>
+#include <stringapiset.h>
 #endif
 
 #ifdef __APPLE__

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -435,19 +435,24 @@ std::string Context::GetAppBundlePath() {
 #endif
 
 #ifdef _WIN32
-    std::string progpath(MAX_PATH, '\0');
+    std::wstring progpath(MAX_PATH, '\0');
 
-    int len = GetModuleFileNameA(NULL, &progpath[0], progpath.size());
+    int len = GetModuleFileNameW(NULL, &progpath[0], progpath.size());
     if (len != 0 && len < progpath.size()) {
         progpath.resize(len);
 
         // Find the last '\' and remove everything after it
-        long unsigned int lastSlash = progpath.find_last_of("\\");
+        long unsigned int lastSlash = progpath.find_last_of('\\');
         if (lastSlash != std::string::npos) {
             progpath.erase(lastSlash);
         }
 
-        return progpath;
+        // Convert wstring to string
+        len = WideCharToMultiByte(CP_UTF8, 0, progpath.data(), (int)progpath.size(), nullptr, 0, nullptr, nullptr);
+        std::string newProgpath(len, 0);
+        WideCharToMultiByte(CP_UTF8, 0, progpath.data(), (int)progpath.size(), &newProgpath[0], len, nullptr, nullptr);
+
+        return newProgpath;
     }
 #endif
 


### PR DESCRIPTION
#869 causes [2ship to not boot if the path contains special characters](https://github.com/HarbourMasters/2ship2harkinian/issues/1220). It seems like `GetModuleFileNameA` does not play well with special characters. This PR changes that to `GetModuleFileNameW` and treats the path as a wide string, then converts it back to a regular string for the return.

This maintains the behavior of locating the O2R when run from a different directory while also allowing for special characters in the path. I'd like to know if @lepideble has any thoughts on this as the author of the aforementioned PR.

https://stackoverflow.com/questions/4804298/how-to-convert-wstring-into-string
https://stackoverflow.com/questions/215963/how-do-you-properly-use-widechartomultibyte
https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte