### PR TITLE
Change OpenGL textures array to vector, and double texture cache

### DIFF
--- a/include/fast/backends/gfx_opengl.h
+++ b/include/fast/backends/gfx_opengl.h
@@ -49,6 +49,12 @@ struct FramebufferOGL {
     GLuint fbo, clrbuf, clrbufMsaa, rbo;
 };
 
+struct TextureInfo {
+    uint16_t width;
+    uint16_t height;
+    uint16_t filtering;
+};
+
 class GfxRenderingAPIOGL final : public GfxRenderingAPI {
   public:
     ~GfxRenderingAPIOGL() override = default;
@@ -100,12 +106,7 @@ class GfxRenderingAPIOGL final : public GfxRenderingAPI {
     std::string BuildFsShader(const CCFeatures& cc_features);
     void SetPerDrawUniforms();
 
-    struct TextureInfo {
-        uint16_t width;
-        uint16_t height;
-        uint16_t filtering;
-    } textures[1024];
-
+    std::vector<TextureInfo> textures;
     GLuint mCurrentTextureIds[SHADER_MAX_TEXTURES];
     uint8_t mCurrentTile;
 

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -521,6 +521,7 @@ void GfxRenderingAPIOGL::ShaderGetInfo(struct ShaderProgram* prg, uint8_t* numIn
 GLuint GfxRenderingAPIOGL::NewTexture() {
     GLuint ret;
     glGenTextures(1, &ret);
+    textures.resize(std::max(textures.size(), (size_t)ret + 1));
     return ret;
 }
 

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -62,7 +62,7 @@ std::stack<std::string> currentDir;
 #define RATIO_Y(activeFb, dims) \
     ((mFbActive ? activeFb->second.applied_height : dims.height) / (2.0f * HALF_SCREEN_HEIGHT(activeFb)))
 
-#define TEXTURE_CACHE_MAX_SIZE 500
+#define TEXTURE_CACHE_MAX_SIZE 1024
 
 namespace Fast {
 


### PR DESCRIPTION
DirectX & Metal were already using vectors for this array, OpenGL had it at a static size which we overflowed due to loading +524 textures for ImGui (`LoadGuiTexture`) + 500 in game textures (TEXTURE_CACHE_MAX_SIZE) > 1024

Would like someone to verify on DirectX, OpenGL & Metal that the cache doubling doesn't break anything. (Hopefully should improve perf by a tiny amount)