### PR TITLE
Impl ResourceManager::WriteResource

### DIFF
--- a/include/ship/resource/ResourceManager.h
+++ b/include/ship/resource/ResourceManager.h
@@ -86,8 +86,7 @@ class ResourceManager {
                       BS::priority_t priority = BS::pr::normal, std::shared_ptr<ResourceInitData> initData = nullptr);
     size_t UnloadResource(const ResourceIdentifier& identifier);
     size_t UnloadResource(const std::string& filePath);
-    bool WriteResource(const ResourceIdentifier& identifier,
-                                    const std::vector<uint8_t>& data);
+    bool WriteResource(const ResourceIdentifier& identifier, const std::vector<uint8_t>& data);
 
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResources(const std::string& searchMask);
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResources(const ResourceFilter& filter);

--- a/include/ship/resource/ResourceManager.h
+++ b/include/ship/resource/ResourceManager.h
@@ -86,6 +86,8 @@ class ResourceManager {
                       BS::priority_t priority = BS::pr::normal, std::shared_ptr<ResourceInitData> initData = nullptr);
     size_t UnloadResource(const ResourceIdentifier& identifier);
     size_t UnloadResource(const std::string& filePath);
+    bool WriteResource(const ResourceIdentifier& identifier,
+                                    const std::vector<uint8_t>& data);
 
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResources(const std::string& searchMask);
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResources(const ResourceFilter& filter);

--- a/include/ship/resource/ResourceManager.h
+++ b/include/ship/resource/ResourceManager.h
@@ -86,7 +86,7 @@ class ResourceManager {
                       BS::priority_t priority = BS::pr::normal, std::shared_ptr<ResourceInitData> initData = nullptr);
     size_t UnloadResource(const ResourceIdentifier& identifier);
     size_t UnloadResource(const std::string& filePath);
-    bool WriteResource(const ResourceIdentifier& identifier, const std::vector<uint8_t>& data);
+    bool WriteResource(const ResourceIdentifier& identifier, const std::vector<uint8_t>& data, bool unloadFile);
 
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResources(const std::string& searchMask);
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResources(const ResourceFilter& filter);

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -408,7 +408,7 @@ size_t ResourceManager::UnloadResource(const std::string& filePath) {
     return UnloadResource({ filePath, mDefaultCacheOwner, mDefaultCacheArchive });
 }
 
-bool ResourceManager::WriteResource(const ResourceIdentifier& identifier, const std::vector<uint8_t>& data) {
+bool ResourceManager::WriteResource(const ResourceIdentifier& identifier, const std::vector<uint8_t>& data, bool unloadFile) {
     std::shared_ptr<Archive> archive = identifier.Parent;
 
     if (!archive) {
@@ -423,7 +423,9 @@ bool ResourceManager::WriteResource(const ResourceIdentifier& identifier, const 
         return false;
     }
 
-    UnloadResource(identifier);
+    if (unloadFile) {
+        UnloadResource(identifier);
+    }
 
     return true;
 }

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -381,27 +381,6 @@ void ResourceManager::UnloadResourcesProcess(const ResourceFilter& filter) {
     }
 }
 
-bool ResourceManager::WriteResource(const ResourceIdentifier& identifier,
-                                    const std::vector<uint8_t>& data) {
-    std::shared_ptr<Archive> archive = identifier.Parent;
-
-    if (!archive) {
-        archive = mArchiveManager->GetArchiveFromFile(identifier.Path);
-    }
-
-    if (!archive) {
-        return false;
-    }
-
-    if (!mArchiveManager->WriteFile(archive, identifier.Path, data)) {
-        return false;
-    }
-
-    UnloadResource(identifier);
-
-    return true;
-}
-
 std::shared_ptr<ArchiveManager> ResourceManager::GetArchiveManager() {
     return mArchiveManager;
 }
@@ -427,6 +406,27 @@ size_t ResourceManager::UnloadResource(const ResourceIdentifier& identifier) {
 
 size_t ResourceManager::UnloadResource(const std::string& filePath) {
     return UnloadResource({ filePath, mDefaultCacheOwner, mDefaultCacheArchive });
+}
+
+bool ResourceManager::WriteResource(const ResourceIdentifier& identifier,
+                                    const std::vector<uint8_t>& data) {
+    std::shared_ptr<Archive> archive = identifier.Parent;
+
+    if (!archive) {
+        archive = mArchiveManager->GetArchiveFromFile(identifier.Path);
+    }
+
+    if (!archive) {
+        return false;
+    }
+
+    if (!mArchiveManager->WriteFile(archive, identifier.Path, data)) {
+        return false;
+    }
+
+    UnloadResource(identifier);
+
+    return true;
 }
 
 bool ResourceManager::OtrSignatureCheck(const char* fileName) {

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -381,6 +381,27 @@ void ResourceManager::UnloadResourcesProcess(const ResourceFilter& filter) {
     }
 }
 
+bool ResourceManager::WriteResource(const ResourceIdentifier& identifier,
+                                    const std::vector<uint8_t>& data) {
+    std::shared_ptr<Archive> archive = identifier.Parent;
+
+    if (!archive) {
+        archive = mArchiveManager->GetArchiveFromFile(identifier.Path);
+    }
+
+    if (!archive) {
+        return false;
+    }
+
+    if (!mArchiveManager->WriteFile(archive, identifier.Path, data)) {
+        return false;
+    }
+
+    UnloadResource(identifier);
+
+    return true;
+}
+
 std::shared_ptr<ArchiveManager> ResourceManager::GetArchiveManager() {
     return mArchiveManager;
 }

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -408,8 +408,7 @@ size_t ResourceManager::UnloadResource(const std::string& filePath) {
     return UnloadResource({ filePath, mDefaultCacheOwner, mDefaultCacheArchive });
 }
 
-bool ResourceManager::WriteResource(const ResourceIdentifier& identifier,
-                                    const std::vector<uint8_t>& data) {
+bool ResourceManager::WriteResource(const ResourceIdentifier& identifier, const std::vector<uint8_t>& data) {
     std::shared_ptr<Archive> archive = identifier.Parent;
 
     if (!archive) {

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -408,7 +408,8 @@ size_t ResourceManager::UnloadResource(const std::string& filePath) {
     return UnloadResource({ filePath, mDefaultCacheOwner, mDefaultCacheArchive });
 }
 
-bool ResourceManager::WriteResource(const ResourceIdentifier& identifier, const std::vector<uint8_t>& data, bool unloadFile) {
+bool ResourceManager::WriteResource(const ResourceIdentifier& identifier, const std::vector<uint8_t>& data,
+                                    bool unloadFile) {
     std::shared_ptr<Archive> archive = identifier.Parent;
 
     if (!archive) {

--- a/src/ship/resource/archive/ArchiveManager.cpp
+++ b/src/ship/resource/archive/ArchiveManager.cpp
@@ -155,9 +155,6 @@ bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::stri
     if (archive) {
         if (archive->WriteFile(filePath, data)) {
             auto hash = CRC64(filePath.c_str());
-            archive->Unload();
-            archive->Load();
-            AddArchive(archive);
             mHashes[hash] = filePath;
             mFileToArchive[hash] = archive;
             return true; // Successfully wrote file


### PR DESCRIPTION
`ArchiveManager::WriteFile()` has always had one glaring issue. It did not properly reset the file in the cache.

Thus,

`ResourceManager::WriteResource()` is now the proper function to add a new file or update a file in an o2r. This function will unload the resource after writing to disk. This will force LUS to load the file next time it gets used. Prior to this PR, it was required to reset the entire file system, or restart the game.

`ArchiveManager::WriteFile()` Now only writes the file to disk, and ensures the file is indexed.

This allows `WriteFile` to be used more generically for other use-cases as seen requested prior.

## OLD USAGE
(This usage is technically still valid. Especially, if you're writing to a lot of files, and wanting to reset the file system later)
```cpp
bool wrote = GameEngine::Instance->context->GetResourceManager()->GetArchiveManager()->WriteFile(track->Archive, sceneFile, bytes);
if (wrote) {
    // Tell the cache this file needs to be reloaded
    auto resource = GameEngine::Instance->context->GetResourceManager()->GetCachedResource(sceneFile);
    if (resource) {
        resource->Dirty();
    }
}
```
## NEW USAGE
```cpp
// ResourceIdentifier will make it more accurate to make sure you're getting the right file.
// This will help prevent unloading or loading the wrong file.
Ship::ResourceIdentifier id(sceneFile, 0, track->Archive);
// Write file to disk
auto rm = GameEngine::Instance->context->GetResourceManager();
//                                  Unload file after write
bool wrote = rm->WriteResource(id, bytes, true);
if (!wrote) {
    SPDLOG_INFO("[SceneManager] [SaveLevel] Failed to write file!");
}
```