### PR TITLE
add error handling to `ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads`

### DIFF
--- a/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
+++ b/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
@@ -59,6 +59,10 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
         }
 
         auto gamepad = SDL_GameControllerOpen(i);
+        // skip if it could not be opened (isn't usable)
+        if (!gamepad) {
+            continue;
+        }
         auto instanceId = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(gamepad));
         auto name = SDL_GameControllerName(gamepad);
 

--- a/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
+++ b/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
@@ -55,12 +55,13 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
 
     for (int32_t i = 0; i < SDL_NumJoysticks(); i++) {
         char deviceGUID[33] = "";
+        // Sould return 00000000000000000000000000000000 if the GUID or controller index is invalid
         SDL_JoystickGetGUIDString(SDL_JoystickGetDeviceGUID(i), deviceGUID, sizeof(deviceGUID));
 
         if (!SDL_IsGameController(i)) {
             SPDLOG_WARN("SDL Joystick (GUID: {}) not recognized as gamepad."
                         "This is likely due to a missing mapping string in gamecontrollerdb.txt."
-                        "See https://github.com/mdqinc/SDL_GameControllerDB for more info.",
+                        "Refer to https://github.com/mdqinc/SDL_GameControllerDB for more information.",
                         i, deviceGUID);
             continue;
         }
@@ -80,9 +81,8 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
         std::string gamepadName;
         auto name = SDL_GameControllerName(gamepad);
         if (name == nullptr) {
-            gamepadName = "Gamepad " + std::to_string(instanceId);
-            SPDLOG_WARN("SDL_GameControllerName returned null (GUID: {}). Setting name to \"{}\"", deviceGUID,
-                        gamepadName);
+            gamepadName = deviceGUID;
+            SPDLOG_WARN("SDL_GameControllerName returned null. Setting name to GUID \"{}\" instead.", gamepadName);
         } else {
             gamepadName = name;
         }

--- a/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
+++ b/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
@@ -59,7 +59,7 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
         SDL_JoystickGUID deviceGUID = SDL_JoystickGetDeviceGUID(i);
         if (SDL_memcmp(&deviceGUID, &sZeroGuid, sizeof(deviceGUID)) == 0) {
             SPDLOG_WARN(
-                "Calling SDL JoystickGetDeviceGUID with index ({}) returned zero GUID. This is likely due to an "
+                "Calling SDL JoystickGetDeviceGUID with index ({:d}) returned zero GUID. This is likely due to an "
                 "invalid index. Refer to https://wiki.libsdl.org/SDL2/SDL_JoystickGetDeviceGUID for more information.",
                 i);
             continue;
@@ -72,7 +72,7 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
             SPDLOG_WARN("SDL Joystick (GUID: {}) not recognized as gamepad."
                         "This is likely due to a missing mapping string in gamecontrollerdb.txt."
                         "Refer to https://github.com/mdqinc/SDL_GameControllerDB for more information.",
-                        i, deviceGuidCStr);
+                        deviceGuidCStr);
             continue;
         }
 

--- a/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
+++ b/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
@@ -63,7 +63,8 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
         auto name = SDL_GameControllerName(gamepad);
 
         mConnectedSDLGamepads[instanceId] = gamepad;
-        mConnectedSDLGamepadNames[instanceId] = name;
+        // "name" can be NULL and the map only likes strings
+        mConnectedSDLGamepadNames[instanceId] = name ? name : "Unknown " + std::to_string(instanceId); 
 
         for (uint8_t port = 1; port < 4; port++) {
             mIgnoredInstanceIds[port].insert(instanceId);

--- a/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
+++ b/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
@@ -52,12 +52,12 @@ void ConnectedPhysicalDeviceManager::HandlePhysicalDeviceDisconnect(int32_t sdlJ
 void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
     mConnectedSDLGamepads.clear();
     mConnectedSDLGamepadNames.clear();
-    static SDL_JoystickGUID s_zeroGUID;
+    static SDL_JoystickGUID sZeroGuid;
 
     for (int32_t i = 0; i < SDL_NumJoysticks(); i++) {
 
         SDL_JoystickGUID deviceGUID = SDL_JoystickGetDeviceGUID(i);
-        if (SDL_memcmp(&deviceGUID, &s_zeroGUID, sizeof(deviceGUID)) == 0) {
+        if (SDL_memcmp(&deviceGUID, &sZeroGuid, sizeof(deviceGUID)) == 0) {
             SPDLOG_WARN(
                 "Calling SDL JoystickGetDeviceGUID with index ({}) returned zero GUID. This is likely due to an "
                 "invalid index. Refer to https://wiki.libsdl.org/SDL2/SDL_JoystickGetDeviceGUID for more information.",
@@ -65,33 +65,33 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
             continue;
         }
 
-        char deviceGUID_CStr[33] = "";
-        SDL_JoystickGetGUIDString(deviceGUID, deviceGUID_CStr, sizeof(deviceGUID_CStr));
+        char deviceGuidCStr[33] = "";
+        SDL_JoystickGetGUIDString(deviceGUID, deviceGuidCStr, sizeof(deviceGuidCStr));
 
         if (!SDL_IsGameController(i)) {
             SPDLOG_WARN("SDL Joystick (GUID: {}) not recognized as gamepad."
                         "This is likely due to a missing mapping string in gamecontrollerdb.txt."
                         "Refer to https://github.com/mdqinc/SDL_GameControllerDB for more information.",
-                        i, deviceGUID_CStr);
+                        i, deviceGuidCStr);
             continue;
         }
 
         auto gamepad = SDL_GameControllerOpen(i);
         if (gamepad == nullptr) {
-            SPDLOG_ERROR("SDL GameControllerOpen error (GUID: {}): {}", deviceGUID_CStr, SDL_GetError());
+            SPDLOG_ERROR("SDL GameControllerOpen error (GUID: {}): {}", deviceGuidCStr, SDL_GetError());
             continue;
         }
 
         auto instanceId = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(gamepad));
         if (instanceId < 0) {
-            SPDLOG_ERROR("SDL JoystickInstanceID error (GUID: {}): {}", deviceGUID_CStr, SDL_GetError());
+            SPDLOG_ERROR("SDL JoystickInstanceID error (GUID: {}): {}", deviceGuidCStr, SDL_GetError());
             continue;
         }
 
         std::string gamepadName;
         auto name = SDL_GameControllerName(gamepad);
         if (name == nullptr) {
-            gamepadName = deviceGUID_CStr;
+            gamepadName = deviceGuidCStr;
             SPDLOG_WARN("SDL_GameControllerName returned null. Setting name to GUID \"{}\" instead.", gamepadName);
         } else {
             gamepadName = name;

--- a/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
+++ b/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
@@ -55,7 +55,7 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
 
     for (int32_t i = 0; i < SDL_NumJoysticks(); i++) {
         char deviceGUID[33] = "";
-        // Sould return 00000000000000000000000000000000 if the GUID or controller index is invalid
+        // Should return 00000000000000000000000000000000 (32*0) if the GUID or controller index is invalid
         SDL_JoystickGetGUIDString(SDL_JoystickGetDeviceGUID(i), deviceGUID, sizeof(deviceGUID));
 
         if (!SDL_IsGameController(i)) {

--- a/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
+++ b/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
@@ -52,36 +52,46 @@ void ConnectedPhysicalDeviceManager::HandlePhysicalDeviceDisconnect(int32_t sdlJ
 void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
     mConnectedSDLGamepads.clear();
     mConnectedSDLGamepadNames.clear();
+    static SDL_JoystickGUID s_zeroGUID;
 
     for (int32_t i = 0; i < SDL_NumJoysticks(); i++) {
-        char deviceGUID[33] = "";
-        // Should return 00000000000000000000000000000000 (32*0) if the GUID or controller index is invalid
-        SDL_JoystickGetGUIDString(SDL_JoystickGetDeviceGUID(i), deviceGUID, sizeof(deviceGUID));
+
+        SDL_JoystickGUID deviceGUID = SDL_JoystickGetDeviceGUID(i);
+        if (SDL_memcmp(&deviceGUID, &s_zeroGUID, sizeof(deviceGUID)) == 0) {
+            SPDLOG_WARN(
+                "Calling SDL JoystickGetDeviceGUID with index ({}) returned zero GUID. This is likely due to an "
+                "invalid index. Refer to https://wiki.libsdl.org/SDL2/SDL_JoystickGetDeviceGUID for more information.",
+                i);
+            continue;
+        }
+
+        char deviceGUID_CStr[33] = "";
+        SDL_JoystickGetGUIDString(deviceGUID, deviceGUID_CStr, sizeof(deviceGUID_CStr));
 
         if (!SDL_IsGameController(i)) {
             SPDLOG_WARN("SDL Joystick (GUID: {}) not recognized as gamepad."
                         "This is likely due to a missing mapping string in gamecontrollerdb.txt."
                         "Refer to https://github.com/mdqinc/SDL_GameControllerDB for more information.",
-                        i, deviceGUID);
+                        i, deviceGUID_CStr);
             continue;
         }
 
         auto gamepad = SDL_GameControllerOpen(i);
         if (gamepad == nullptr) {
-            SPDLOG_ERROR("SDL GameControllerOpen error (GUID: {}): {}", deviceGUID, SDL_GetError());
+            SPDLOG_ERROR("SDL GameControllerOpen error (GUID: {}): {}", deviceGUID_CStr, SDL_GetError());
             continue;
         }
 
         auto instanceId = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(gamepad));
         if (instanceId < 0) {
-            SPDLOG_ERROR("SDL JoystickInstanceID error (GUID: {}): {}", deviceGUID, SDL_GetError());
+            SPDLOG_ERROR("SDL JoystickInstanceID error (GUID: {}): {}", deviceGUID_CStr, SDL_GetError());
             continue;
         }
 
         std::string gamepadName;
         auto name = SDL_GameControllerName(gamepad);
         if (name == nullptr) {
-            gamepadName = deviceGUID;
+            gamepadName = deviceGUID_CStr;
             SPDLOG_WARN("SDL_GameControllerName returned null. Setting name to GUID \"{}\" instead.", gamepadName);
         } else {
             gamepadName = name;


### PR DESCRIPTION
- Fixes https://github.com/Kenix3/libultraship/issues/976
- Uses the GUID as name instead, if that is the case:
  <img width="451" height="92" alt="531769358-fa077d06-701a-4cce-895c-48ce356790d9" src="https://github.com/user-attachments/assets/00b12b22-3436-43b0-bd44-79b403b804b8" />
- Adds error checking at multiple points of failure and skips the device if any of them occur, because it's most likely unusable in those cases.
- Add logging for the errors catched above
### LUS bump PRs for ports:
- SoH: https://github.com/HarbourMasters/Shipwright/pull/6121