### PR TITLE
Some rendering fixes

### DIFF
--- a/include/fast/lus_gbi.h
+++ b/include/fast/lus_gbi.h
@@ -844,7 +844,11 @@ constexpr int8_t RDP_G_SETTARGETINTERPINDEX = OPCODE(0x45);
  * Vertex (set up for use with colors)
  */
 typedef struct {
-    short ob[3]; /* x, y, z */
+#ifndef GBI_FLOATS
+	short		ob[3];	/* x, y, z */
+#else
+	float		ob[3];	/* x, y, z */
+#endif
     unsigned short flag;
     short tc[2];         /* texture coord */
     unsigned char cn[4]; /* color & alpha */
@@ -854,7 +858,11 @@ typedef struct {
  * Vertex (set up for use with normals)
  */
 typedef struct {
-    short ob[3]; /* x, y, z */
+#ifndef GBI_FLOATS
+	short		ob[3];	/* x, y, z */
+#else
+	float		ob[3];	/* x, y, z */
+#endif
     unsigned short flag;
     short tc[2];      /* texture coord */
     signed char n[3]; /* normal */

--- a/include/fast/lus_gbi.h
+++ b/include/fast/lus_gbi.h
@@ -845,9 +845,9 @@ constexpr int8_t RDP_G_SETTARGETINTERPINDEX = OPCODE(0x45);
  */
 typedef struct {
 #ifndef GBI_FLOATS
-	short		ob[3];	/* x, y, z */
+    short ob[3]; /* x, y, z */
 #else
-	float		ob[3];	/* x, y, z */
+    float ob[3]; /* x, y, z */
 #endif
     unsigned short flag;
     short tc[2];         /* texture coord */
@@ -859,9 +859,9 @@ typedef struct {
  */
 typedef struct {
 #ifndef GBI_FLOATS
-	short		ob[3];	/* x, y, z */
+    short ob[3]; /* x, y, z */
 #else
-	float		ob[3];	/* x, y, z */
+    float ob[3]; /* x, y, z */
 #endif
     unsigned short flag;
     short tc[2];      /* texture coord */

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -1014,9 +1014,9 @@
  */
 typedef struct {
 #ifndef GBI_FLOATS
-	short		ob[3];	/* x, y, z */
+    short ob[3]; /* x, y, z */
 #else
-	float		ob[3];	/* x, y, z */
+    float ob[3]; /* x, y, z */
 #endif
     unsigned short flag;
     short tc[2];         /* texture coord */
@@ -1028,9 +1028,9 @@ typedef struct {
  */
 typedef struct {
 #ifndef GBI_FLOATS
-	short		ob[3];	/* x, y, z */
+    short ob[3]; /* x, y, z */
 #else
-	float		ob[3];	/* x, y, z */
+    float ob[3]; /* x, y, z */
 #endif
     unsigned short flag;
     short tc[2];      /* texture coord */

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -1013,7 +1013,11 @@
  * Vertex (set up for use with colors)
  */
 typedef struct {
-    short ob[3]; /* x, y, z */
+#ifndef GBI_FLOATS
+	short		ob[3];	/* x, y, z */
+#else
+	float		ob[3];	/* x, y, z */
+#endif
     unsigned short flag;
     short tc[2];         /* texture coord */
     unsigned char cn[4]; /* color & alpha */
@@ -1023,7 +1027,11 @@ typedef struct {
  * Vertex (set up for use with normals)
  */
 typedef struct {
-    short ob[3]; /* x, y, z */
+#ifndef GBI_FLOATS
+	short		ob[3];	/* x, y, z */
+#else
+	float		ob[3];	/* x, y, z */
+#endif
     unsigned short flag;
     short tc[2];      /* texture coord */
     signed char n[3]; /* normal */

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2825,7 +2825,7 @@ bool gfx_mtx_otr_handler_custom_f3d(F3DGfx** cmd0) {
         (const int32_t*)Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer(hash);
     if (mtx != nullptr) {
         cmd--;
-        gfx->GfxSpMatrix(C0(16, 8), (const int32_t*)gfx->SegAddr(cmd->words.w1));
+        gfx->GfxSpMatrix(C0(16, 8), mtx);
         cmd++;
     }
     return false;

--- a/src/fast/resource/factory/DisplayListFactory.cpp
+++ b/src/fast/resource/factory/DisplayListFactory.cpp
@@ -177,7 +177,7 @@ ResourceFactoryBinaryDisplayListV0::ReadResource(std::shared_ptr<Ship::File> fil
 
         int8_t opcode = (int8_t)(command.words.w0 >> 24);
         bool isExpanded = opcode == G_SETTIMG_OTR_HASH || opcode == G_DL_OTR_HASH || opcode == G_VTX_OTR_HASH ||
-                          opcode == G_BRANCH_Z_OTR || opcode == G_MARKER || opcode == G_MTX_OTR;
+                          opcode == G_BRANCH_Z_OTR || opcode == G_MARKER || opcode == G_MTX_OTR || opcode == G_MOVEMEM_OTR;
 
         // These are 128-bit commands, so read an extra 64 bits...
         if (isExpanded) {

--- a/src/fast/resource/factory/DisplayListFactory.cpp
+++ b/src/fast/resource/factory/DisplayListFactory.cpp
@@ -177,7 +177,8 @@ ResourceFactoryBinaryDisplayListV0::ReadResource(std::shared_ptr<Ship::File> fil
 
         int8_t opcode = (int8_t)(command.words.w0 >> 24);
         bool isExpanded = opcode == G_SETTIMG_OTR_HASH || opcode == G_DL_OTR_HASH || opcode == G_VTX_OTR_HASH ||
-                          opcode == G_BRANCH_Z_OTR || opcode == G_MARKER || opcode == G_MTX_OTR || opcode == G_MOVEMEM_OTR;
+                          opcode == G_BRANCH_Z_OTR || opcode == G_MARKER || opcode == G_MTX_OTR ||
+                          opcode == G_MOVEMEM_OTR;
 
         // These are 128-bit commands, so read an extra 64 bits...
         if (isExpanded) {


### PR DESCRIPTION
The tidy-format is a false positive, it should be ignored since it breaks the gbi file

- It adds back Vtx being as float when GBI_FLOATS is enabled, taken from the original Fast3D Repo
- Fixes G_MOVEMEM_OTR not being declared as an expanded command when it is
- Fixed a bug on F3D that reads invalid mtxs