### PR TITLE
Fix window resize crash on macOS with Metal

### DIFF
--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -606,9 +606,6 @@ void GfxRenderingAPIMetal::SetupScreenFramebuffer(uint32_t width, uint32_t heigh
 
     NS::AutoreleasePool* autorelease_pool = NS::AutoreleasePool::alloc()->init();
 
-    if (tex.texture != nullptr)
-        tex.texture->release();
-
     tex.texture = mCurrentDrawable->texture();
 
     MTL::RenderPassDescriptor* render_pass_descriptor = MTL::RenderPassDescriptor::renderPassDescriptor();


### PR DESCRIPTION
Previously, the code manually released the texture associated with the current drawable during SetupScreenFramebuffer. However, textures obtained via CAMetalDrawable->texture() are managed by the Core Animation layer. Manually calling release() caused a race condition where the system compositor (CA::Context) would attempt to access a deallocated texture, leading to a "Corrupt NSInvocation" EXC_BREAKPOINT crash.

This fix relies on the CAMetalLayer's internal pool to manage the lifecycle of these textures.

Relevant: https://github.com/HarbourMasters/Shipwright/issues/5764