### PR TITLE
Fixed meta files failing to load

### DIFF
--- a/src/ship/resource/archive/Archive.cpp
+++ b/src/ship/resource/archive/Archive.cpp
@@ -107,11 +107,6 @@ void Archive::SetGameVersion(uint32_t gameVersion) {
 }
 
 void Archive::IndexFile(const std::string& filePath) {
-    if (filePath.length() > 5 && filePath.substr(filePath.length() - 5) == ".meta") {
-        IndexFile(filePath.substr(0, filePath.length() - 5));
-        return;
-    }
-
     (*mHashes)[CRC64(filePath.c_str())] = filePath;
 }
 


### PR DESCRIPTION
This PR fixes the bug that caused the removal of the .meta when calling IndexFile, which ends telling the resource manager to never find it