### PR TITLE
Cursor Visibility Tweaks

### DIFF
--- a/include/fast/backends/gfx_dxgi.h
+++ b/include/fast/backends/gfx_dxgi.h
@@ -23,7 +23,7 @@ class GfxWindowBackendDXGI final : public GfxWindowBackend {
     void SetFullscreenChangedCallback(void (*onnFullscreenChanged)(bool is_now_fullscreen)) override;
     void SetFullscreen(bool fullscreen) override;
     void GetActiveWindowRefreshRate(uint32_t* refreshRate) override;
-    void SetCursorVisability(bool visability) override;
+    void SetCursorVisibility(bool visability) override;
     void SetMousePos(int32_t posX, int32_t posY) override;
     void GetMousePos(int32_t* x, int32_t* y) override;
     void GetMouseDelta(int32_t* x, int32_t* y) override;

--- a/include/fast/backends/gfx_sdl.h
+++ b/include/fast/backends/gfx_sdl.h
@@ -16,7 +16,7 @@ class GfxWindowBackendSDL2 final : public GfxWindowBackend {
     void SetFullscreenChangedCallback(void (*onFullscreenChanged)(bool is_now_fullscreen)) override;
     void SetFullscreen(bool fullscreen) override;
     void GetActiveWindowRefreshRate(uint32_t* refreshRate) override;
-    void SetCursorVisability(bool visability) override;
+    void SetCursorVisibility(bool visability) override;
     void SetMousePos(int32_t posX, int32_t posY) override;
     void GetMousePos(int32_t* x, int32_t* y) override;
     void GetMouseDelta(int32_t* x, int32_t* y) override;

--- a/include/fast/backends/gfx_window_manager_api.h
+++ b/include/fast/backends/gfx_window_manager_api.h
@@ -15,7 +15,7 @@ class GfxWindowBackend {
     virtual void SetFullscreenChangedCallback(void (*mOnFullscreenChanged)(bool is_now_fullscreen)) = 0;
     virtual void SetFullscreen(bool fullscreen) = 0;
     virtual void GetActiveWindowRefreshRate(uint32_t* refreshRate) = 0;
-    virtual void SetCursorVisability(bool visability) = 0;
+    virtual void SetCursorVisibility(bool visability) = 0;
     virtual void SetMousePos(int32_t posX, int32_t posY) = 0;
     virtual void GetMousePos(int32_t* x, int32_t* y) = 0;
     virtual void GetMouseDelta(int32_t* x, int32_t* y) = 0;

--- a/src/fast/Fast3dWindow.cpp
+++ b/src/fast/Fast3dWindow.cpp
@@ -206,7 +206,7 @@ void Fast3dWindow::HandleEvents() {
 }
 
 void Fast3dWindow::SetCursorVisibility(bool visible) {
-    mWindowManagerApi->SetCursorVisability(visible);
+    mWindowManagerApi->SetCursorVisibility(visible);
 }
 
 uint32_t Fast3dWindow::GetWidth() {

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -607,28 +607,13 @@ void GfxWindowBackendDXGI::SetFullscreenChangedCallback(void (*mOnFullscreenChan
 }
 
 void GfxWindowBackendDXGI::SetCursorVisibility(bool visible) {
-    // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showcursor
-    // https://devblogs.microsoft.com/oldnewthing/20091217-00/?p=15643
-    // ShowCursor uses a counter, not a boolean value, and increments or decrements that value when called
-    // This means we need to keep calling it until we get the value we want
-
-    //
-    //  NOTE:  If you continue calling until you "get the value you want" and there is no mouse attached,
-    //  it will lock the software up.  Windows always returns -1 if there is no mouse!
-    //
-
-    const int _MAX_TRIES = 15; // Prevent spinning infinitely if no mouse is plugged in
-
-    int cursorVisibilityTries = 0;
-    int cursorVisibilityCounter;
+    // This used to utilize the Windows API of ShowCursor(), but because you'd have to loop through the
+    // return values from ShowCursor() to get to the value you wanted, it was changed to SetCursor, as
+    // this was instantaneously effective for hiding and showing
     if (visible) {
-        do {
-            cursorVisibilityCounter = ShowCursor(true);
-        } while (cursorVisibilityCounter < 0 && ++cursorVisibilityTries < _MAX_TRIES);
+        SetCursor(LoadCursor(nullptr, IDC_ARROW));
     } else {
-        do {
-            cursorVisibilityCounter = ShowCursor(false);
-        } while (cursorVisibilityCounter >= 0);
+        SetCursor(nullptr);
     }
 }
 

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -606,7 +606,7 @@ void GfxWindowBackendDXGI::SetFullscreenChangedCallback(void (*mOnFullscreenChan
     mOnFullscreenChanged = mOnFullscreenChanged;
 }
 
-void GfxWindowBackendDXGI::SetCursorVisability(bool visible) {
+void GfxWindowBackendDXGI::SetCursorVisibility(bool visible) {
     // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showcursor
     // https://devblogs.microsoft.com/oldnewthing/20091217-00/?p=15643
     // ShowCursor uses a counter, not a boolean value, and increments or decrements that value when called
@@ -678,12 +678,12 @@ void GfxWindowBackendDXGI::SetMouseCapture(bool capture) {
     mIsMouseCaptured = capture;
     if (capture) {
         ApplyMouseCaptureClip();
-        SetCursorVisability(false);
+        SetCursorVisibility(false);
         SetCapture(h_wnd);
         mHasMousePosition = false;
     } else {
         ClipCursor(nullptr);
-        SetCursorVisability(true);
+        SetCursorVisibility(true);
         ReleaseCapture();
         UpdateMousePrevPos();
     }

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -443,7 +443,7 @@ void GfxWindowBackendSDL2::SetFullscreen(bool enable) {
     SetFullscreenImpl(enable, true);
 }
 
-void GfxWindowBackendSDL2::SetCursorVisability(bool visible) {
+void GfxWindowBackendSDL2::SetCursorVisibility(bool visible) {
     if (visible) {
         SDL_ShowCursor(SDL_ENABLE);
     } else {

--- a/src/ship/window/gui/Gui.cpp
+++ b/src/ship/window/gui/Gui.cpp
@@ -619,8 +619,9 @@ void Gui::CursorTimeoutTick() {
         }
         if (mCursorVisibleTicks > 0) {
             mCursorVisibleTicks--;
-        } else {
+        } else if (mCursorVisibleTicks == 0) {
             wnd->SetCursorVisibility(false);
+            mCursorVisibleTicks = -1;
         }
         mPrevMousePos = mousePos;
     }

--- a/src/ship/window/gui/Gui.cpp
+++ b/src/ship/window/gui/Gui.cpp
@@ -610,20 +610,28 @@ void Gui::HandleMouseCapture() {
 
 void Gui::CursorTimeoutTick() {
     auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Context::GetInstance()->GetWindow());
-    if (!wnd->ShouldForceCursorVisibility()) {
-        Ship::Coords mousePos = wnd->GetMousePos();
-        if ((!wnd->IsMouseCaptured()) &&
-            (abs(mousePos.x - mPrevMousePos.x) > 0 || abs(mousePos.y - mPrevMousePos.y) > 0)) {
-            wnd->SetCursorVisibility(true);
-            mCursorVisibleTicks = mCursorVisibleSeconds * wnd->GetTargetFps();
-        }
-        if (mCursorVisibleTicks > 0) {
-            mCursorVisibleTicks--;
-        } else if (mCursorVisibleTicks == 0) {
-            wnd->SetCursorVisibility(false);
-            mCursorVisibleTicks = -1;
-        }
-        mPrevMousePos = mousePos;
+    if (wnd->ShouldForceCursorVisibility() || wnd->IsMouseCaptured()) {
+        return;
+    }
+
+    Ship::Coords mousePos = wnd->GetMousePos();
+    bool mouseMoved = abs(mousePos.x - mPrevMousePos.x) > 0 || abs(mousePos.y - mPrevMousePos.y) > 0;
+    mPrevMousePos = mousePos;
+
+    if (mouseMoved) {
+        wnd->SetCursorVisibility(true);
+        mCursorVisibleTicks = mCursorVisibleSeconds * wnd->GetTargetFps();
+        return;
+    }
+
+    if (mCursorVisibleTicks == 0) {
+        wnd->SetCursorVisibility(false);
+        mCursorVisibleTicks = -1;
+        return;
+    }
+
+    if (mCursorVisibleTicks > 0) {
+        mCursorVisibleTicks--;
     }
 }
 


### PR DESCRIPTION
It seems the longer the cursor was not visible (and calling `wnd->SetCursorVisibility(false)` each frame), the longer it took for mouse movement to register as far as making the cursor visible again. This tweaks the cursor visibility tick to only call SetCursorVisibility(false) once per visibility cycle (by setting `mCursorVisibleTicks` to -1 after calling it, where it remains until mouse movement registers again).

Also fixes a related typo (ForceCursorVisability -> ForceCursorVisibility).