### PR TITLE
Add option for empty paths list when initializing resource manager.

### DIFF
--- a/include/ship/Context.h
+++ b/include/ship/Context.h
@@ -72,7 +72,8 @@ class Context {
     bool InitConfiguration();
     bool InitConsoleVariables();
     bool InitResourceManager(const std::vector<std::string>& archivePaths = {},
-                             const std::unordered_set<uint32_t>& validHashes = {}, uint32_t reservedThreadCount = 1);
+                             const std::unordered_set<uint32_t>& validHashes = {}, uint32_t reservedThreadCount = 1,
+                             const bool allowEmptyPaths = false);
     bool InitControlDeck(std::shared_ptr<ControlDeck> controlDeck = nullptr);
     bool InitCrashHandler();
     bool InitAudio(AudioSettings settings);

--- a/src/ship/Context.cpp
+++ b/src/ship/Context.cpp
@@ -197,7 +197,8 @@ bool Context::InitConsoleVariables() {
 }
 
 bool Context::InitResourceManager(const std::vector<std::string>& archivePaths,
-                                  const std::unordered_set<uint32_t>& validHashes, uint32_t reservedThreadCount) {
+                                  const std::unordered_set<uint32_t>& validHashes, uint32_t reservedThreadCount,
+                                  const bool allowEmptyPaths) {
     if (GetResourceManager() != nullptr) {
         return true;
     }
@@ -216,7 +217,7 @@ bool Context::InitResourceManager(const std::vector<std::string>& archivePaths,
         GetResourceManager()->Init(archivePaths, validHashes, reservedThreadCount);
     }
 
-    if (!GetResourceManager()->IsLoaded()) {
+    if (!allowEmptyPaths && !GetResourceManager()->IsLoaded()) {
         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "OTR file not found",
                                  "Main OTR file not found. Please generate one", nullptr);
         SPDLOG_ERROR("Main OTR file not found!");


### PR DESCRIPTION
This is desired because my ImGui Extraction Flow is setup to handle the port archive not existing on its own, which makes the system popup, and even the iOS exit, redundant, so I don't want that part to process if the port archive happens to not exist during tests.

Defaults to false to maintain current functionality.