### PR TITLE
Allow writing new blocks to config

### DIFF
--- a/src/ship/config/Config.cpp
+++ b/src/ship/config/Config.cpp
@@ -156,6 +156,8 @@ void Config::SetBlock(const std::string& key, nlohmann::json block) {
     } else {
         if (gjson.contains(key)) {
             gjson[key] = block;
+        } else {
+            gjson.emplace(key, block);
         }
     }
     mFlattenedJson = gjson.flatten();

--- a/src/ship/config/Config.cpp
+++ b/src/ship/config/Config.cpp
@@ -154,11 +154,7 @@ void Config::SetBlock(const std::string& key, nlohmann::json block) {
             }
         }
     } else {
-        if (gjson.contains(key)) {
-            gjson[key] = block;
-        } else {
-            gjson.emplace(key, block);
-        }
+        gjson[key] = block;
     }
     mFlattenedJson = gjson.flatten();
     Save();


### PR DESCRIPTION
Fixes a bug where trying to write a block that does not already exist in the config will fail. Credit @garrettjoecox 