### PR TITLE
run clang-format (fix comment format in `gbi.h`)

### DIFF
--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -1836,15 +1836,15 @@ typedef union Gfx {
     { (_SHIFTL(G_VTX, 24, 8) | _SHIFTL((n), 12, 8) | _SHIFTL((v0) + (n), 1, 7)), (uintptr_t)(v)MakeTrace() }
 
 #elif (defined(F3DEX_GBI) || defined(F3DLP_GBI))
-/*
- * F3DEX_GBI: G_VTX GBI format was changed to support 64 vertice.
- *
- *        +--------+--------+------+----------+
- *  G_VTX |  cmd:8 |  v0:8  |  n:6 |length:10 |
- *        +-+---+--+--------+------+----------+
- *        | |seg|          address            |
- *        +-+---+-----------------------------+
- */
+                 /*
+                  * F3DEX_GBI: G_VTX GBI format was changed to support 64 vertice.
+                  *
+                  *        +--------+--------+------+----------+
+                  *  G_VTX |  cmd:8 |  v0:8  |  n:6 |length:10 |
+                  *        +-+---+--+--------+------+----------+
+                  *        | |seg|          address            |
+                  *        +-+---+-----------------------------+
+                  */
 #define __gSPVertex(pkt, v, n, v0) gDma1p((pkt), G_VTX, (v), ((n) << 10) | (sizeof(Vtx) * (n)-1), (v0)*2)
 #define gsSPVertex(v, n, v0) gsDma1p(G_VTX, (v), ((n) << 10) | (sizeof(Vtx) * (n)-1), (v0)*2)
 #else


### PR DESCRIPTION
https://github.com/Kenix3/libultraship/pull/974 said "The tidy-format is a false positive, it should be ignored since it breaks the gbi file"

that makes sense for *tidy* issues, as tidy rules can force naming that would break things

turns out there was a *format* issue with a comment in the file, this fixes that