### PR TITLE
Log Error No File No Line

### DIFF
--- a/include/libultraship/log/luslog.h
+++ b/include/libultraship/log/luslog.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 void luslog(const char* file, int32_t line, int32_t logLevel, const char* msg);
 void lusprintf(const char* file, int32_t line, int32_t logLevel, const char* fmt, ...);
+void luslog_err(const char* msg);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libultraship/log/luslog.cpp
+++ b/src/libultraship/log/luslog.cpp
@@ -20,4 +20,9 @@ void lusprintf(const char* file, int32_t line, int32_t logLevel, const char* fmt
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     luslog(file, line, logLevel, buffer);
 }
+
+void luslog_err(const char* msg) {
+    std::string str(msg);
+    spdlog::error(str);
+}
 }


### PR DESCRIPTION
Alternatively, we can add this instead

```cpp
#if defined(__GNUC__) || defined(__clang__)
__attribute__((format(printf, 1, 2)))
#endif
[[noreturn]] void lus_throw_runtime_error(const char* fmt, ...) {
    char error_mesg[2048];

    va_list args;
    va_start(args, fmt);
    vsnprintf(error_mesg, sizeof(error_mesg), fmt, args);
    va_end(args);

    const char* crash_desc = "\nSpaghettiKart has crashed! Please upload the logs to the support channel in Discord.";
    strncat(error_mesg, crash_desc, sizeof(error_mesg) - strlen(error_mesg) - 1);

    SPDLOG_ERROR(error_mesg);

    SDL_ShowSimpleMessageBox(
        SDL_MESSAGEBOX_ERROR,
        "You dropped your plate of Spaghetti!",
        error_mesg,
        NULL
    );

    exit(EXIT_FAILURE);
}
```