### PR TITLE
remove shared in ArchiveManager getter and setter

### DIFF
--- a/include/ship/resource/archive/ArchiveManager.h
+++ b/include/ship/resource/archive/ArchiveManager.h
@@ -22,8 +22,8 @@ class ArchiveManager {
 
     std::shared_ptr<Archive> AddArchive(const std::string& archivePath);
     std::shared_ptr<Archive> AddArchive(std::shared_ptr<Archive> archive);
-    std::shared_ptr<std::vector<std::shared_ptr<Archive>>> GetArchives();
-    void SetArchives(std::shared_ptr<std::vector<std::shared_ptr<Archive>>> archives);
+    std::vector<std::shared_ptr<Archive>> GetArchives();
+    void SetArchives(std::vector<std::shared_ptr<Archive>> archives);
     size_t RemoveArchive(std::shared_ptr<Archive> archive);
     size_t RemoveArchive(const std::string& path);
 

--- a/src/ship/resource/archive/ArchiveManager.cpp
+++ b/src/ship/resource/archive/ArchiveManager.cpp
@@ -32,7 +32,7 @@ void ArchiveManager::Init(const std::vector<std::string>& archivePaths,
 
 ArchiveManager::~ArchiveManager() {
     SPDLOG_TRACE("destruct archive manager");
-    SetArchives(nullptr);
+    SetArchives({});
 }
 
 bool ArchiveManager::IsLoaded() {
@@ -127,10 +127,10 @@ void ArchiveManager::AddGameVersion(uint32_t newGameVersion) {
     mGameVersions.push_back(newGameVersion);
 }
 
-std::shared_ptr<std::vector<std::shared_ptr<Archive>>> ArchiveManager::GetArchives() {
-    auto archives = std::make_shared<std::vector<std::shared_ptr<Archive>>>();
+std::vector<std::shared_ptr<Archive>> ArchiveManager::GetArchives() {
+    auto archives = std::vector<std::shared_ptr<Archive>>();
     for (const auto& archive : mArchives) {
-        archives->push_back(archive);
+        archives.push_back(archive);
     }
     return archives;
 }
@@ -183,11 +183,11 @@ size_t ArchiveManager::RemoveArchive(std::shared_ptr<Archive> archive) {
     return RemoveArchive(archive->GetPath());
 }
 
-void ArchiveManager::SetArchives(std::shared_ptr<std::vector<std::shared_ptr<Archive>>> archives) {
+void ArchiveManager::SetArchives(std::vector<std::shared_ptr<Archive>> archives) {
     mArchives.clear();
 
-    if (archives) {
-        for (const auto& archive : *archives) {
+    if (!archives.empty()) {
+        for (const auto& archive : archives) {
             mArchives.push_back(archive);
         }
     }


### PR DESCRIPTION
Remove shared because it's useless to have it in this context