### PR TITLE
Mac: If running in Rosetta, indicate in window title

### DIFF
--- a/include/ship/utils/macUtils.h
+++ b/include/ship/utils/macUtils.h
@@ -18,6 +18,12 @@ void toggleNativeMacOSFullscreen(SDL_Window* window);
  */
 bool isNativeMacOSFullscreenActive(SDL_Window* window);
 
+/**
+ * @brief Checks whether the current process is running under Rosetta 2 (Apple's x86 translation layer).
+ * @return true if current process is an x86 process running on an ARM CPU, false otherwise.
+ */
+bool isRunningUnderRosetta();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -367,8 +367,16 @@ void GfxWindowBackendSDL2::Init(const char* gameName, const char* gfxApiName, bo
     }
 #endif
 
+    const char* emulation = "";
+#if defined(__APPLE__)
+    if (isRunningUnderRosetta()) {
+        SPDLOG_WARN("Process is running under Rosetta");
+        emulation = ", Rosetta";
+    }
+#endif
+
     char title[512];
-    int len = snprintf(title, sizeof(title), "%s (%s)", gameName, gfxApiName);
+    int len = snprintf(title, sizeof(title), "%s (%s%s)", gameName, gfxApiName, emulation);
 
 #ifdef __IOS__
     Uint32 flags = SDL_WINDOW_BORDERLESS | SDL_WINDOW_SHOWN;

--- a/src/ship/utils/macUtils.mm
+++ b/src/ship/utils/macUtils.mm
@@ -3,6 +3,7 @@
 #import "ship/utils/macUtils.h"
 #import <SDL_syswm.h>
 #import <Cocoa/Cocoa.h>
+#include <sys/sysctl.h>
 
 //Just a simple function to toggle the native macOS fullscreen.
 void toggleNativeMacOSFullscreen(SDL_Window *window) {
@@ -23,6 +24,15 @@ bool isNativeMacOSFullscreenActive(SDL_Window *window) {
         NSWindow *nswindow = wmInfo.info.cocoa.window;
         return (([nswindow styleMask] & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen);
     }
+    return false;
+}
+
+//Whether the current process is running under Rosetta 2 translation.
+bool isRunningUnderRosetta() {
+    int translated = 0;
+    size_t size = sizeof(translated);
+    if (sysctlbyname("sysctl.proc_translated", &translated, &size, nullptr, 0) == 0)
+        return translated;
     return false;
 }
 #endif


### PR DESCRIPTION
I didn’t realize but I was running SoH under Rosetta (macOS translation layer for running x64 programs on ARM). This extra layer of translation results in longer startup times (especially on first run) and likely impacts performance.

This pull request adds an extra label to the title, e.g.
> Ship of Harkinian (Metal, Rosetta)

The logic for the check is taken from [Apple’s docs](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment#Determine-Whether-Your-App-Is-Running-as-a-Translated-Binary).