### PR TITLE
Add fallback to WARP (software renderer) for DirectX

### DIFF
--- a/include/fast/backends/gfx_dxgi.h
+++ b/include/fast/backends/gfx_dxgi.h
@@ -51,7 +51,7 @@ class GfxWindowBackendDXGI final : public GfxWindowBackend {
     // These need to be public to be accessible in the window callback
     void CreateSwapChain(IUnknown* mDevice, std::function<void()>&& before_destroy_fn);
     void CreateFactoryAndDevice(bool debug, int d3d_version, class GfxRenderingAPIDX11* self,
-                                bool (*createFunc)(class GfxRenderingAPIDX11* self));
+                                bool (*createFunc)(class GfxRenderingAPIDX11* self, bool SoftwareRenderer));
     void OnKeydown(WPARAM wParam, LPARAM lParam);
     void OnKeyup(WPARAM wParam, LPARAM lParam);
     void OnMouseButtonDown(int btn);

--- a/include/fast/backends/gfx_dxgi.h
+++ b/include/fast/backends/gfx_dxgi.h
@@ -51,8 +51,7 @@ class GfxWindowBackendDXGI final : public GfxWindowBackend {
     // These need to be public to be accessible in the window callback
     void CreateSwapChain(IUnknown* mDevice, std::function<void()>&& before_destroy_fn);
     void CreateFactoryAndDevice(bool debug, int d3d_version, class GfxRenderingAPIDX11* self,
-                                bool (*createFunc)(class GfxRenderingAPIDX11* self, IDXGIAdapter1* adapter,
-                                                   bool test_only));
+                                bool (*createFunc)(class GfxRenderingAPIDX11* self));
     void OnKeydown(WPARAM wParam, LPARAM lParam);
     void OnKeyup(WPARAM wParam, LPARAM lParam);
     void OnMouseButtonDown(int btn);

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -156,6 +156,10 @@ static bool CreateDeviceFunc(class GfxRenderingAPIDX11* self, bool SoftwareRende
         SPDLOG_WARN("D3D adapter doesn't support D3D feature level 10_0 or greater.");
         sprintf(error_message, "%s doesn't support D3D feature level 10_0 or greater.%s", adapterNameCStr,
                 SoftwareRenderer ? SoftwareText : HardwareText);
+    }
+
+    else if (self->mFeatureLevel < D3D_FEATURE_LEVEL_10_1) {
+        SPDLOG_WARN("D3D adapter doesn't support D3D feature level 10_1 or greater. MSAA setting will be ignored.");
 
     } else {
         // Check for Compute Shader support
@@ -818,7 +822,7 @@ void GfxRenderingAPIDX11::UpdateFramebufferParameters(int fb_id, uint32_t width,
 
     width = ((width) > (1U) ? (width) : (1U));
     height = ((height) > (1U) ? (height) : (1U));
-    // We can't use MSAA the way we are using it on Feature Level 10.0 Hardware, so disable it altogether.
+    // We can't use MSAA the way we are using it on feature level 10_0 hardware, so disable it altogether.
     msaa_level = mFeatureLevel < D3D_FEATURE_LEVEL_10_1 ? 1 : msaa_level;
     while (msaa_level > 1 && mMsaaNumQualityLevels[msaa_level - 1] == 0) {
         --msaa_level;

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -110,7 +110,7 @@ static bool CreateDeviceFunc(class GfxRenderingAPIDX11* self, bool SoftwareRende
                                    "You can also try to change the graphic backend of the port in its config file.\n"
                                    "Window->Backend->Id\n"
                                    "0 = DX11, 1 = OpenGL";
-    const char SoftwareText[42] = "\nUsing software renderer failed. Exiting.";
+    const char SoftwareText[33] = "\nUsing software renderer failed.";
 
     if (SoftwareRenderer) {
         SPDLOG_INFO("Using software renderer.");
@@ -181,15 +181,9 @@ static bool CreateDeviceFunc(class GfxRenderingAPIDX11* self, bool SoftwareRende
         if (self->mDevice) {
             self->mDevice->Release();
         }
-        if (SoftwareRenderer) {
-            SPDLOG_ERROR(log_message);
-            MessageBoxA(self->mWindowBackend->GetWindowHandle(), error_message, "Error", MB_OK | MB_ICONERROR);
-            throw;
-        } else {
-            SPDLOG_WARN(log_message);
-            MessageBoxA(self->mWindowBackend->GetWindowHandle(), error_message, "Warning", MB_OK | MB_ICONWARNING);
-            return false;
-        }
+        SPDLOG_WARN(log_message);
+        MessageBoxA(self->mWindowBackend->GetWindowHandle(), error_message, "Warning", MB_OK | MB_ICONWARNING);
+        return false;
     }
     return true;
 };

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -165,7 +165,7 @@ static bool CreateDeviceFunc(class GfxRenderingAPIDX11* self, bool SoftwareRende
             D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS features;
             self->mDevice->CheckFeatureSupport(D3D11_FEATURE_D3D10_X_HARDWARE_OPTIONS, &features,
                                                sizeof(D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS));
-            if (features.ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x == true) {
+            if (features.ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x == false) {
                 CreationFailed = true;
                 sprintf(log_message, "D3D adapter doesn't support compute shaders.");
                 sprintf(error_message, "%s doesn't support compute shaders.%s", adapterNameCStr,

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -97,26 +97,21 @@ void GfxRenderingAPIDX11::CreateDepthStencilObjects(uint32_t width, uint32_t hei
         ThrowIfFailed(mDevice->CreateShaderResourceView(texture.Get(), &srv_desc, srv));
     }
 }
-static bool CreateDeviceFunc(class GfxRenderingAPIDX11* self, IDXGIAdapter1* adapter, bool test_only) {
+static bool CreateDeviceFunc(class GfxRenderingAPIDX11* self) {
 #if DEBUG_D3D
     UINT device_creation_flags = D3D11_CREATE_DEVICE_DEBUG;
 #else
     UINT device_creation_flags = 0;
 #endif
-    D3D_FEATURE_LEVEL FeatureLevels[] = { D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_10_0 };
+    // D3D_FEATURE_LEVEL FeatureLevels[] = { D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_10_0 };
 
-    HRESULT res = self->mDX11CreateDevice(adapter,
-                                          D3D_DRIVER_TYPE_UNKNOWN, // since we use a specific adapter
-                                          nullptr, device_creation_flags, FeatureLevels, ARRAYSIZE(FeatureLevels),
-                                          D3D11_SDK_VERSION, test_only ? nullptr : self->mDevice.GetAddressOf(),
-                                          &self->mFeatureLevel, test_only ? nullptr : self->mContext.GetAddressOf());
+    HRESULT res = self->mDX11CreateDevice(NULL, D3D_DRIVER_TYPE_HARDWARE, nullptr, device_creation_flags, NULL, NULL,
+                                          D3D11_SDK_VERSION, self->mDevice.GetAddressOf(), &self->mFeatureLevel,
+                                          self->mContext.GetAddressOf());
 
-    if (test_only) {
-        return SUCCEEDED(res);
-    } else {
-        ThrowIfFailed(res, self->mWindowBackend->GetWindowHandle(), "Failed to create D3D11 device.");
-        return true;
-    }
+
+    ThrowIfFailed(res, self->mWindowBackend->GetWindowHandle(), "Failed to create D3D11 device.");
+    return SUCCEEDED(res);
 };
 
 void GfxRenderingAPIDX11::Init() {

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -126,7 +126,6 @@ static bool CreateDeviceFunc(class GfxRenderingAPIDX11* self, bool SoftwareRende
     DXGI_ADAPTER_DESC adapterDesc;
     std::wstring adapterName;
     char adapterNameCStr[128] = "";
-    char log_message[256];
     char error_message[512];
     HRESULT res2;
 
@@ -143,19 +142,18 @@ static bool CreateDeviceFunc(class GfxRenderingAPIDX11* self, bool SoftwareRende
         }
         DXGIDevice->Release();
     }
-    sprintf(log_message, "Using D3D adapter: %s", adapterNameCStr);
-    SPDLOG_INFO(log_message);
+    SPDLOG_INFO("Using D3D adapter: {0}", adapterNameCStr);
 
     if (FAILED(res)) {
         CreationFailed = true;
-        sprintf(log_message, "Failed to create a D3D device. HRESULT: 0x%08X", res);
+        SPDLOG_WARN("Failed to create a D3D device. HRESULT: 0x{0:08x}", res);
         sprintf(error_message, "Failed to create a D3D device on %s\nHRESULT: 0x%08X%s", adapterNameCStr, res,
                 SoftwareRenderer ? SoftwareText : HardwareText);
     }
 
     else if (self->mFeatureLevel < D3D_FEATURE_LEVEL_10_0) {
         CreationFailed = true;
-        sprintf(log_message, "D3D adapter doesn't support D3D feature level 10_0 or greater.");
+        SPDLOG_WARN("D3D adapter doesn't support D3D feature level 10_0 or greater.");
         sprintf(error_message, "%s doesn't support D3D feature level 10_0 or greater.%s", adapterNameCStr,
                 SoftwareRenderer ? SoftwareText : HardwareText);
 
@@ -167,7 +165,7 @@ static bool CreateDeviceFunc(class GfxRenderingAPIDX11* self, bool SoftwareRende
                                                sizeof(D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS));
             if (features.ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x == false) {
                 CreationFailed = true;
-                sprintf(log_message, "D3D adapter doesn't support compute shaders.");
+                SPDLOG_WARN("D3D adapter doesn't support compute shaders.");
                 sprintf(error_message, "%s doesn't support compute shaders.%s", adapterNameCStr,
                         SoftwareRenderer ? SoftwareText : HardwareText);
             }
@@ -181,7 +179,6 @@ static bool CreateDeviceFunc(class GfxRenderingAPIDX11* self, bool SoftwareRende
         if (self->mDevice) {
             self->mDevice->Release();
         }
-        SPDLOG_WARN(log_message);
         MessageBoxA(self->mWindowBackend->GetWindowHandle(), error_message, "Warning", MB_OK | MB_ICONWARNING);
         return false;
     }

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -104,9 +104,9 @@ static bool CreateDeviceFunc(class GfxRenderingAPIDX11* self, bool SoftwareRende
     UINT device_creation_flags = 0;
 #endif
     bool CreationFailed = false;
-    const char HardwareText[319] = "\nUsing software renderer. Performance issues are to be expected.\n\n"
-                                   "Please check your prefered GPU in Windows graphics or GPU driver settings and make "
-                                   "sure you have the correct GPU drivers installed.\n\n"
+    const char HardwareText[320] = "\nUsing software renderer. Performance issues are to be expected.\n\n"
+                                   "Please check your preferred GPU in Windows graphics or GPU driver settings and "
+                                   "make sure you have the correct GPU drivers installed.\n\n"
                                    "You can also try to change the graphic backend of the port in its config file.\n"
                                    "Window->Backend->Id\n"
                                    "0 = DX11, 1 = OpenGL";

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -975,8 +975,7 @@ void GfxWindowBackendDXGI::SetMaxFrameLatency(int latency) {
 }
 
 void GfxWindowBackendDXGI::CreateFactoryAndDevice(bool debug, int d3d_version, class GfxRenderingAPIDX11* self,
-                                                  bool (*createFunc)(class GfxRenderingAPIDX11* self,
-                                                                     IDXGIAdapter1* adapter, bool test_only)) {
+                                                  bool (*createFunc)(class GfxRenderingAPIDX11* self)) {
     if (CreateDXGIFactory2 != nullptr) {
         ThrowIfFailed(CreateDXGIFactory2(debug ? DXGI_CREATE_FACTORY_DEBUG : 0, __uuidof(IDXGIFactory2), &mFactory));
     } else {
@@ -997,18 +996,7 @@ void GfxWindowBackendDXGI::CreateFactoryAndDevice(bool debug, int d3d_version, c
         mTearingSupport = SUCCEEDED(hr) && allowTearing;
     }
 
-    ComPtr<IDXGIAdapter1> adapter;
-    for (UINT i = 0; mFactory->EnumAdapters1(i, &adapter) != DXGI_ERROR_NOT_FOUND; i++) {
-        DXGI_ADAPTER_DESC1 desc;
-        adapter->GetDesc1(&desc);
-        if (desc.Flags & 2 /*DXGI_ADAPTER_FLAG_SOFTWARE*/) { // declaration missing in mingw headers
-            continue;
-        }
-        if (createFunc(self, adapter.Get(), true)) {
-            break;
-        }
-    }
-    createFunc(self, adapter.Get(), false);
+    createFunc(self);
 }
 
 void GfxWindowBackendDXGI::CreateSwapChain(IUnknown* mDevice, std::function<void()>&& before_destroy_fn) {

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -996,9 +996,13 @@ void GfxWindowBackendDXGI::CreateFactoryAndDevice(bool debug, int d3d_version, c
 
         mTearingSupport = SUCCEEDED(hr) && allowTearing;
     }
-
-    if (!createFunc(self, false)) {
-        createFunc(self, true);
+    // Try preferred hardware adapter and then try software adapter (WARP), if that fails.
+    // Maybe we can try a different renderer (like OpenGL) here first before software?
+    if (!createFunc(self, false) && !createFunc(self, true)) {
+        SPDLOG_CRITICAL("Creating D3D renderer failed. Exiting");
+        MessageBoxA(self->mWindowBackend->GetWindowHandle(), "Creating D3D renderer failed. Exiting", "Error",
+                    MB_OK | MB_ICONERROR);
+        throw;
     }
 }
 

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -975,7 +975,8 @@ void GfxWindowBackendDXGI::SetMaxFrameLatency(int latency) {
 }
 
 void GfxWindowBackendDXGI::CreateFactoryAndDevice(bool debug, int d3d_version, class GfxRenderingAPIDX11* self,
-                                                  bool (*createFunc)(class GfxRenderingAPIDX11* self)) {
+                                                  bool (*createFunc)(class GfxRenderingAPIDX11* self,
+                                                                     bool SoftwareRenderer)) {
     if (CreateDXGIFactory2 != nullptr) {
         ThrowIfFailed(CreateDXGIFactory2(debug ? DXGI_CREATE_FACTORY_DEBUG : 0, __uuidof(IDXGIFactory2), &mFactory));
     } else {
@@ -996,7 +997,9 @@ void GfxWindowBackendDXGI::CreateFactoryAndDevice(bool debug, int d3d_version, c
         mTearingSupport = SUCCEEDED(hr) && allowTearing;
     }
 
-    createFunc(self);
+    if (!createFunc(self, false)) {
+        createFunc(self, true);
+    }
 }
 
 void GfxWindowBackendDXGI::CreateSwapChain(IUnknown* mDevice, std::function<void()>&& before_destroy_fn) {


### PR DESCRIPTION
This actually changes multiple things for the Directx renderer:
- Graphic adapters (more or less "GPUs") aren't enumerated and checked until one can do at least feature level 10_0. Instead the first one (preferred) is used. This makes the checks easier (only one needs to be tried) and also always respects the "preferred GPU" setting from Windows10 (or driver control panel on older Windows versions).
- Fallback to WARP (software renderer), if the primary adapter can't at least do feature level 10_0, can't do compute shaders / DirectCompute or fails for some other reason.
- More granular error messages why the selected adapter isn't suitable/capable. Those will pop up each start, even when the fallback is successful.
- More logging. Including adapter / GPU name.
- Log when MSAA setting is ignored on old feature level 10_0 hardware. This was the case since some attempts for more compatibility where made, but was never logged. Also apparently there are not many GPUs out there that only support feature level 10_0, but with compute shaders. So this was and will be rarely noticed. But better save than sorry.

I feel like it's ready. Feel free to suggest better messages or anything else that can be improved. 

### Builds:
- Ship of Harkinian: implemented since official release of version 9.2.0
- 2 Ship 2 Harkinian: https://github.com/HarbourMasters/2ship2harkinian/pull/1408
- Ghostship: https://github.com/HarbourMasters/Ghostship/pull/148