### PR TITLE
Restore lost `fileSinks` push into `sinks` during initialization.

### DIFF
--- a/src/ship/Context.cpp
+++ b/src/ship/Context.cpp
@@ -144,6 +144,7 @@ bool Context::InitLogging() {
 
         auto logPath = GetPathRelativeToAppDirectory(("logs/" + GetName() + ".log"));
         auto fileSink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(logPath, 1024 * 1024 * 10, 10);
+        sinks.push_back(fileSink);
 #ifdef _DEBUG
         mLogger = std::make_shared<spdlog::logger>("multi_sink", sinks.begin(), sinks.end());
         GetLogger()->flush_on(spdlog::level::trace);


### PR DESCRIPTION
This was lost in #915, and resulted in no log file outputs.