### PR TITLE
Implement Texture Scrolling Interpolation

### DIFF
--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -146,7 +146,7 @@ struct GfxExecStack {
     // stack for OpenDisp/CloseDisps
     std::vector<CodeDisp> disp_stack{};
 
-    void start(F3DGfx* stack);
+    void start(F3DGfx* dlist);
     void stop();
     F3DGfx*& currCmd();
     void openDisp(const char* file, int line);
@@ -516,7 +516,8 @@ class Interpreter {
     bool mMarkerOn; // This was originally a debug feature. Now it seems to control s2dex?
     std::vector<std::string> shader_ids;
     int32_t mInterpolationIndex;
-    int32_t mInterpolatedFrameCount;
+    int32_t mInterpolationCount;
+    float mVIsPerFrame;
 };
 
 void gfx_set_target_ucode(UcodeHandlers ucode);

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -516,7 +516,7 @@ class Interpreter {
     bool mMarkerOn; // This was originally a debug feature. Now it seems to control s2dex?
     std::vector<std::string> shader_ids;
     int32_t mInterpolationIndex;
-    int32_t mNumInterpolatedFrames;
+    int32_t mInterpolatedFrameCount;
 };
 
 void gfx_set_target_ucode(UcodeHandlers ucode);

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -135,7 +135,7 @@ struct GfxExecStack {
     std::stack<F3DGfx*> cmd_stack = {};
     // This is also a dlist stack but a std::vector is used to make it possible
     // to iterate on the elements.
-    // The purpose of this is to identify an instruction at a poin in time
+    // The purpose of this is to identify an instruction at a point in time
     // which would not be possible with just a F3DGfx* because a dlist can be called multiple times
     // what we do instead is store the call path that leads to the instruction (including branches)
     std::vector<const F3DGfx*> gfx_path = {};
@@ -146,7 +146,7 @@ struct GfxExecStack {
     // stack for OpenDisp/CloseDisps
     std::vector<CodeDisp> disp_stack{};
 
-    void start(F3DGfx* dlist);
+    void start(F3DGfx* stack);
     void stop();
     F3DGfx*& currCmd();
     void openDisp(const char* file, int line);
@@ -294,8 +294,6 @@ struct RDP {
         uint32_t line_size_bytes;
         uint8_t palette;
         uint8_t tmem_index; // 0 or 1 for offset 0 kB or offset 2 kB, respectively
-        uint8_t interpolate;
-        std::vector<TextureInterpValues> vecInterp;
     } texture_tile[8];
     bool textures_changed[2];
 
@@ -439,7 +437,6 @@ class Interpreter {
     void GfxDpSetTile(uint8_t fmt, uint32_t siz, uint32_t line, uint32_t tmem, uint8_t tile, uint32_t palette,
                       uint32_t cmt, uint32_t maskt, uint32_t shiftt, uint32_t cms, uint32_t masks, uint32_t shifts);
     void GfxDpSetTileSize(uint8_t tile, uint16_t uls, uint16_t ult, uint16_t lrs, uint16_t lrt);
-    void GfxDpSetTileInterp(TextureInterpValues& interp);
     void GfxDpLoadTlut(uint8_t tile, uint32_t high_index);
     void GfxDpLoadBlock(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t lrs, uint32_t dxt);
     void GfxDpLoadTile(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t lrs, uint32_t lrt);
@@ -527,10 +524,8 @@ class Interpreter {
     const std::unordered_map<Mtx*, MtxF>* mCurMtxReplacements;
     bool mMarkerOn; // This was originally a debug feature. Now it seems to control s2dex?
     std::vector<std::string> shader_ids;
-    int mInterpolationIndex;
-    int mInterpolationIndexTarget;
-
-    std::vector<TextureInterpValues> mScrollingTextureInterpolation;
+    int32_t mInterpolationIndex;
+    int32_t mNumInterpolatedFrames;
 };
 
 void gfx_set_target_ucode(UcodeHandlers ucode);

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -255,15 +255,6 @@ struct RSP {
     ShaderMod current_shader;
 };
 
-
-struct TextureInterpValues {
-    uint32_t tile;
-    float lrs;
-    float lrt;
-    float uls;
-    float ult;
-};
-
 struct RDP {
     const uint8_t* palettes[2];
     struct {

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -285,6 +285,7 @@ struct RDP {
         uint32_t line_size_bytes;
         uint8_t palette;
         uint8_t tmem_index; // 0 or 1 for offset 0 kB or offset 2 kB, respectively
+        uint8_t interpolate;
     } texture_tile[8];
     bool textures_changed[2];
 
@@ -428,6 +429,7 @@ class Interpreter {
     void GfxDpSetTile(uint8_t fmt, uint32_t siz, uint32_t line, uint32_t tmem, uint8_t tile, uint32_t palette,
                       uint32_t cmt, uint32_t maskt, uint32_t shiftt, uint32_t cms, uint32_t masks, uint32_t shifts);
     void GfxDpSetTileSize(uint8_t tile, uint16_t uls, uint16_t ult, uint16_t lrs, uint16_t lrt);
+    void GfxDpSetTileInterp(uint8_t tile);
     void GfxDpLoadTlut(uint8_t tile, uint32_t high_index);
     void GfxDpLoadBlock(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t lrs, uint32_t dxt);
     void GfxDpLoadTile(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t lrs, uint32_t lrt);
@@ -517,6 +519,17 @@ class Interpreter {
     std::vector<std::string> shader_ids;
     int mInterpolationIndex;
     int mInterpolationIndexTarget;
+
+    struct TextureInterpValues {
+        uint32_t tile;
+        float lrs;
+        float lrt;
+        float uls;
+        float ult;
+    };
+
+    bool bScrollingTexture;
+    std::vector<TextureInterpValues> mScrollingTextureInterpolation;
 };
 
 void gfx_set_target_ucode(UcodeHandlers ucode);

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -515,9 +515,8 @@ class Interpreter {
     const std::unordered_map<Mtx*, MtxF>* mCurMtxReplacements;
     bool mMarkerOn; // This was originally a debug feature. Now it seems to control s2dex?
     std::vector<std::string> shader_ids;
-    int32_t mInterpolationIndex;
-    int32_t mInterpolationCount;
-    float mVIsPerFrame;
+    uint32_t mInterpolationIndex;
+    uint32_t mInterpolationCount;
 };
 
 void gfx_set_target_ucode(UcodeHandlers ucode);

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -255,6 +255,15 @@ struct RSP {
     ShaderMod current_shader;
 };
 
+
+struct TextureInterpValues {
+    uint32_t tile;
+    float lrs;
+    float lrt;
+    float uls;
+    float ult;
+};
+
 struct RDP {
     const uint8_t* palettes[2];
     struct {
@@ -286,6 +295,7 @@ struct RDP {
         uint8_t palette;
         uint8_t tmem_index; // 0 or 1 for offset 0 kB or offset 2 kB, respectively
         uint8_t interpolate;
+        std::vector<TextureInterpValues> vecInterp;
     } texture_tile[8];
     bool textures_changed[2];
 
@@ -429,7 +439,7 @@ class Interpreter {
     void GfxDpSetTile(uint8_t fmt, uint32_t siz, uint32_t line, uint32_t tmem, uint8_t tile, uint32_t palette,
                       uint32_t cmt, uint32_t maskt, uint32_t shiftt, uint32_t cms, uint32_t masks, uint32_t shifts);
     void GfxDpSetTileSize(uint8_t tile, uint16_t uls, uint16_t ult, uint16_t lrs, uint16_t lrt);
-    void GfxDpSetTileInterp(uint8_t tile);
+    void GfxDpSetTileInterp(TextureInterpValues& interp);
     void GfxDpLoadTlut(uint8_t tile, uint32_t high_index);
     void GfxDpLoadBlock(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t lrs, uint32_t dxt);
     void GfxDpLoadTile(uint8_t tile, uint32_t uls, uint32_t ult, uint32_t lrs, uint32_t lrt);
@@ -520,15 +530,6 @@ class Interpreter {
     int mInterpolationIndex;
     int mInterpolationIndexTarget;
 
-    struct TextureInterpValues {
-        uint32_t tile;
-        float lrs;
-        float lrt;
-        float uls;
-        float ult;
-    };
-
-    bool bScrollingTexture;
     std::vector<TextureInterpValues> mScrollingTextureInterpolation;
 };
 

--- a/include/fast/lus_gbi.h
+++ b/include/fast/lus_gbi.h
@@ -68,7 +68,6 @@ constexpr int8_t OTR_G_REGBLENDEDTEX = OPCODE(0x3f);
 constexpr int8_t OTR_G_SETINTENSITY = OPCODE(0x40);
 constexpr int8_t OTR_G_MOVEMEM_HASH = OPCODE(0x42);
 constexpr int8_t OTR_G_LOAD_SHADER = OPCODE(0x43);
-constexpr int8_t RDP_G_SETTILESIZE_INTERP = OPCODE(0x44);
 constexpr int8_t RDP_G_SETTARGETINTERPINDEX = OPCODE(0x45);
 
 /*

--- a/include/fast/lus_gbi.h
+++ b/include/fast/lus_gbi.h
@@ -68,7 +68,7 @@ constexpr int8_t OTR_G_REGBLENDEDTEX = OPCODE(0x3f);
 constexpr int8_t OTR_G_SETINTENSITY = OPCODE(0x40);
 constexpr int8_t OTR_G_MOVEMEM_HASH = OPCODE(0x42);
 constexpr int8_t OTR_G_LOAD_SHADER = OPCODE(0x43);
-constexpr int8_t RDP_G_SETTARGETINTERPINDEX = OPCODE(0x45);
+constexpr int8_t RDP_G_SCROLL_TEXTURE = OPCODE(0x44);
 
 /*
  * The following commands are the "generated" RDP commands; the user

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -3212,26 +3212,25 @@ typedef union Gfx {
             _SHIFTL(tile, 24, 3) | _SHIFTL(lrs, 12, 12) | _SHIFTL(lrt, 0, 12) \
     }
 
-#define gDPScrollTexture(pkt, t, uls, ult, lrs, lrt, stepX, stepY)                      \
-    _DW({                                                                               \
-        Gfx* _g = (Gfx*)(pkt);                                                          \
-        if (pkt)                                                                        \
-            ;                                                                           \
-        _g->words.w0 = (_SHIFTL(G_SCROLL_TEXTURE, 24, 8) | _SHIFTL(tile, 0, 12));       \
-        _g->words.w1 = (_SHIFTL(stepX, 32, 32) | _SHIFTL(stepY, 0, 32));                \
-        _g++;                                                                           \
-        _g->words.w0 = (_SHIFTL(uls, 32, 32) | _SHIFTL(ult, 0, 32));                    \
-        _g->words.w1 = (_SHIFTL(lrs, 32, 32) | _SHIFTL(lrt, 0, 32));                    \
-    })                                                                                  \
+#define gDPScrollTexture(pkt, t, uls, ult, lrs, lrt, stepX, stepY)                \
+    _DW({                                                                         \
+        Gfx* _g = (Gfx*)(pkt);                                                    \
+        if (pkt)                                                                  \
+            ;                                                                     \
+        _g->words.w0 = (_SHIFTL(G_SCROLL_TEXTURE, 24, 8) | _SHIFTL(tile, 0, 12)); \
+        _g->words.w1 = (_SHIFTL(stepX, 32, 32) | _SHIFTL(stepY, 0, 32));          \
+        _g++;                                                                     \
+        _g->words.w0 = (_SHIFTL(uls, 32, 32) | _SHIFTL(ult, 0, 32));              \
+        _g->words.w1 = (_SHIFTL(lrs, 32, 32) | _SHIFTL(lrt, 0, 32));              \
+    })                                                                            \
 
-#define gsDPScrollTexture(t, uls, ult, lrs, lrt, stepX, stepY)          \
-    {                                                                   \
-        (_SHIFTL(G_SCROLL_TEXTURE, 24, 8) | _SHIFTL(tile, 0, 12)),      \
-        (_SHIFTL(stepX, 32, 32) | _SHIFTL(stepY, 0, 32)),               \
-    },                                                                  \
-    {                                                                   \
-        (_SHIFTL(uls, 32, 32) | _SHIFTL(ult, 0, 32)),                   \
-        (_SHIFTL(lrs, 32, 32) | _SHIFTL(lrt, 0, 32)),                   \
+#define gsDPScrollTexture(t, uls, ult, lrs, lrt, stepX, stepY)                                      \
+    {                                                                                               \
+        (_SHIFTL(G_SCROLL_TEXTURE, 24, 8) | _SHIFTL(tile, 0, 12)),                                  \
+        (_SHIFTL(stepX, 32, 32) | _SHIFTL(stepY, 0, 32)),                                           \
+    },                                                                                              \
+    {                                                                                               \
+        (_SHIFTL(uls, 32, 32) | _SHIFTL(ult, 0, 32)), (_SHIFTL(lrs, 32, 32) | _SHIFTL(lrt, 0, 32)), \
     }
 
 #define gDPSetTileSize(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_SETTILESIZE, t, uls, ult, lrs, lrt)

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -3222,7 +3222,7 @@ typedef union Gfx {
         _g++;                                                                     \
         _g->words.w0 = (_SHIFTL(uls, 32, 32) | _SHIFTL(ult, 0, 32));              \
         _g->words.w1 = (_SHIFTL(lrs, 32, 32) | _SHIFTL(lrt, 0, 32));              \
-    })                                                                            \
+    })
 
 #define gsDPScrollTexture(t, uls, ult, lrs, lrt, stepX, stepY)                                      \
     {                                                                                               \

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -3221,8 +3221,6 @@ typedef union Gfx {
         _g->words.w1 = index;                        \
     })
 
-#define __gDPSetTileSizeInterp(pkt, t, uls, ult, lrs, lrt) \
-    gDPLoadTileGeneric(pkt, G_SETTILESIZE_INTERP, t, uls, ult, lrs, lrt)
 #define gDPSetTileSize(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_SETTILESIZE, t, uls, ult, lrs, lrt)
 #define gsDPSetTileSize(t, uls, ult, lrs, lrt) gsDPLoadTileGeneric(G_SETTILESIZE, t, uls, ult, lrs, lrt)
 #define gDPLoadTile(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_LOADTILE, t, uls, ult, lrs, lrt)

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -190,8 +190,7 @@
 #define G_READFB 0x3e
 #define G_SETINTENSITY 0x40
 #define G_LOAD_SHADER 0x43
-#define G_SETTILESIZE_INTERP 0x44
-#define G_SETTARGETINTERPINDEX 0x45
+#define G_SCROLL_TEXTURE 0x44
 
 /*
  * The following commands are the "generated" RDP commands; the user
@@ -3213,13 +3212,27 @@ typedef union Gfx {
             _SHIFTL(tile, 24, 3) | _SHIFTL(lrs, 12, 12) | _SHIFTL(lrt, 0, 12) \
     }
 
-#define gDPSetInterpolation(pkt, index)              \
-    _DW({                                            \
-        Gfx* _g = (Gfx*)(pkt);                       \
-                                                     \
-        _g->words.w0 = G_SETTARGETINTERPINDEX << 24; \
-        _g->words.w1 = index;                        \
-    })
+#define gDPScrollTexture(pkt, t, uls, ult, lrs, lrt, stepX, stepY)                      \
+    _DW({                                                                               \
+        Gfx* _g = (Gfx*)(pkt);                                                          \
+        if (pkt)                                                                        \
+            ;                                                                           \
+        _g->words.w0 = (_SHIFTL(G_SCROLL_TEXTURE, 24, 8) | _SHIFTL(tile, 0, 12));       \
+        _g->words.w1 = (_SHIFTL(stepX, 32, 32) | _SHIFTL(stepY, 0, 32));                \
+        _g++;                                                                           \
+        _g->words.w0 = (_SHIFTL(uls, 32, 32) | _SHIFTL(ult, 0, 32));                    \
+        _g->words.w1 = (_SHIFTL(lrs, 32, 32) | _SHIFTL(lrt, 0, 32));                    \
+    })                                                                                  \
+
+#define gsDPScrollTexture(t, uls, ult, lrs, lrt, stepX, stepY)          \
+    {                                                                   \
+        (_SHIFTL(G_SCROLL_TEXTURE, 24, 8) | _SHIFTL(tile, 0, 12)),      \
+        (_SHIFTL(stepX, 32, 32) | _SHIFTL(stepY, 0, 32)),               \
+    },                                                                  \
+    {                                                                   \
+        (_SHIFTL(uls, 32, 32) | _SHIFTL(ult, 0, 32)),                   \
+        (_SHIFTL(lrs, 32, 32) | _SHIFTL(lrt, 0, 32)),                   \
+    }
 
 #define gDPSetTileSize(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_SETTILESIZE, t, uls, ult, lrs, lrt)
 #define gsDPSetTileSize(t, uls, ult, lrs, lrt) gsDPLoadTileGeneric(G_SETTILESIZE, t, uls, ult, lrs, lrt)

--- a/include/ship/window/Window.h
+++ b/include/ship/window/Window.h
@@ -82,6 +82,8 @@ class Window {
     void SetFullscreenScancode(int32_t scancode);
     void SetMouseCaptureScancode(int32_t scancode);
 
+    uint64_t mFrameCount;
+
   protected:
     void SetWindowBackend(WindowBackend backend);
     void AddAvailableWindowBackend(WindowBackend backend);

--- a/include/ship/window/Window.h
+++ b/include/ship/window/Window.h
@@ -81,7 +81,6 @@ class Window {
     int32_t GetMouseCaptureScancode();
     void SetFullscreenScancode(int32_t scancode);
     void SetMouseCaptureScancode(int32_t scancode);
-
     uint64_t mFrameCount;
 
   protected:

--- a/src/fast/Fast3dWindow.cpp
+++ b/src/fast/Fast3dWindow.cpp
@@ -206,6 +206,7 @@ bool Fast3dWindow::DrawAndRunGraphicsCommands(Gfx* commands, const std::unordere
 }
 
 void Fast3dWindow::HandleEvents() {
+    mFrameCount += 1;
     mWindowManagerApi->HandleEvents();
 }
 

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -3634,14 +3634,14 @@ bool gfx_scroll_texture_handler_rdp(F3DGfx** cmd0) {
     }
 
     int32_t stepX = (int32_t) C1(32, 32);
-    int32_t stepY = (int32_t) C1( 0, 32);
+    int32_t stepY = (int32_t) C1(0, 32);
 
     ++(*cmd0);
 
     int32_t origin_uls = (int32_t)C0(32, 32);
-    int32_t origin_ult = (int32_t)C0( 0, 32);
+    int32_t origin_ult = (int32_t)C0(0, 32);
     int32_t origin_lrs = (int32_t)C1(32, 32);
-    int32_t origin_lrt = (int32_t)C1( 0, 32);
+    int32_t origin_lrt = (int32_t)C1(0, 32);
 
     /** Calculate Interpolation **/
     origin_uls += stepX;
@@ -3940,7 +3940,7 @@ class UcodeHandler {
 
 static constexpr UcodeHandler rdpHandlers = {
     { RDP_G_SCROLL_TEXTURE,
-      { "G_SCROLL_TEXTURE", gfx_scroll_texture_handler_rdp } },            // G_SETTILESIZE_INTERP
+    { "G_SCROLL_TEXTURE", gfx_scroll_texture_handler_rdp } },                        // G_SCROLL_TEXTURE
     { RDP_G_TEXRECT, { "G_TEXRECT", gfx_tex_rect_and_flip_handler_rdp } },           // G_TEXRECT (-28)
     { RDP_G_TEXRECTFLIP, { "G_TEXRECTFLIP", gfx_tex_rect_and_flip_handler_rdp } },   // G_TEXRECTFLIP (-27)
     { RDP_G_RDPLOADSYNC, { "mRdpLOADSYNC", gfx_stubbed_command_handler } },          // mRdpLOADSYNC (-26)

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -29,11 +29,13 @@
 #include "fast/backends/gfx_window_manager_api.h"
 #include "fast/backends/gfx_rendering_api.h"
 
+#include "ship/window/Window.h"
 #include "ship/window/gui/Gui.h"
 #include "ship/resource/ResourceManager.h"
 #include "ship/utils/Utils.h"
 #include "ship/Context.h"
 #include "ship/config/ConsoleVariable.h"
+
 
 #include "libultraship/libultra/os.h"
 

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -34,7 +34,6 @@
 #include "ship/utils/Utils.h"
 #include "ship/Context.h"
 #include "ship/config/ConsoleVariable.h"
-#include "ship/window/Window.h"
 
 #include "libultraship/libultra/os.h"
 
@@ -2627,11 +2626,11 @@ void* Interpreter::SegAddr(uintptr_t w1) {
 #define C0(pos, width) ((cmd->words.w0 >> (pos)) & ((1U << width) - 1))
 #define C1(pos, width) ((cmd->words.w1 >> (pos)) & ((1U << width) - 1))
 
-void GfxExecStack::start(F3DGfx* stack) {
+void GfxExecStack::start(F3DGfx* dlist) {
     while (!cmd_stack.empty())
         cmd_stack.pop();
     gfx_path.clear();
-    cmd_stack.push(stack);
+    cmd_stack.push(dlist);
     disp_stack.clear();
 }
 
@@ -3633,7 +3632,7 @@ bool gfx_set_tile_size_interp_handler_rdp(F3DGfx** cmd0) {
     interpFrames /= ceil((60.0f / 2)); /* gVIsPerFrame */
 
     // Verify the frame should be interpolated
-    if (gfx->mInterpolationIndex >= interpFrames) {
+    if (gfx->mInterpolationIndex >= gfx->mInterpolationCount) {
         ++(*cmd0);
         ++(*cmd0);
         return false;
@@ -3665,8 +3664,8 @@ bool gfx_set_tile_size_interp_handler_rdp(F3DGfx** cmd0) {
     lrs = (float) (x % 2048);
     lrt = (float) (y % 2048);
 
-    incX = (float)stepX / (float)interpFrames;
-    incY = (float)stepY / (float)interpFrames;
+    incX = (float)stepX / (float)gfx->mInterpolationCount;
+    incY = (float)stepY / (float)gfx->mInterpolationCount;
 
     // Calculate the interpolation for the current frame
     lrs += incX * gfx->mInterpolationIndex;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1515,7 +1515,7 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
     uint32_t tm = 0;
     uint32_t tex_width[2], tex_height[2], tex_width2[2], tex_height2[2];
 
-    for (int i = 0; i < 1; i++) {
+    for (int i = 0; i < 2; i++) {
         uint32_t tile = mRdp->first_tile_index + i;
         if (comb->usedTextures[i]) {
             if (mRdp->textures_changed[i]) {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -3627,10 +3627,6 @@ bool gfx_set_tile_size_interp_handler_rdp(F3DGfx** cmd0) {
     float lrs, lrt, uls, ult;
     float incX, incY;
 
-    /** Interpolate **/
-    uint32_t interpFrames = Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
-    interpFrames /= ceil((60.0f / 2)); /* gVIsPerFrame */
-
     // Verify the frame should be interpolated
     if (gfx->mInterpolationIndex >= gfx->mInterpolationCount) {
         ++(*cmd0);
@@ -3673,7 +3669,7 @@ bool gfx_set_tile_size_interp_handler_rdp(F3DGfx** cmd0) {
     uls = (float) ( lrs + ( (width - 1) ) );
     ult = (float) ( lrt + ( (height - 1) ) );
 
-    // Apply to texture
+    // Apply values to texture
     gfx->mRdp->texture_tile[tile].lrs = lrs;
     gfx->mRdp->texture_tile[tile].lrt = lrt;
     gfx->mRdp->texture_tile[tile].uls = uls;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -3633,8 +3633,8 @@ bool gfx_scroll_texture_handler_rdp(F3DGfx** cmd0) {
         return false;
     }
 
-    int32_t stepX = (int32_t) C1(32, 32);
-    int32_t stepY = (int32_t) C1(0, 32);
+    int32_t stepX = (int32_t)C1(32, 32);
+    int32_t stepY = (int32_t)C1(0, 32);
 
     ++(*cmd0);
 
@@ -3939,32 +3939,31 @@ class UcodeHandler {
 };
 
 static constexpr UcodeHandler rdpHandlers = {
-    { RDP_G_SCROLL_TEXTURE,
-    { "G_SCROLL_TEXTURE", gfx_scroll_texture_handler_rdp } },                        // G_SCROLL_TEXTURE
-    { RDP_G_TEXRECT, { "G_TEXRECT", gfx_tex_rect_and_flip_handler_rdp } },           // G_TEXRECT (-28)
-    { RDP_G_TEXRECTFLIP, { "G_TEXRECTFLIP", gfx_tex_rect_and_flip_handler_rdp } },   // G_TEXRECTFLIP (-27)
-    { RDP_G_RDPLOADSYNC, { "mRdpLOADSYNC", gfx_stubbed_command_handler } },          // mRdpLOADSYNC (-26)
-    { RDP_G_RDPPIPESYNC, { "mRdpPIPESYNC", gfx_stubbed_command_handler } },          // mRdpPIPESYNC (-25)
-    { RDP_G_RDPTILESYNC, { "mRdpTILESYNC", gfx_stubbed_command_handler } },          // mRdpPIPESYNC (-24)
-    { RDP_G_RDPFULLSYNC, { "mRdpFULLSYNC", gfx_stubbed_command_handler } },          // mRdpFULLSYNC (-23)
-    { RDP_G_SETSCISSOR, { "G_SETSCISSOR", gfx_SetScissor_handler_rdp } },            // G_SETSCISSOR (-19)
-    { RDP_G_SETPRIMDEPTH, { "G_SETPRIMDEPTH", gfx_set_prim_depth_handler_rdp } },    // G_SETPRIMDEPTH (-18)
-    { RDP_G_RDPSETOTHERMODE, { "mRdpSETOTHERMODE", gfx_rdp_set_other_mode_rdp } },   // mRdpSETOTHERMODE (-17)
-    { RDP_G_LOADTLUT, { "G_LOADTLUT", gfx_load_tlut_handler_rdp } },                 // G_LOADTLUT (-16)
-    { RDP_G_SETTILESIZE, { "G_SETTILESIZE", gfx_set_tile_size_handler_rdp } },       // G_SETTILESIZE (-14)
-    { RDP_G_LOADBLOCK, { "G_LOADBLOCK", gfx_load_block_handler_rdp } },              // G_LOADBLOCK (-13)
-    { RDP_G_LOADTILE, { "G_LOADTILE", gfx_load_tile_handler_rdp } },                 // G_LOADTILE (-12)
-    { RDP_G_SETTILE, { "G_SETTILE", gfx_set_tile_handler_rdp } },                    // G_SETTILE (-11)
-    { RDP_G_FILLRECT, { "G_FILLRECT", gfx_fill_rect_handler_rdp } },                 // G_FILLRECT (-10)
-    { RDP_G_SETFILLCOLOR, { "G_SETFILLCOLOR", gfx_set_fill_color_handler_rdp } },    // G_SETFILLCOLOR (-9)
-    { RDP_G_SETFOGCOLOR, { "G_SETFOGCOLOR", gfx_set_fog_color_handler_rdp } },       // G_SETFOGCOLOR (-8)
-    { RDP_G_SETBLENDCOLOR, { "G_SETBLENDCOLOR", gfx_set_blend_color_handler_rdp } }, // G_SETBLENDCOLOR (-7)
-    { RDP_G_SETPRIMCOLOR, { "G_SETPRIMCOLOR", gfx_set_prim_color_handler_rdp } },    // G_SETPRIMCOLOR (-6)
-    { RDP_G_SETENVCOLOR, { "G_SETENVCOLOR", gfx_set_env_color_handler_rdp } },       // G_SETENVCOLOR (-5)
-    { RDP_G_SETCOMBINE, { "G_SETCOMBINE", gfx_set_combine_handler_rdp } },           // G_SETCOMBINE (-4)
-    { RDP_G_SETTIMG, { "G_SETTIMG", gfx_set_timg_handler_rdp } },                    // G_SETTIMG (-3)
-    { RDP_G_SETZIMG, { "G_SETZIMG", gfx_set_z_img_handler_rdp } },                   // G_SETZIMG (-2)
-    { RDP_G_SETCIMG, { "G_SETCIMG", gfx_set_c_img_handler_rdp } },                   // G_SETCIMG (-1)
+    { RDP_G_SCROLL_TEXTURE, { "G_SCROLL_TEXTURE", gfx_scroll_texture_handler_rdp } }, // G_SCROLL_TEXTURE
+    { RDP_G_TEXRECT, { "G_TEXRECT", gfx_tex_rect_and_flip_handler_rdp } },            // G_TEXRECT (-28)
+    { RDP_G_TEXRECTFLIP, { "G_TEXRECTFLIP", gfx_tex_rect_and_flip_handler_rdp } },    // G_TEXRECTFLIP (-27)
+    { RDP_G_RDPLOADSYNC, { "mRdpLOADSYNC", gfx_stubbed_command_handler } },           // mRdpLOADSYNC (-26)
+    { RDP_G_RDPPIPESYNC, { "mRdpPIPESYNC", gfx_stubbed_command_handler } },           // mRdpPIPESYNC (-25)
+    { RDP_G_RDPTILESYNC, { "mRdpTILESYNC", gfx_stubbed_command_handler } },           // mRdpPIPESYNC (-24)
+    { RDP_G_RDPFULLSYNC, { "mRdpFULLSYNC", gfx_stubbed_command_handler } },           // mRdpFULLSYNC (-23)
+    { RDP_G_SETSCISSOR, { "G_SETSCISSOR", gfx_SetScissor_handler_rdp } },             // G_SETSCISSOR (-19)
+    { RDP_G_SETPRIMDEPTH, { "G_SETPRIMDEPTH", gfx_set_prim_depth_handler_rdp } },     // G_SETPRIMDEPTH (-18)
+    { RDP_G_RDPSETOTHERMODE, { "mRdpSETOTHERMODE", gfx_rdp_set_other_mode_rdp } },    // mRdpSETOTHERMODE (-17)
+    { RDP_G_LOADTLUT, { "G_LOADTLUT", gfx_load_tlut_handler_rdp } },                  // G_LOADTLUT (-16)
+    { RDP_G_SETTILESIZE, { "G_SETTILESIZE", gfx_set_tile_size_handler_rdp } },        // G_SETTILESIZE (-14)
+    { RDP_G_LOADBLOCK, { "G_LOADBLOCK", gfx_load_block_handler_rdp } },               // G_LOADBLOCK (-13)
+    { RDP_G_LOADTILE, { "G_LOADTILE", gfx_load_tile_handler_rdp } },                  // G_LOADTILE (-12)
+    { RDP_G_SETTILE, { "G_SETTILE", gfx_set_tile_handler_rdp } },                     // G_SETTILE (-11)
+    { RDP_G_FILLRECT, { "G_FILLRECT", gfx_fill_rect_handler_rdp } },                  // G_FILLRECT (-10)
+    { RDP_G_SETFILLCOLOR, { "G_SETFILLCOLOR", gfx_set_fill_color_handler_rdp } },     // G_SETFILLCOLOR (-9)
+    { RDP_G_SETFOGCOLOR, { "G_SETFOGCOLOR", gfx_set_fog_color_handler_rdp } },        // G_SETFOGCOLOR (-8)
+    { RDP_G_SETBLENDCOLOR, { "G_SETBLENDCOLOR", gfx_set_blend_color_handler_rdp } },  // G_SETBLENDCOLOR (-7)
+    { RDP_G_SETPRIMCOLOR, { "G_SETPRIMCOLOR", gfx_set_prim_color_handler_rdp } },     // G_SETPRIMCOLOR (-6)
+    { RDP_G_SETENVCOLOR, { "G_SETENVCOLOR", gfx_set_env_color_handler_rdp } },        // G_SETENVCOLOR (-5)
+    { RDP_G_SETCOMBINE, { "G_SETCOMBINE", gfx_set_combine_handler_rdp } },            // G_SETCOMBINE (-4)
+    { RDP_G_SETTIMG, { "G_SETTIMG", gfx_set_timg_handler_rdp } },                     // G_SETTIMG (-3)
+    { RDP_G_SETZIMG, { "G_SETZIMG", gfx_set_z_img_handler_rdp } },                    // G_SETZIMG (-2)
+    { RDP_G_SETCIMG, { "G_SETCIMG", gfx_set_c_img_handler_rdp } },                    // G_SETCIMG (-1)
 };
 
 static constexpr UcodeHandler otrHandlers = {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -36,7 +36,6 @@
 #include "ship/Context.h"
 #include "ship/config/ConsoleVariable.h"
 
-
 #include "libultraship/libultra/os.h"
 
 #include <spdlog/fmt/fmt.h>

--- a/src/ship/window/Window.cpp
+++ b/src/ship/window/Window.cpp
@@ -16,6 +16,7 @@ Window::Window(std::shared_ptr<Gui> gui) {
     mGui = gui;
     mAvailableWindowBackends = std::make_shared<std::vector<WindowBackend>>();
     mConfig = Context::GetInstance()->GetConfig();
+    mFrameCount = 0;
 }
 
 Window::Window(std::vector<std::shared_ptr<GuiWindow>> guiWindows) : Window(std::make_shared<Gui>(guiWindows)) {


### PR DESCRIPTION
First of all... *Actually, hold on a second.*

Merry Christmas! I hope everyone is hanging out with their family, and safe travels to everyone travelling during this time. Stay safe, stay warm (It's about to be -50 celcius where I'm from that's -58 in freedom units). And I hope you're playing a plethora of Christmas carols to annoy every family member who has been sick of hearing them play in the grocery store since September. Okay, with that out of the way.

*First of all,* I've had very little sleep. I'm tired, I'm emotional, I just want to go home. And as such, I'm going to need a little bit of grace on my next point (*...and all the other ones as well*).
Second of all, 2Ship can go stick their heads in a snowbank*.
Third of all, this is still wip and it may not quite work yet please provide as helpful suggestions as possible as we work together to find a solution that works for everyone. However, please refrain from statements such as *I don't like this because 2ship will have to do more work* or *2ship already implemented tex scrolling* or *I don't like this PR because I'm only getting coal and socks for Christmas* because these are not very helpful statements, *and why should I care anyway? You probably deserved the coal. Socks on the other hand, oooh, wouldn't wish that on my worst enemy, but still, sucks to suck!*

I intend to do the following:
* Implement the gbi.h commands 'properly' and not half [censored]
* Implement the feature in a way that works for everyone, and not just myself \**cough*\* \**cough\** 2ship \**cough\** *\*cough\** *\*cough*\* *\*dies*\* *\*you bastards*\* *Was I supposed to be dead? My bad*
* Implement the rsp and rdp versions of the gbi command so it works with static DLists (*if you even know what that is*).
* Communicate and interact with the other ports so that we have a thriving community and attempt to provide at least basic technical advice to others where possible (*Or at least are acquainted with each other*).
* Implement the interpolation on the *(and this point is extremely critical*) --> \*INTERPRETER SIDE\* <-- of the code-base where it belongs
  * Say it aloud with me *on the INTERPRETER SIDE WHERE IT BELONGS*, (For those who actually said it aloud, thank you. For those who didn't, please see my second point at the top of the PR)).
* Investigate if the interpolation in the original 'method' (*I use the word 'method' pretty loosely here*), even works as well as may be desirable (using really shitty computer, so not sure).
  * If concludes the interpolation could be improved, try to see what could be done on that front
  * If concludes it's fine. Then maybe consider crediting the original author in this PR for their work (*Ha, fat chance at that!*)
* Make sure everyone benefits from this PR
* Deeply contemplate my mental status (*I'm fine, just dramatically under paid*).


*Please do not actually go stick your head in a snowbank. (*I've been informed not to say this, but f it*) No matter how much I wish you would 

# Todo
- [ ] Possibly better place for mFrameCount (it's a clock)
- [x] Make GBI commands smaller
- [x] Make GBI macro

### Possible Improvements
* Currently stuck with matrix-based interpolations.
  * The texture scrolling could be interpolated *more* times but not currently possible because this is done in GfxSpTri1
* Delta time
  * Couldn't get it fully unlinked from framerate
  * Might need more render frames to have any difference from frameCount
* Replace G_SETTILESIZE with G_SCROLL_TEXTURE
  * Would need a way to plug in stepX/stepY

## Port-side Implementation Instructions
Add this line beside mInterpolationIndex
```c
interpreter->mInterpolationCount = mtx_replacements.size();
```
<img width="847" height="540" alt="image" src="https://github.com/user-attachments/assets/02b9dbfa-8fd8-4b3a-859e-e3e0a6b2bc42" />
Any ports using frameCounter like so:
```cpp
gDPScrollTexture(gfx, 0, (this->frameCounter * -15) & 0xFF, 32, 64, 0, -15));
```
Will need to remove frameCounter. This is done in lus now.
The updated version would be `gDPScrollTexture(gfx, 0, 0, 0, 32, 64, 0, -15)`

## Normal DL Example
Replace gDPSetTileSize with:
```cpp
// Steps by Y 10 every frame
gDPScrollTexture(gfx++, tile, uls, ult, lrs, lrt, 0, 10);
// Using simpler terms:
gDPScrollTexture(gfx++, tile, x, y, width, height, 0, 10);
```

## Static DL Example
Run this once at the start of your level. Be sure to that the life time of writableDList outlasts the level and draw phase otherwise it will crash if it becomes null
```cpp
/**
 * This function finds a G_SETTILESIZE command and hooks it.
 * Then writes the interpolation command into the provided gfx array
 * The game continues as normal after leaving the writableDList
 *
 * @arg gfxAsset the model needing interpolated scrolling textures
 * @arg writableDList - Provide Gfx myGfx[3]. This memory MUST stay alive for the lifetime of the object
 */

void scroll_texture_interpolated(Gfx* writableDList, const char* gfxAsset, s32 stepX, s32 stepY) {
    int8_t opcode = 0;
    if ((NULL == writableDList) || (NULL == gfxAsset)) {
        return;
    }

    Gfx* gfx = (Gfx*) gfxAsset;
    if (GameEngine_OTRSigCheck(gfx)) {
        gfx = (Gfx*) ResourceGetDataByName(gfx);
    }

    while ((opcode = GFX_GET_OPCODE(gfx->words.w0) >> 24) != G_ENDDL) {
        if (opcode == (int8_t)G_SETTILESIZE) {
            // Get values from the old tile size command
            int32_t tile = _SHIFTR(gfx->words.w1, 24, 12);
            int32_t uls  = _SHIFTR(gfx->words.w0, 12, 12);
            int32_t ult  = _SHIFTR(gfx->words.w0, 0,  12);
            int32_t lrs  = _SHIFTR(gfx->words.w1, 12, 12);
            int32_t lrt  = _SHIFTR(gfx->words.w1, 0,  12);
            
            // Write over old command to point to the new writeableDList
            __gSPDisplayList(gfx, &writableDList[0]);

            // Write DL data into writableDList. gDPScrollTexture takes up two Gfx
            gDPScrollTexture(&writableDList[0], tile, uls, ult, lrs, lrt, stepX, stepY);
            gSPEndDisplayList(&writableDList[2]);
            break;
        }
        gfx++;
    }
}
```
## Modify Scroll After Created Static DL Example
```cpp
Level::Tick() {
    D_802B87CC = random_int(300) / 40;
    if (D_802B87C8 < 0) {
        D_802B87C8 = random_int(300) / 40;
    } else {
        D_802B87C8 = -(random_int(300) / 40);
    }
    //                                stepX                                         stepY
    scroll3[0].words.w1 = (SHIFTL(D_802B87C8, 32, 32)) | SHIFTL(D_802B87CC, 0, 32));
}
```

## Possible Delta Time Solution
This solution didn't work because it locked the scroll speed into the framerate. Whereas this was mostly solved, it was still a tiny bit effect and didn't have a noticeable improvement over frameCount. It's also likely that the deltaTime function used by SpaghettiKart needs to be ported as it still uses the old macro for OS Time

If this was to be re-looked at, suggest waiting for Kenix tick/draw component PR and then having a deltaTime calculation baked into lus
```cpp
bool gfx_set_tile_size_interp_delta_time_handler_rdp(F3DGfx** cmd0) {
    F3DGfx* cmd = *cmd0;
    Interpreter* gfx = mInstance.lock().get();
    //float lrs, lrt;
    float incX, incY;
    float deltaTime = Ship::Context::GetInstance()->GetWindow()->mDeltaTime;
    uint32_t tile = C0(0, 12);
    
    float stepX = (int32_t) ((*cmd0)->words.w1 >> 32);
    float stepY = (int32_t) (*cmd0)->words.w1;

    ++(*cmd0);

    float uls = *reinterpret_cast<float*>((((u8*)&(*cmd0)->words.w0)) + sizeof(float));
    float ult = *reinterpret_cast<float*>(&(*cmd0)->words.w0);
    float lrs = *reinterpret_cast<float*>((((u8*)&(*cmd0)->words.w1)) + sizeof(float));
    float lrt = *reinterpret_cast<float*>(&(*cmd0)->words.w1);
    // printf("rec uls %d ult %d lrs %d lrt %d\n", origin_uls, origin_ult, origin_lrs, origin_lrt);

    // Clamp deltaTime to a reasonable range to avoid drastic changes
    if (deltaTime > 0.1f) {
        deltaTime = 0.1f;  // Cap deltaTime to prevent excessive scrolling speed
    }

    /** Calculate Interpolation **/

    deltaTime /= gfx->mInterpolationCount;
    stepX /= gfx->mInterpolationCount;
    stepY /= gfx->mInterpolationCount;
    //deltaTime *= gfx->mInterpolationIndex;

    if (gfx->mInterpolationCount == 1) {
        deltaTime *= gfx->mInterpolationIndex + 1;
        stepX *= gfx->mInterpolationIndex + 1;
        stepY *= gfx->mInterpolationIndex + 1;
    } else {
        deltaTime *= gfx->mInterpolationIndex;
        stepX *= gfx->mInterpolationIndex;
        stepY *= gfx->mInterpolationIndex;
    }


    stepX *= deltaTime;
    stepY *= deltaTime;

    incX = (float)stepX;
    incY = (float)stepY;

    // Calculate the interpolation for the current frame
    uls += incX;// * gfx->mInterpolationIndex;
    ult += incY;// * gfx->mInterpolationIndex;

    lrs += incX;// * gfx->mInterpolationIndex;
    lrt += incY;// * gfx->mInterpolationIndex;

    // Clamp
    uls = std::fmod(uls, 2048);
    ult = std::fmod(ult, 2048);
    lrs = std::fmod(lrs, 2048);
    lrt = std::fmod(lrt, 2048);

    // Apply values to texture
    gfx->mRdp->texture_tile[tile].uls = uls;
    gfx->mRdp->texture_tile[tile].ult = ult;
    gfx->mRdp->texture_tile[tile].lrs = lrs;
    gfx->mRdp->texture_tile[tile].lrt = lrt;

    // Save the new values back into the gfx
    (*cmd0)->words.w0 = (uintptr_t) (*(uint32_t*)&uls << 32 | *(uint32_t*)&ult);
    (*cmd0)->words.w1 = (uintptr_t) (*(uint32_t*)&lrs << 32 | *(uint32_t*)&lrt);
    printf("applied uls %f ult %f lrs %f lrt %f delta %f\n", uls, ult, lrs, lrt, deltaTime);

    return false;
}
```

## Troubleshooting
Note that SETTILESIZE command will over-write the values and likely reset the scrolling texture.
It's recommended to replace the tile size command with the texture scroll command.