### PR TITLE
Fix SDL audio

### DIFF
--- a/src/ship/audio/Audio.cpp
+++ b/src/ship/audio/Audio.cpp
@@ -18,8 +18,10 @@ void Audio::InitAudioPlayer() {
 #endif
         case AudioBackend::SDL:
             mAudioPlayer = std::make_shared<SDLAudioPlayer>(this->mAudioSettings);
+            break;
         default:
             mAudioPlayer = std::make_shared<NullAudioPlayer>(this->mAudioSettings);
+            break;
     }
 
     if (mAudioPlayer && !mAudioPlayer->Init()) {


### PR DESCRIPTION
Fixes SDL audio. It was broken by https://github.com/Kenix3/libultraship/commit/91065569f7f98192e878e96814d1f98012c9e038 because of the switch case for `SDL` audio falling through to `NUL`.