### PR TITLE
Fix race condition in WASAPI when changing between 2 and 6 channel configuration.

### DIFF
--- a/include/ship/audio/WasapiAudioPlayer.h
+++ b/include/ship/audio/WasapiAudioPlayer.h
@@ -6,6 +6,7 @@
 #include <wrl/client.h>
 #include <mmdeviceapi.h>
 #include <audioclient.h>
+#include <mutex>
 
 using namespace Microsoft::WRL;
 
@@ -43,6 +44,7 @@ class WasapiAudioPlayer : public AudioPlayer, public IMMNotificationClient {
     bool mInitialized = false;
     bool mStarted = false;
     int32_t mNumChannels = 2;
+    std::mutex mMutex;
 };
 } // namespace Ship
 #endif


### PR DESCRIPTION
The WASAPI backend has a race condition when changing the channel configuration in audio, that resulted in a crash when changing between e.g. stereo and surround. Tested in Ghostship and soh.