### PR TITLE
Improve ResourceManager cache lookup performance

### DIFF
--- a/include/ship/resource/ResourceManager.h
+++ b/include/ship/resource/ResourceManager.h
@@ -122,12 +122,11 @@ class ResourceManager {
   protected:
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResourcesProcess(const ResourceFilter& filter);
     void UnloadResourcesProcess(const ResourceFilter& filter);
-    std::variant<ResourceLoadError, std::shared_ptr<IResource>> CheckCache(const ResourceIdentifier& identifier,
-                                                                           bool loadExact = false);
-    std::variant<ResourceLoadError, std::shared_ptr<IResource>> CheckCache(const std::string& filePath,
-                                                                           bool loadExact = false);
+    const std::variant<ResourceLoadError, std::shared_ptr<IResource>>* CheckCache(const ResourceIdentifier& identifier);
+    const std::variant<ResourceLoadError, std::shared_ptr<IResource>>* CheckCache(const std::string& filePath);
 
-    std::shared_ptr<IResource> GetCachedResource(std::variant<ResourceLoadError, std::shared_ptr<IResource>> cacheLine);
+    std::shared_ptr<IResource>
+    GetCachedResource(const std::variant<ResourceLoadError, std::shared_ptr<IResource>>& cacheLine);
 
   private:
     std::unordered_map<ResourceIdentifier, std::variant<ResourceLoadError, std::shared_ptr<IResource>>,


### PR DESCRIPTION
This can help to improve the performance on low end systems. I checked the improved performance with the macOS Instruments profiling tool. On other systems this change can have a lower or higher positive impact. Note that the ResourceManager is only a part of this library, so improvement is not mind-blowing.
