### PR TITLE
Mobile: Update deps for Android/iOS and add Android CI

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -104,6 +104,48 @@ jobs:
         name: soh-linux
         path: build-cmake/src/*.a
         if-no-files-found: error
+  build-android:
+    runs-on: ubuntu-latest
+    env:
+      ANDROID_NDK_HOME: ${{ github.workspace }}/android-ndk/android-ndk-r29
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y $(cat .github/workflows/apt-deps.txt) unzip curl
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2.14
+      with:
+        key: ${{ runner.os }}-android-ccache-${{ github.ref }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-android-ccache-${{ github.ref }}
+          ${{ runner.os }}-android-ccache-
+    - name: Install Android NDK
+      run: |
+        curl -L https://dl.google.com/android/repository/android-ndk-r29-linux.zip -o android-ndk.zip
+        unzip -q android-ndk.zip
+        mkdir -p android-ndk
+        mv android-ndk-r29 android-ndk/
+    - name: Configure libultraship for Android
+      run: |
+        cmake --no-warn-unused-cli -S . -Bbuild-cmake-android -GNinja \
+          -DCMAKE_BUILD_TYPE:STRING=Release \
+          -DCMAKE_SYSTEM_NAME=Android \
+          -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake \
+          -DANDROID_NDK=${ANDROID_NDK_HOME} \
+          -DANDROID_ABI=arm64-v8a \
+          -DANDROID_PLATFORM=latest \
+          -DANDROID_STL=c++_static
+    - name: Build libultraship for Android
+      run: |
+        cmake --build build-cmake-android --config Release --parallel 10
+    - name: Upload build
+      uses: actions/upload-artifact@v4
+      with:
+        name: soh-android
+        path: build-cmake-android/src/*.a
+        if-no-files-found: error
   build-windows-x64:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -32,8 +32,6 @@ jobs:
         path: build-cmake/src/*.a
         if-no-files-found: error
   build-ios:
-    # temporarily disable iOS CI
-    if: false 
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4

--- a/cmake/dependencies/android.cmake
+++ b/cmake/dependencies/android.cmake
@@ -1,14 +1,73 @@
+include(FetchContent)
+
+#=================== SDL2 ===================
 find_package(SDL2 QUIET)
 if (NOT ${SDL2_FOUND})
-    include(FetchContent)
     FetchContent_Declare(
         SDL2
     GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-    GIT_TAG release-2.28.1 
+    GIT_TAG release-2.32.10
     )
     message("SDL2 not found. Downloading now...")
     FetchContent_MakeAvailable(SDL2)
     message("SDL2 downloaded to " ${FETCHCONTENT_BASE_DIR}/sdl2-src)
+endif()
+
+#=================== nlohmann-json ===================
+find_package(nlohmann_json QUIET)
+if (NOT ${nlohmann_json_FOUND})
+    FetchContent_Declare(
+        nlohmann_json
+        GIT_REPOSITORY https://github.com/nlohmann/json.git
+        GIT_TAG v3.12.0
+        OVERRIDE_FIND_PACKAGE
+    )
+    FetchContent_MakeAvailable(nlohmann_json)
+endif()
+
+#=================== tinyxml2 ===================
+find_package(tinyxml2 QUIET)
+if (NOT ${tinyxml2_FOUND})
+    set(tinyxml2_BUILD_TESTING OFF)
+    FetchContent_Declare(
+        tinyxml2
+        GIT_REPOSITORY https://github.com/leethomason/tinyxml2.git
+        GIT_TAG 11.0.0
+        OVERRIDE_FIND_PACKAGE
+    )
+    FetchContent_MakeAvailable(tinyxml2)
+endif()
+
+#=================== spdlog ===================
+find_package(spdlog QUIET)
+if (NOT ${spdlog_FOUND})
+    FetchContent_Declare(
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog.git
+        GIT_TAG v1.16.0
+        OVERRIDE_FIND_PACKAGE
+    )
+    FetchContent_MakeAvailable(spdlog)
+endif()
+
+#=================== libzip ===================
+find_package(libzip QUIET)
+if (NOT ${libzip_FOUND})
+    set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+    set(BUILD_TOOLS OFF)
+    set(BUILD_REGRESS OFF)
+    set(BUILD_EXAMPLES OFF)
+    set(BUILD_DOC OFF)
+    set(BUILD_OSSFUZZ OFF)
+    set(BUILD_SHARED_LIBS OFF)
+    FetchContent_Declare(
+        libzip
+        GIT_REPOSITORY https://github.com/nih-at/libzip.git
+        GIT_TAG v1.11.4
+        OVERRIDE_FIND_PACKAGE
+    )
+    FetchContent_MakeAvailable(libzip)
+    list(APPEND ADDITIONAL_LIB_INCLUDES ${libzip_SOURCE_DIR}/lib ${libzip_BINARY_DIR})
 endif()
 
 target_link_libraries(ImGui PUBLIC SDL2::SDL2)

--- a/cmake/dependencies/ios.cmake
+++ b/cmake/dependencies/ios.cmake
@@ -6,7 +6,7 @@ if (NOT ${SDL2_FOUND})
     FetchContent_Declare(
         SDL2
         GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-        GIT_TAG release-2.28.1
+        GIT_TAG release-2.32.10
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(SDL2)
@@ -18,7 +18,7 @@ if (NOT ${nlohmann_json_FOUND})
     FetchContent_Declare(
         nlohmann_json
         GIT_REPOSITORY https://github.com/nlohmann/json.git
-        GIT_TAG v3.11.3
+        GIT_TAG v3.12.0
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(nlohmann_json)
@@ -31,7 +31,7 @@ if (NOT ${tinyxml2_FOUND})
     FetchContent_Declare(
         tinyxml2
         GIT_REPOSITORY https://github.com/leethomason/tinyxml2.git
-        GIT_TAG 10.0.0
+        GIT_TAG 11.0.0
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(tinyxml2)
@@ -43,7 +43,7 @@ if (NOT ${spdlog_FOUND})
     FetchContent_Declare(
         spdlog
         GIT_REPOSITORY https://github.com/gabime/spdlog.git
-        GIT_TAG v1.14.1
+        GIT_TAG v1.16.0
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(spdlog)
@@ -62,7 +62,7 @@ if (NOT ${libzip_FOUND})
     FetchContent_Declare(
         libzip
         GIT_REPOSITORY https://github.com/nih-at/libzip.git
-        GIT_TAG v1.10.1
+        GIT_TAG v1.11.4
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(libzip)

--- a/src/ship/port/mobile/MobileImpl.cpp
+++ b/src/ship/port/mobile/MobileImpl.cpp
@@ -1,7 +1,7 @@
 #if defined(__ANDROID__) || defined(__IOS__)
-#include "MobileImpl.h"
+#include "ship/port/mobile/MobileImpl.h"
 #include <SDL2/SDL.h>
-#include "ship/public/bridge/consolevariablebridge.h"
+#include "libultraship/bridge/consolevariablebridge.h"
 
 #include <imgui_internal.h>
 

--- a/src/ship/window/gui/Gui.cpp
+++ b/src/ship/window/gui/Gui.cpp
@@ -31,7 +31,7 @@
 #endif
 
 #if defined(__ANDROID__) || defined(__IOS__)
-#include "port/mobile/MobileImpl.h"
+#include "ship/port/mobile/MobileImpl.h"
 #endif
 
 #ifdef ENABLE_OPENGL


### PR DESCRIPTION
iOS builds were failing due to the SDL2 version being too old, which caused a CMake compatibility error with newer CMake versions. This PR updates all of the deps, fixes the affected include paths, re-enables iOS CI, and adds Android CI.