### PR TITLE
SDL init: fix log

### DIFF
--- a/src/ship/audio/SDLAudioPlayer.cpp
+++ b/src/ship/audio/SDLAudioPlayer.cpp
@@ -10,7 +10,7 @@ SDLAudioPlayer::~SDLAudioPlayer() {
 
 bool SDLAudioPlayer::DoInit() {
     if (SDL_Init(SDL_INIT_AUDIO) != 0) {
-        SPDLOG_ERROR("SDL init error: %s\n", SDL_GetError());
+        SPDLOG_ERROR("SDL init error: {}", SDL_GetError());
         return false;
     }
     mNumChannels = this->GetAudioChannels() == AudioChannelsSetting::audioSurround51 ? 6 : 2;


### PR DESCRIPTION
Error in console was literally %s instead of interpolated error message