### PR TITLE
perf: avoid string allocations in CheckCache hot path via heterogeneo…

### DIFF
--- a/include/ship/resource/ResourceManager.h
+++ b/include/ship/resource/ResourceManager.h
@@ -3,6 +3,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <string>
+#include <string_view>
 #include <list>
 #include <vector>
 #include <mutex>
@@ -47,8 +48,28 @@ struct ResourceIdentifier {
     size_t mHash;
 };
 
+// Lightweight non-owning key for cache lookups — avoids copying the path string.
+// Used with heterogeneous unordered_map::find() to skip ResourceIdentifier construction.
+struct ResourceLookupKey {
+    std::string_view Path;
+    uintptr_t Owner = 0;
+    const Archive* ParentRaw = nullptr;
+    size_t Hash = 0;
+
+    ResourceLookupKey(std::string_view path, uintptr_t owner, const std::shared_ptr<Archive>& parent);
+};
+
 struct ResourceIdentifierHash {
+    using is_transparent = void;
     size_t operator()(const ResourceIdentifier& rcd) const;
+    size_t operator()(const ResourceLookupKey& key) const;
+};
+
+struct ResourceIdentifierEqual {
+    using is_transparent = void;
+    bool operator()(const ResourceIdentifier& a, const ResourceIdentifier& b) const;
+    bool operator()(const ResourceIdentifier& a, const ResourceLookupKey& b) const;
+    bool operator()(const ResourceLookupKey& a, const ResourceIdentifier& b) const;
 };
 
 class ResourceManager {
@@ -131,7 +152,7 @@ class ResourceManager {
 
   private:
     std::unordered_map<ResourceIdentifier, std::variant<ResourceLoadError, std::shared_ptr<IResource>>,
-                       ResourceIdentifierHash>
+                       ResourceIdentifierHash, ResourceIdentifierEqual>
         mResourceCache;
     std::shared_ptr<ResourceLoader> mResourceLoader;
     std::shared_ptr<ArchiveManager> mArchiveManager;

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -31,15 +31,40 @@ bool ResourceIdentifier::operator==(const ResourceIdentifier& rhs) const {
 }
 
 size_t ResourceIdentifier::CalculateHash() {
-    size_t hash = Math::HashCombine(std::hash<std::string>{}(Path), std::hash<std::uintptr_t>{}(Owner));
+    // Use string_view hash to match ResourceLookupKey hashing for heterogeneous lookup correctness.
+    size_t hash = Math::HashCombine(std::hash<std::string_view>{}(Path), std::hash<std::uintptr_t>{}(Owner));
     if (Parent != nullptr) {
-        hash = Math::HashCombine(hash, std::hash<std::string>{}(Parent->GetPath()));
+        hash = Math::HashCombine(hash, std::hash<std::string_view>{}(Parent->GetPath()));
     }
     return hash;
 }
 
+ResourceLookupKey::ResourceLookupKey(std::string_view path, uintptr_t owner, const std::shared_ptr<Archive>& parent)
+    : Path(path), Owner(owner), ParentRaw(parent.get()) {
+    Hash = Math::HashCombine(std::hash<std::string_view>{}(Path), std::hash<std::uintptr_t>{}(Owner));
+    if (ParentRaw != nullptr) {
+        Hash = Math::HashCombine(Hash, std::hash<std::string_view>{}(parent->GetPath()));
+    }
+}
+
 size_t ResourceIdentifierHash::operator()(const ResourceIdentifier& rcd) const {
     return rcd.GetHash();
+}
+
+size_t ResourceIdentifierHash::operator()(const ResourceLookupKey& key) const {
+    return key.Hash;
+}
+
+bool ResourceIdentifierEqual::operator()(const ResourceIdentifier& a, const ResourceIdentifier& b) const {
+    return a == b;
+}
+
+bool ResourceIdentifierEqual::operator()(const ResourceIdentifier& a, const ResourceLookupKey& b) const {
+    return a.Owner == b.Owner && a.Path == b.Path && a.Parent.get() == b.ParentRaw;
+}
+
+bool ResourceIdentifierEqual::operator()(const ResourceLookupKey& a, const ResourceIdentifier& b) const {
+    return b.Owner == a.Owner && b.Path == a.Path && b.Parent.get() == a.ParentRaw;
 }
 
 ResourceManager::ResourceManager() {
@@ -257,7 +282,12 @@ ResourceManager::CheckCache(const ResourceIdentifier& identifier) {
 
 const std::variant<ResourceManager::ResourceLoadError, std::shared_ptr<IResource>>*
 ResourceManager::CheckCache(const std::string& filePath) {
-    return CheckCache({ filePath, mDefaultCacheOwner, mDefaultCacheArchive });
+    const std::lock_guard<std::mutex> lock(mMutex);
+    auto cacheFind = mResourceCache.find(ResourceLookupKey{ filePath, mDefaultCacheOwner, mDefaultCacheArchive });
+    if (cacheFind == mResourceCache.end()) {
+        return nullptr;
+    }
+    return &cacheFind->second;
 }
 
 std::shared_ptr<IResource> ResourceManager::GetCachedResource(const ResourceIdentifier& identifier, bool loadExact) {
@@ -424,8 +454,9 @@ bool ResourceManager::WriteResource(const ResourceIdentifier& identifier, const 
 }
 
 bool ResourceManager::OtrSignatureCheck(const char* fileName) {
-    static const char* sOtrSignature = "__OTR__";
-    return strncmp(fileName, sOtrSignature, strlen(sOtrSignature)) == 0;
+    static constexpr char sOtrSignature[] = "__OTR__";
+    static constexpr size_t sOtrSignatureLen = sizeof(sOtrSignature) - 1;
+    return strncmp(fileName, sOtrSignature, sOtrSignatureLen) == 0;
 }
 
 bool ResourceManager::IsAltAssetsEnabled() {


### PR DESCRIPTION
…us map lookup

  Every call to CheckCache(const std::string&) previously constructed a full
  ResourceIdentifier, copying the path string onto the heap, computing a hash,
  then immediately freeing it on cache hits.

  Fix using C++20 heterogeneous unordered_map lookup:

  - Add ResourceLookupKey: a lightweight non-owning struct holding a string_view, owner, and raw Archive* — zero heap allocation.
  - Add is_transparent to ResourceIdentifierHash (adds operator() for ResourceLookupKey) and add ResourceIdentifierEqual with is_transparent (handles ResourceIdentifier vs ResourceLookupKey comparisons).
  - Update mResourceCache to use ResourceIdentifierEqual as its key equality.
  - CheckCache(const std::string&) now does the find() via ResourceLookupKey, skipping ResourceIdentifier construction entirely on cache hits.
  - Align CalculateHash() to use std::hash<std::string_view> for hash consistency with ResourceLookupKey across all standard library implementations.
  - Use constexpr length in OtrSignatureCheck, removing a redundant strlen().