### PR TITLE
Check compute shaders compat

### DIFF
--- a/include/fast/backends/gfx_dxgi.h
+++ b/include/fast/backends/gfx_dxgi.h
@@ -116,6 +116,7 @@ class GfxWindowBackendDXGI final : public GfxWindowBackend {
 #ifdef DECLARE_GFX_DXGI_FUNCTIONS
 void ThrowIfFailed(HRESULT res);
 void ThrowIfFailed(HRESULT res, HWND h_wnd, const char* message);
+void ThrowWithMessage(HWND h_wnd, const char* message);
 #endif
 
 #endif

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -236,7 +236,7 @@ void CSMain(uint3 DTid : SV_DispatchThreadID) {
 
     const char* shader_source_msaa = R"(
 sampler my_sampler : register(s0);
-Texture2DMS<float, 2> tex : register(t0);
+Texture2DMS<float> tex : register(t0);
 StructuredBuffer<int2> coord : register(t1);
 RWStructuredBuffer<float> output : register(u0);
 

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -225,7 +225,8 @@ void GfxRenderingAPIDX11::Init() {
     mDevice->CheckFeatureSupport(D3D11_FEATURE_D3D10_X_HARDWARE_OPTIONS, &features,
                                  sizeof(D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS));
     if (features.ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x == false) {
-        ThrowWithMessage(mWindowBackend->GetWindowHandle(), "D3D device doesn't support compute shaders 4.0 or greater.");
+        ThrowWithMessage(mWindowBackend->GetWindowHandle(),
+                         "D3D device doesn't support compute shaders 4.0 or greater.");
     }
 
     const char* shader_source = R"(

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -221,6 +221,12 @@ void GfxRenderingAPIDX11::Init() {
                   mWindowBackend->GetWindowHandle(), "Failed to create per-draw constant buffer.");
 
     // Create compute shader that can be used to retrieve depth buffer values
+    D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS features;
+    mDevice->CheckFeatureSupport(D3D11_FEATURE_D3D10_X_HARDWARE_OPTIONS, &features,
+                                 sizeof(D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS));
+    if (features.ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x == false) {
+        ThrowWithMessage(mWindowBackend->GetWindowHandle(), "D3D device doesn't support compute shaders 4.0 or greater.");
+    }
 
     const char* shader_source = R"(
 sampler my_sampler : register(s0);

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -1090,10 +1090,10 @@ void ThrowIfFailed(HRESULT res, HWND h_wnd, const char* message) {
     }
 }
 void ThrowWithMessage(HWND h_wnd, const char* message) {
-        char full_message[256];
-        sprintf(full_message, message);
-        MessageBoxA(h_wnd, full_message, "Error", MB_OK | MB_ICONERROR);
-        throw;
+    char full_message[256];
+    sprintf(full_message, message);
+    MessageBoxA(h_wnd, full_message, "Error", MB_OK | MB_ICONERROR);
+    throw;
 }
 
 #endif

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -1089,5 +1089,11 @@ void ThrowIfFailed(HRESULT res, HWND h_wnd, const char* message) {
         throw res;
     }
 }
+void ThrowWithMessage(HWND h_wnd, const char* message) {
+        char full_message[256];
+        sprintf(full_message, message);
+        MessageBoxA(h_wnd, full_message, "Error", MB_OK | MB_ICONERROR);
+        throw;
+}
 
 #endif


### PR DESCRIPTION
Still a draft because I'm unsure about the ThrowWithMessage addition. Also everything feels hacked together somehow... 

Loose follow up to https://github.com/Kenix3/libultraship/pull/497

- fix DEVICE_DRAW_RESOURCE_SAMPLE_COUNT_MISMATCH
 we are already using shader model 4.1 for that, so we can just use the unsized version of Texture2DMS (probably not even needed, but the debug layer shuts up now)

- add ThrowWithMessage
 similar to ThrowIfFaled, but not bound to an actual thing failing (should this be done different?)

- check GPU for ComputeShader support and throw a slightly more useful message if not supported (maybe this solves our feature level mystery?).
EDIT: It does! The error is triggered on Intel HD graphics 3000. 

SoH build: https://github.com/HarbourMasters/Shipwright/pull/5888 