### PR TITLE
KeyUp Variables

### DIFF
--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -86,8 +86,10 @@ void Fast3dWindow::Init() {
         width = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Width", 640);
         height = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Height", 480);
     }
-    mFullscreenScancode = Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.Fullscreen", Ship::KbScancode::LUS_KB_F11);
-    mMouseCaptureScancode = Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.MouseCapture", Ship::KbScancode::LUS_KB_F2);
+    mFullscreenScancode =
+        Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.Fullscreen", Ship::KbScancode::LUS_KB_F11);
+    mMouseCaptureScancode =
+        Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.MouseCapture", Ship::KbScancode::LUS_KB_F2);
 
     SetForceCursorVisibility(CVarGetInteger("gForceCursorVisibility", 0));
 

--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -86,6 +86,8 @@ void Fast3dWindow::Init() {
         width = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Width", 640);
         height = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Height", 480);
     }
+    mFullscreenScancode = Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.Fullscreen", Ship::KbScancode::LUS_KB_F11);
+    mMouseCaptureScancode = Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.MouseCapture", Ship::KbScancode::LUS_KB_F2);
 
     SetForceCursorVisibility(CVarGetInteger("gForceCursorVisibility", 0));
 
@@ -321,13 +323,11 @@ const char* Fast3dWindow::GetKeyName(int32_t scancode) {
 }
 
 bool Fast3dWindow::KeyUp(int32_t scancode) {
-    if (scancode ==
-        Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.Fullscreen", Ship::KbScancode::LUS_KB_F11)) {
+    if (scancode == mFullscreenScancode) {
         Ship::Context::GetInstance()->GetWindow()->ToggleFullscreen();
     }
 
-    if (scancode ==
-        Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.MouseCapture", Ship::KbScancode::LUS_KB_F2)) {
+    if (scancode == mMouseCaptureScancode) {
         bool captureState = Ship::Context::GetInstance()->GetWindow()->IsMouseCaptured();
         Ship::Context::GetInstance()->GetWindow()->SetMouseCapture(!captureState);
     }

--- a/src/window/Window.h
+++ b/src/window/Window.h
@@ -78,6 +78,8 @@ class Window {
   protected:
     void SetWindowBackend(WindowBackend backend);
     void AddAvailableWindowBackend(WindowBackend backend);
+    static int32_t mFullscreenScancode;
+    static int32_t mMouseCaptureScancode;
 
   private:
     std::shared_ptr<Gui> mGui;


### PR DESCRIPTION
Convert mouse capture and fullscreen scancode lookups in `Fast3dWindow::KeyUp` to variable-centered flow to prevent performance hitches when pressing keys quickly.