### PR TITLE
KeyUp Variables Quick Fix

### DIFF
--- a/src/graphic/Fast3D/Fast3dWindow.cpp
+++ b/src/graphic/Fast3D/Fast3dWindow.cpp
@@ -86,10 +86,10 @@ void Fast3dWindow::Init() {
         width = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Width", 640);
         height = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Height", 480);
     }
-    mFullscreenScancode =
-        Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.Fullscreen", Ship::KbScancode::LUS_KB_F11);
-    mMouseCaptureScancode =
-        Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.MouseCapture", Ship::KbScancode::LUS_KB_F2);
+    Ship::Context::GetInstance()->GetWindow()->SetFullscreenScancode(
+        Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.Fullscreen", Ship::KbScancode::LUS_KB_F11));
+    Ship::Context::GetInstance()->GetWindow()->SetMouseCaptureScancode(
+        Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.MouseCapture", Ship::KbScancode::LUS_KB_F2));
 
     InitWindowManager();
     mInterpreter->Init(mWindowManagerApi, mRenderingApi, Ship::Context::GetInstance()->GetName().c_str(), isFullscreen,
@@ -327,11 +327,11 @@ const char* Fast3dWindow::GetKeyName(int32_t scancode) {
 }
 
 bool Fast3dWindow::KeyUp(int32_t scancode) {
-    if (scancode == mFullscreenScancode) {
+    if (scancode == Ship::Context::GetInstance()->GetWindow()->GetFullscreenScancode()) {
         Ship::Context::GetInstance()->GetWindow()->ToggleFullscreen();
     }
 
-    if (scancode == mMouseCaptureScancode) {
+    if (scancode == Ship::Context::GetInstance()->GetWindow()->GetMouseCaptureScancode()) {
         bool captureState = Ship::Context::GetInstance()->GetWindow()->IsMouseCaptured();
         Ship::Context::GetInstance()->GetWindow()->SetMouseCapture(!captureState);
     }

--- a/src/window/Window.cpp
+++ b/src/window/Window.cpp
@@ -100,6 +100,22 @@ void Window::SetForceCursorVisibility(bool visible) {
     mForceCursorVisibility = visible;
 }
 
+int32_t Window::GetFullscreenScancode() {
+    return mFullscreenScancode;
+}
+
+int32_t Window::GetMouseCaptureScancode() {
+    return mMouseCaptureScancode;
+}
+
+void Window::SetFullscreenScancode(int32_t scancode) {
+    mFullscreenScancode = scancode;
+}
+
+void Window::SetMouseCaptureScancode(int32_t scancode) {
+    mMouseCaptureScancode = scancode;
+}
+
 void Window::SetWindowBackend(WindowBackend backend) {
     mWindowBackend = backend;
     Context::GetInstance()->GetConfig()->SetWindowBackend(GetWindowBackend());

--- a/src/window/Window.h
+++ b/src/window/Window.h
@@ -76,12 +76,14 @@ class Window {
     void SetAutoCaptureMouse(bool capture);
     bool ShouldForceCursorVisibility();
     void SetForceCursorVisibility(bool visible);
+    int32_t GetFullscreenScancode();
+    int32_t GetMouseCaptureScancode();
+    void SetFullscreenScancode(int32_t scancode);
+    void SetMouseCaptureScancode(int32_t scancode);
 
   protected:
     void SetWindowBackend(WindowBackend backend);
     void AddAvailableWindowBackend(WindowBackend backend);
-    static int32_t mFullscreenScancode;
-    static int32_t mMouseCaptureScancode;
 
   private:
     std::shared_ptr<Gui> mGui;
@@ -93,5 +95,7 @@ class Window {
     std::shared_ptr<Config> mConfig;
     bool mAutoCaptureMouse = false;
     bool mForceCursorVisibility = false;
+    int32_t mFullscreenScancode;
+    int32_t mMouseCaptureScancode;
 };
 } // namespace Ship


### PR DESCRIPTION
So apparently, static class members in the header are illegal. Somehow, this wasn't caught in local testing or LUS Actions. This removes static from the variables, privates them, and adds getters/setters for them for use with the `Ship::Context::GetInstance()->GetWindow()` chain.