### PR TITLE
Mouse Capture Clip Adjustment

### DIFF
--- a/include/fast/backends/gfx_sdl.h
+++ b/include/fast/backends/gfx_sdl.h
@@ -51,6 +51,7 @@ class GfxWindowBackendSDL2 final : public GfxWindowBackend {
     void SyncFramerateWithTime() const;
 
     SDL_Window* mWnd;
+    SDL_Rect mCursorClip;
     SDL_GLContext mCtx;
     SDL_Renderer* mRenderer;
     int mSdlToLusTable[512];

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -279,10 +279,10 @@ void GfxWindowBackendDXGI::Close() {
 
 void GfxWindowBackendDXGI::ApplyMouseCaptureClip() {
     RECT rect;
-    rect.left = mPosX + 1;
-    rect.top = mPosY + 1;
-    rect.right = mPosX + current_width - 1;
-    rect.bottom = mPosY + current_height - 1;
+    rect.left = mPosX + (current_width / 2) - 1;
+    rect.top = mPosY + (current_height / 2) - 1;
+    rect.right = rect.left + 2;
+    rect.bottom = rect.top + 2;
     ClipCursor(&rect);
 }
 

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -478,9 +478,9 @@ void GfxWindowBackendSDL2::SetMouseCapture(bool capture) {
     SDL_SetRelativeMouseMode(static_cast<SDL_bool>(capture));
     auto mouse = SDL_GetWindowMouseRect(mWnd);
     if (capture) {
-        SDL_Rect window;
-        SDL_GetWindowSize(mWnd, &window.w, &window.h);
-        mCursorClip = { (window.w / 2) - 1, (window.h / 2) - 1, 2, 2 };
+        int w,h;
+        SDL_GetWindowSize(mWnd, &w, &h);
+        mCursorClip = { (w / 2) - 1, (h / 2) - 1, 2, 2 };
     }
     SDL_SetWindowMouseRect(mWnd, capture ? &mCursorClip : NULL);
 }

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -476,6 +476,14 @@ bool GfxWindowBackendSDL2::GetMouseState(uint32_t btn) {
 
 void GfxWindowBackendSDL2::SetMouseCapture(bool capture) {
     SDL_SetRelativeMouseMode(static_cast<SDL_bool>(capture));
+    auto mouse = SDL_GetWindowMouseRect(mWnd);
+    if (capture) {
+        SDL_Rect window;
+        SDL_GetWindowSize(mWnd, &window.w, &window.h);
+        SDL_GetWindowPosition(mWnd, &window.x, &window.y);
+        mCursorClip = { window.x + (window.w / 2) - 1, window.y + (window.h / 2) - 1, 2, 2 };
+    }
+    SDL_SetWindowMouseRect(mWnd, capture ? &mCursorClip : NULL);
 }
 
 bool GfxWindowBackendSDL2::IsMouseCaptured() {

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -481,7 +481,7 @@ void GfxWindowBackendSDL2::SetMouseCapture(bool capture) {
     // Revisit on SDL3
     auto mouse = SDL_GetWindowMouseRect(mWnd);
     if (capture) {
-        int w,h;
+        int w, h;
         SDL_GetWindowSize(mWnd, &w, &h);
         mCursorClip = { (w / 2) - 1, (h / 2) - 1, 2, 2 };
     }

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -480,8 +480,7 @@ void GfxWindowBackendSDL2::SetMouseCapture(bool capture) {
     if (capture) {
         SDL_Rect window;
         SDL_GetWindowSize(mWnd, &window.w, &window.h);
-        SDL_GetWindowPosition(mWnd, &window.x, &window.y);
-        mCursorClip = { window.x + (window.w / 2) - 1, window.y + (window.h / 2) - 1, 2, 2 };
+        mCursorClip = { (window.w / 2) - 1, (window.h / 2) - 1, 2, 2 };
     }
     SDL_SetWindowMouseRect(mWnd, capture ? &mCursorClip : NULL);
 }

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -476,6 +476,9 @@ bool GfxWindowBackendSDL2::GetMouseState(uint32_t btn) {
 
 void GfxWindowBackendSDL2::SetMouseCapture(bool capture) {
     SDL_SetRelativeMouseMode(static_cast<SDL_bool>(capture));
+    // TODO: Manually setting a clipping rect here because
+    // https://wiki.libsdl.org/SDL2/SDL_HINT_MOUSE_RELATIVE_MODE_CENTER isn't working as epxected.
+    // Revisit on SDL3
     auto mouse = SDL_GetWindowMouseRect(mWnd);
     if (capture) {
         int w,h;


### PR DESCRIPTION
The default SDL capture clip rect appeared to just be the size of the window. DXGI's was set to be just inside the size of the window. This causes issues with auto-hidden taskbars (being able to show them when the hidden cursor still goes to the edge of the window) and docked windows (which would block mouse button clicks from getting to the main game, blocking their input processing) in the ports.
This adds a 2x2 clip rect at the center of the window in SDL when mouse capture is active, and adjusts DXGI's to match.