### PR TITLE
Mouse Capture Improvements

### DIFF
--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -98,11 +98,11 @@ void Fast3dWindow::Init() {
 }
 
 int32_t Fast3dWindow::GetTargetFps() {
-    return mInterpreter->GetTargetFPS();
+    return mInterpreter->GetTargetFps();
 }
 
 void Fast3dWindow::SetTargetFps(int32_t fps) {
-    mInterpreter->SetTargetFPS(fps);
+    mInterpreter->SetTargetFps(fps);
 }
 
 void Fast3dWindow::SetMaximumFrameLatency(int32_t latency) {

--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -362,13 +362,6 @@ bool Fast3dWindow::MouseButtonDown(int button) {
 void Fast3dWindow::OnFullscreenChanged(bool isNowFullscreen) {
     std::shared_ptr<Window> wnd = Ship::Context::GetInstance()->GetWindow();
 
-    if (isNowFullscreen) {
-        auto menuVisible = wnd->GetGui()->GetMenuOrMenubarVisible();
-        wnd->SetMouseCapture(!(menuVisible || wnd->ShouldForceCursorVisibility()));
-    } else {
-        wnd->SetMouseCapture(false);
-    }
-
     // Re-save fullscreen enabled after
     Ship::Context::GetInstance()->GetConfig()->SetBool("Window.Fullscreen.Enabled", isNowFullscreen);
 }

--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -97,6 +97,10 @@ void Fast3dWindow::Init() {
     SetTextureFilter((FilteringMode)CVarGetInteger(CVAR_TEXTURE_FILTER, FILTER_THREE_POINT));
 }
 
+int32_t Fast3dWindow::GetTargetFps() {
+    return mInterpreter->GetTargetFPS();
+}
+
 void Fast3dWindow::SetTargetFps(int32_t fps) {
     mInterpreter->SetTargetFPS(fps);
 }

--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -87,8 +87,6 @@ void Fast3dWindow::Init() {
         height = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Height", 480);
     }
 
-    SetForceCursorVisibility(CVarGetInteger("gForceCursorVisibility", 0));
-
     InitWindowManager();
     mInterpreter->Init(mWindowManagerApi, mRenderingApi, Ship::Context::GetInstance()->GetName().c_str(), isFullscreen,
                        width, height, posX, posY);

--- a/src/graphic/Fast3D/Fast3dWindow.h
+++ b/src/graphic/Fast3D/Fast3dWindow.h
@@ -48,6 +48,7 @@ class Fast3dWindow : public Ship::Window {
     const char* GetKeyName(int32_t scancode) override;
 
     void InitWindowManager();
+    int32_t GetTargetFps();
     void SetTargetFps(int32_t fps);
     void SetMaximumFrameLatency(int32_t latency);
     void GetPixelDepthPrepare(float x, float y);

--- a/src/graphic/Fast3D/backends/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/backends/gfx_dxgi.cpp
@@ -987,6 +987,10 @@ double GfxWindowBackendDXGI::GetTime() {
     return (double)(t.QuadPart - qpc_init) / qpc_freq;
 }
 
+int GfxWindowBackendDXGI::GetTargetFPS() {
+    return mTargetFps;
+}
+
 void GfxWindowBackendDXGI::SetTargetFPS(int fps) {
     uint32_t old_fps = mTargetFps;
     uint64_t t0 = mFrameTimeStamp / old_fps;

--- a/src/graphic/Fast3D/backends/gfx_dxgi.cpp
+++ b/src/graphic/Fast3D/backends/gfx_dxgi.cpp
@@ -987,11 +987,11 @@ double GfxWindowBackendDXGI::GetTime() {
     return (double)(t.QuadPart - qpc_init) / qpc_freq;
 }
 
-int GfxWindowBackendDXGI::GetTargetFPS() {
+int GfxWindowBackendDXGI::GetTargetFps() {
     return mTargetFps;
 }
 
-void GfxWindowBackendDXGI::SetTargetFPS(int fps) {
+void GfxWindowBackendDXGI::SetTargetFps(int fps) {
     uint32_t old_fps = mTargetFps;
     uint64_t t0 = mFrameTimeStamp / old_fps;
     uint32_t t1 = mFrameTimeStamp % old_fps;

--- a/src/graphic/Fast3D/backends/gfx_dxgi.h
+++ b/src/graphic/Fast3D/backends/gfx_dxgi.h
@@ -37,8 +37,8 @@ class GfxWindowBackendDXGI final : public GfxWindowBackend {
     void SwapBuffersBegin() override;
     void SwapBuffersEnd() override;
     double GetTime() override;
-    int GetTargetFPS();
-    void SetTargetFPS(int fps) override;
+    int GetTargetFps();
+    void SetTargetFps(int fps) override;
     void SetMaxFrameLatency(int latency) override;
     const char* GetKeyName(int scancode) override;
     bool CanDisableVsync() override;

--- a/src/graphic/Fast3D/backends/gfx_dxgi.h
+++ b/src/graphic/Fast3D/backends/gfx_dxgi.h
@@ -37,6 +37,7 @@ class GfxWindowBackendDXGI final : public GfxWindowBackend {
     void SwapBuffersBegin() override;
     void SwapBuffersEnd() override;
     double GetTime() override;
+    int GetTargetFPS();
     void SetTargetFPS(int fps) override;
     void SetMaxFrameLatency(int latency) override;
     const char* GetKeyName(int scancode) override;

--- a/src/graphic/Fast3D/backends/gfx_sdl.h
+++ b/src/graphic/Fast3D/backends/gfx_sdl.h
@@ -30,6 +30,7 @@ class GfxWindowBackendSDL2 final : public GfxWindowBackend {
     void SwapBuffersBegin() override;
     void SwapBuffersEnd() override;
     double GetTime() override;
+    int GetTargetFPS();
     void SetTargetFPS(int fps) override;
     void SetMaxFrameLatency(int latency) override;
     const char* GetKeyName(int scancode) override;

--- a/src/graphic/Fast3D/backends/gfx_sdl.h
+++ b/src/graphic/Fast3D/backends/gfx_sdl.h
@@ -30,8 +30,8 @@ class GfxWindowBackendSDL2 final : public GfxWindowBackend {
     void SwapBuffersBegin() override;
     void SwapBuffersEnd() override;
     double GetTime() override;
-    int GetTargetFPS();
-    void SetTargetFPS(int fps) override;
+    int GetTargetFps();
+    void SetTargetFps(int fps) override;
     void SetMaxFrameLatency(int latency) override;
     const char* GetKeyName(int scancode) override;
     bool CanDisableVsync() override;

--- a/src/graphic/Fast3D/backends/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/backends/gfx_sdl2.cpp
@@ -693,11 +693,11 @@ double GfxWindowBackendSDL2::GetTime() {
     return 0.0;
 }
 
-int GfxWindowBackendSDL2::GetTargetFPS() {
+int GfxWindowBackendSDL2::GetTargetFps() {
     return mTargetFps;
 }
 
-void GfxWindowBackendSDL2::SetTargetFPS(int fps) {
+void GfxWindowBackendSDL2::SetTargetFps(int fps) {
     mTargetFps = fps;
 }
 

--- a/src/graphic/Fast3D/backends/gfx_sdl2.cpp
+++ b/src/graphic/Fast3D/backends/gfx_sdl2.cpp
@@ -693,6 +693,10 @@ double GfxWindowBackendSDL2::GetTime() {
     return 0.0;
 }
 
+int GfxWindowBackendSDL2::GetTargetFPS() {
+    return mTargetFps;
+}
+
 void GfxWindowBackendSDL2::SetTargetFPS(int fps) {
     mTargetFps = fps;
 }

--- a/src/graphic/Fast3D/backends/gfx_window_manager_api.h
+++ b/src/graphic/Fast3D/backends/gfx_window_manager_api.h
@@ -29,8 +29,8 @@ class GfxWindowBackend {
     virtual void SwapBuffersBegin() = 0;
     virtual void SwapBuffersEnd() = 0;
     virtual double GetTime() = 0;
-    virtual int GetTargetFPS() = 0;
-    virtual void SetTargetFPS(int fps) = 0;
+    virtual int GetTargetFps() = 0;
+    virtual void SetTargetFps(int fps) = 0;
     virtual void SetMaxFrameLatency(int latency) = 0;
     virtual const char* GetKeyName(int scancode) = 0;
     virtual bool CanDisableVsync() = 0;

--- a/src/graphic/Fast3D/backends/gfx_window_manager_api.h
+++ b/src/graphic/Fast3D/backends/gfx_window_manager_api.h
@@ -29,6 +29,7 @@ class GfxWindowBackend {
     virtual void SwapBuffersBegin() = 0;
     virtual void SwapBuffersEnd() = 0;
     virtual double GetTime() = 0;
+    virtual int GetTargetFPS() = 0;
     virtual void SetTargetFPS(int fps) = 0;
     virtual void SetMaxFrameLatency(int latency) = 0;
     virtual const char* GetKeyName(int scancode) = 0;

--- a/src/graphic/Fast3D/interpreter.cpp
+++ b/src/graphic/Fast3D/interpreter.cpp
@@ -4367,12 +4367,12 @@ void gfx_set_target_ucode(UcodeHandlers ucode) {
     ucode_handler_index = ucode;
 }
 
-int Interpreter::GetTargetFPS() {
-    return mWapi->GetTargetFPS();
+int Interpreter::GetTargetFps() {
+    return mWapi->GetTargetFps();
 }
 
-void Interpreter::SetTargetFPS(int fps) {
-    mWapi->SetTargetFPS(fps);
+void Interpreter::SetTargetFps(int fps) {
+    mWapi->SetTargetFps(fps);
 }
 
 void Interpreter::SetMaxFrameLatency(int latency) {

--- a/src/graphic/Fast3D/interpreter.cpp
+++ b/src/graphic/Fast3D/interpreter.cpp
@@ -4367,6 +4367,10 @@ void gfx_set_target_ucode(UcodeHandlers ucode) {
     ucode_handler_index = ucode;
 }
 
+int Interpreter::GetTargetFPS() {
+    return mWapi->GetTargetFPS();
+}
+
 void Interpreter::SetTargetFPS(int fps) {
     mWapi->SetTargetFPS(fps);
 }

--- a/src/graphic/Fast3D/interpreter.h
+++ b/src/graphic/Fast3D/interpreter.h
@@ -368,8 +368,8 @@ class Interpreter {
     void HandleWindowEvents();
     bool IsFrameReady();
     bool ViewportMatchesRendererResolution();
-    int GetTargetFPS();
-    void SetTargetFPS(int fps);
+    int GetTargetFps();
+    void SetTargetFps(int fps);
     void SetMaxFrameLatency(int latency);
     int CreateFrameBuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height,
                           uint8_t resize);

--- a/src/graphic/Fast3D/interpreter.h
+++ b/src/graphic/Fast3D/interpreter.h
@@ -368,6 +368,7 @@ class Interpreter {
     void HandleWindowEvents();
     bool IsFrameReady();
     bool ViewportMatchesRendererResolution();
+    int GetTargetFPS();
     void SetTargetFPS(int fps);
     void SetMaxFrameLatency(int latency);
     int CreateFrameBuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height,

--- a/src/window/Window.cpp
+++ b/src/window/Window.cpp
@@ -84,6 +84,14 @@ bool Window::IsAvailableWindowBackend(int32_t backendId) {
            mAvailableWindowBackends->end();
 }
 
+bool Window::ShouldAutoCaptureMouse() {
+    return mAutoCaptureMouse;
+}
+
+void Window::SetAutoCaptureMouse(bool capture) {
+    mAutoCaptureMouse = capture;
+}
+
 bool Window::ShouldForceCursorVisibility() {
     return mForceCursorVisibility;
 }

--- a/src/window/Window.cpp
+++ b/src/window/Window.cpp
@@ -90,8 +90,6 @@ bool Window::ShouldForceCursorVisibility() {
 
 void Window::SetForceCursorVisibility(bool visible) {
     mForceCursorVisibility = visible;
-    CVarSetInteger("gForceCursorVisibility", visible);
-    CVarSave();
 }
 
 void Window::SetWindowBackend(WindowBackend backend) {

--- a/src/window/Window.h
+++ b/src/window/Window.h
@@ -72,6 +72,8 @@ class Window {
     float GetCurrentAspectRatio();
     void SaveWindowToConfig();
     std::shared_ptr<Gui> GetGui();
+    bool ShouldAutoCaptureMouse();
+    void SetAutoCaptureMouse(bool capture);
     bool ShouldForceCursorVisibility();
     void SetForceCursorVisibility(bool visible);
 
@@ -87,6 +89,7 @@ class Window {
     // Hold a reference to Config because Window has a Save function called on Context destructor, where the singleton
     // is no longer available.
     std::shared_ptr<Config> mConfig;
-    bool mForceCursorVisibility;
+    bool mAutoCaptureMouse = false;
+    bool mForceCursorVisibility = false;
 };
 } // namespace Ship

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -543,6 +543,8 @@ void Gui::DrawMenu() {
         }
         if (!GetMenuOrMenubarVisible()) {
             Context::GetInstance()->GetWindow()->SetMouseCapture(wnd->ShouldAutoCaptureMouse());
+        } else {
+            Context::GetInstance()->GetWindow()->SetMouseCapture(false);
         }
         if (CVarGetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0) && GetMenuOrMenubarVisible()) {
             mImGuiIo->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
@@ -595,7 +597,8 @@ void Gui::CursorTimeoutTick() {
     auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Context::GetInstance()->GetWindow());
     if (!wnd->ShouldForceCursorVisibility()) {
         Ship::Coords mousePos = wnd->GetMousePos();
-        if (!wnd->ShouldAutoCaptureMouse() && (abs(mousePos.x - mPrevMousePos.x) > 0 || abs(mousePos.y - mPrevMousePos.y) > 0)) {
+        if ((!wnd->IsMouseCaptured()) && 
+                 (abs(mousePos.x - mPrevMousePos.x) > 0 || abs(mousePos.y - mPrevMousePos.y) > 0)) {
             wnd->SetCursorVisibility(true);
             mCursorVisibleTicks = mCursorVisibleSeconds * wnd->GetTargetFps();
         }

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -600,8 +600,8 @@ void Gui::CursorTimeoutTick() {
     auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Context::GetInstance()->GetWindow());
     if (!wnd->ShouldForceCursorVisibility()) {
         Ship::Coords mousePos = wnd->GetMousePos();
-        if ((!wnd->IsMouseCaptured()) && 
-                 (abs(mousePos.x - mPrevMousePos.x) > 0 || abs(mousePos.y - mPrevMousePos.y) > 0)) {
+        if ((!wnd->IsMouseCaptured()) &&
+            (abs(mousePos.x - mPrevMousePos.x) > 0 || abs(mousePos.y - mPrevMousePos.y) > 0)) {
             wnd->SetCursorVisibility(true);
             mCursorVisibleTicks = mCursorVisibleSeconds * wnd->GetTargetFps();
         }

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -592,12 +592,12 @@ void Gui::HandleMouseCapture() {
 }
 
 void Gui::CursorTimeoutTick() {
-    auto wnd = Context::GetInstance()->GetWindow();
+    auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Context::GetInstance()->GetWindow());
     if (!wnd->ShouldForceCursorVisibility()) {
         Ship::Coords mousePos = wnd->GetMousePos();
         if (!wnd->ShouldAutoCaptureMouse() && (abs(mousePos.x - mPrevMousePos.x) > 0 || abs(mousePos.y - mPrevMousePos.y) > 0)) {
             wnd->SetCursorVisibility(true);
-            mCursorVisibleTicks = mCursorVisibleSeconds * wnd->GetCurrentRefreshRate();
+            mCursorVisibleTicks = mCursorVisibleSeconds * wnd->GetTargetFps();
         }
         if (mCursorVisibleTicks > 0) {
             mCursorVisibleTicks--;

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -545,6 +545,9 @@ void Gui::DrawMenu() {
             Context::GetInstance()->GetWindow()->SetMouseCapture(wnd->ShouldAutoCaptureMouse());
         } else {
             Context::GetInstance()->GetWindow()->SetMouseCapture(false);
+            Context::GetInstance()->GetWindow()->SetCursorVisibility(true);
+            auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Context::GetInstance()->GetWindow());
+            mCursorVisibleTicks = mCursorVisibleSeconds * wnd->GetTargetFps();
         }
         if (CVarGetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0) && GetMenuOrMenubarVisible()) {
             mImGuiIo->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;

--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -614,6 +614,10 @@ void Gui::CursorTimeoutTick() {
     }
 }
 
+void Gui::SetCursorVisibilityTime(int32_t seconds) {
+    mCursorVisibleSeconds = seconds;
+}
+
 void Gui::StartFrame() {
     CursorTimeoutTick();
     HandleMouseCapture();

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -128,6 +128,7 @@ class Gui {
     void CheckSaveCvars();
     void HandleMouseCapture();
     void CursorTimeoutTick();
+    void SetCursorVisibilityTime(int32_t seconds);
     ImVec2 mTemporaryWindowPos;
     ImGuiIO* mImGuiIo;
     std::map<std::string, std::shared_ptr<GuiWindow>> mGuiWindows;

--- a/src/window/gui/Gui.h
+++ b/src/window/gui/Gui.h
@@ -127,6 +127,7 @@ class Gui {
     int16_t GetIntegerScaleFactor();
     void CheckSaveCvars();
     void HandleMouseCapture();
+    void CursorTimeoutTick();
     ImVec2 mTemporaryWindowPos;
     ImGuiIO* mImGuiIo;
     std::map<std::string, std::shared_ptr<GuiWindow>> mGuiWindows;
@@ -139,6 +140,8 @@ class Gui {
     std::shared_ptr<GuiMenuBar> mMenuBar;
     std::shared_ptr<GuiWindow> mMenu;
     std::unordered_map<std::string, GuiTextureMetadata> mGuiTextures;
+    uint32_t mCursorVisibleTicks = 180;
+    uint32_t mCursorVisibleSeconds = 3;
 };
 } // namespace Ship
 


### PR DESCRIPTION
Including various cleanups (TargetFPS -> TargetFps, unneeded CVars for ForceCursorVisibility), this PR also adds a mouse input autocapture framework parallel to ForceCursorVisibility to allow the port to register whether autocapture is desirable. This now works windowed or fullscreen, since it's possible to not have it at all.

This also adds a cursor visibility timer, with a default timeout of 3 seconds at 60 FPS, but also configurable from the port-side.

Relevant testing PR from SoH: https://github.com/HarbourMasters/Shipwright/pull/5797