### PR TITLE
Fix memory leaks in Gui and ConsoleWindow

### DIFF
--- a/include/ship/window/gui/Gui.h
+++ b/include/ship/window/gui/Gui.h
@@ -136,6 +136,8 @@ class Gui {
   private:
     GuiWindowInitData mImpl;
     bool mNeedsConsoleVariableSave;
+    std::string mImGuiIniPath;
+    std::string mImGuiLogPath;
     std::shared_ptr<GameOverlay> mGameOverlay;
     std::shared_ptr<GuiMenuBar> mMenuBar;
     std::shared_ptr<GuiWindow> mMenu;

--- a/src/ship/window/gui/ConsoleWindow.cpp
+++ b/src/ship/window/gui/ConsoleWindow.cpp
@@ -291,10 +291,11 @@ int32_t ConsoleWindow::CheckVarType(const std::string& input) {
 
 ConsoleWindow::~ConsoleWindow() {
     SPDLOG_TRACE("destruct console window");
+    delete[] mInputBuffer;
+    delete[] mFilterBuffer;
 }
 
 void ConsoleWindow::InitElement() {
-    // TODO: These buffers are never freed.
     mInputBuffer = new char[gMaxBufferSize];
     strcpy(mInputBuffer, "");
     mFilterBuffer = new char[gMaxBufferSize];

--- a/src/ship/window/gui/Gui.cpp
+++ b/src/ship/window/gui/Gui.cpp
@@ -92,18 +92,6 @@ Gui::Gui() : Gui(std::vector<std::shared_ptr<GuiWindow>>()) {
 
 Gui::~Gui() {
     SPDLOG_TRACE("destruct gui");
-    if (mImGuiIo != nullptr) {
-        //! @todo Refactor required to prevent memory leak. Also,
-        // the delete statements result in a use-after free when the program is closed.
-        if (mImGuiIo->IniFilename != nullptr) {
-            // delete[] mImGuiIo->IniFilename;
-        }
-        if (mImGuiIo->LogFilename != nullptr) {
-            // delete[] mImGuiIo->LogFilename;
-        }
-        // mImGuiIo->IniFilename = nullptr;
-        // mImGuiIo->LogFilename = nullptr;
-    }
 }
 
 void Gui::Init(GuiWindowInitData windowImpl) {
@@ -133,10 +121,10 @@ void Gui::Init(GuiWindowInitData windowImpl) {
     mImGuiIo->FontGlobalScale = 2.0f;
 #endif
 
-    auto imguiIniPath = Context::GetPathRelativeToAppDirectory("imgui.ini");
-    auto imguiLogPath = Context::GetPathRelativeToAppDirectory("imgui_log.txt");
-    mImGuiIo->IniFilename = strcpy(new char[imguiIniPath.length() + 1], imguiIniPath.c_str());
-    mImGuiIo->LogFilename = strcpy(new char[imguiLogPath.length() + 1], imguiLogPath.c_str());
+    mImGuiIniPath = Context::GetPathRelativeToAppDirectory("imgui.ini");
+    mImGuiLogPath = Context::GetPathRelativeToAppDirectory("imgui_log.txt");
+    mImGuiIo->IniFilename = mImGuiIniPath.c_str();
+    mImGuiIo->LogFilename = mImGuiLogPath.c_str();
 
     if (SupportsViewports() &&
         Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_ENABLE_MULTI_VIEWPORTS, 1)) {


### PR DESCRIPTION
- Store ImGui ini/log paths as std::string members instead of raw char* allocations, eliminating manual memory management
- Free mInputBuffer and mFilterBuffer in ConsoleWindow destructor