### PR TITLE
Fix Crash in O2R Archive Remove Flow

### DIFF
--- a/src/ship/resource/archive/O2rArchive.cpp
+++ b/src/ship/resource/archive/O2rArchive.cpp
@@ -100,6 +100,7 @@ bool O2rArchive::Close() {
         return false;
     }
 
+    mZipArchive = nullptr;
     return true;
 }
 


### PR DESCRIPTION
With `O2rArchive` calling `Close()` within its destructor, that meant it got called twice in the process of `ArchiveManager::RemoveArchive()` because it got called in `Unload()` as well as the destructor after being removed from `mArchives`. This was a problem because the only thing gating the process in `Close()` was a `nullptr` check on `mZipArchive`, and it would be a garbage pointer after the first `zip_close()` call instead of `nullptr`, and the program would then crash calling `zip_close()` on that garbage pointer.  This sets `mZipArchive` to nullptr after `zip_close()` in `O2rArchive::Close()` to prevent that.