### PR TITLE
Initialize WheelHandler::mBufferedCoords to fix undefined behavior

### DIFF
--- a/src/ship/controller/controldevice/controller/mapping/mouse/WheelHandler.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/mouse/WheelHandler.cpp
@@ -5,6 +5,7 @@
 namespace Ship {
 WheelHandler::WheelHandler() {
     mDirections = { LUS_WHEEL_NONE, LUS_WHEEL_NONE };
+    mBufferedCoords = { 0.0f, 0.0f };
 }
 
 WheelHandler::~WheelHandler() {


### PR DESCRIPTION
The mBufferedCoords member was never initialized, causing UpdateAxisBuffer to read uninitialized memory when checking if the buffer value is non-zero.

Related: https://github.com/HarbourMasters/Shipwright/issues/5976