### PR TITLE
Add SetColorImage callback and aux framebuffer readback

### DIFF
--- a/include/fast/backends/gfx_direct3d_common.h
+++ b/include/fast/backends/gfx_direct3d_common.h
@@ -176,6 +176,11 @@ class GfxRenderingAPIDX11 final : public GfxRenderingAPI {
     Microsoft::WRL::ComPtr<ID3D11SamplerState> mLastSamplerStates[SHADER_MAX_TEXTURES] = { nullptr, nullptr };
 
     D3D_PRIMITIVE_TOPOLOGY mLastPrimitaveTopology = D3D_PRIMITIVE_TOPOLOGY_UNDEFINED;
+
+    // Cached staging texture for ReadFramebufferToCPU — avoids CreateTexture2D/Release per frame
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> mReadbackStaging;
+    uint32_t mReadbackStagingW = 0;
+    uint32_t mReadbackStagingH = 0;
 };
 
 std::string gfx_direct3d_common_build_shader(size_t& numFloats, const CCFeatures& cc_features,

--- a/include/fast/backends/gfx_direct3d_common.h
+++ b/include/fast/backends/gfx_direct3d_common.h
@@ -93,6 +93,7 @@ class GfxRenderingAPIDX11 final : public GfxRenderingAPI {
     void EndFrame() override;
     void FinishRender() override;
     int CreateFramebuffer() override;
+    void DeleteFramebuffer(int fbId) override;
     void UpdateFramebufferParameters(int fb_id, uint32_t width, uint32_t height, uint32_t msaa_level,
                                      bool opengl_invertY, bool render_target, bool has_depth_buffer,
                                      bool can_extract_depth) override;

--- a/include/fast/backends/gfx_metal.h
+++ b/include/fast/backends/gfx_metal.h
@@ -146,6 +146,7 @@ class GfxRenderingAPIMetal final : public GfxRenderingAPI {
     void EndFrame() override;
     void FinishRender() override;
     int CreateFramebuffer() override;
+    void DeleteFramebuffer(int fbId) override;
     void UpdateFramebufferParameters(int fb_id, uint32_t width, uint32_t height, uint32_t msaa_level,
                                      bool opengl_invertY, bool render_target, bool has_depth_buffer,
                                      bool can_extract_depth) override;

--- a/include/fast/backends/gfx_opengl.h
+++ b/include/fast/backends/gfx_opengl.h
@@ -82,6 +82,7 @@ class GfxRenderingAPIOGL final : public GfxRenderingAPI {
     void EndFrame() override;
     void FinishRender() override;
     int CreateFramebuffer() override;
+    void DeleteFramebuffer(int fbId) override;
     void UpdateFramebufferParameters(int fb_id, uint32_t width, uint32_t height, uint32_t msaa_level,
                                      bool opengl_invertY, bool render_target, bool has_depth_buffer,
                                      bool can_extract_depth) override;

--- a/include/fast/backends/gfx_rendering_api.h
+++ b/include/fast/backends/gfx_rendering_api.h
@@ -54,6 +54,7 @@ class GfxRenderingAPI {
     virtual void EndFrame() = 0;
     virtual void FinishRender() = 0;
     virtual int CreateFramebuffer() = 0;
+    virtual void DeleteFramebuffer(int fbId) = 0;
     virtual void UpdateFramebufferParameters(int fb_id, uint32_t width, uint32_t height, uint32_t msaa_level,
                                              bool opengl_invertY, bool render_target, bool has_depth_buffer,
                                              bool can_extract_depth) = 0;

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <stack>
 #include <string>
+#include <functional>
 
 #include "fast/lus_gbi.h"
 #include "fast/types.h"
@@ -383,6 +384,12 @@ class Interpreter {
     void RegisterBlendedTexture(const char* name, uint8_t* mask, uint8_t* replacement);
     void UnregisterBlendedTexture(const char* name);
 
+    // Callback fired when gDPSetColorImage changes the target address.
+    // Parameters: (oldAddress, newAddress). Ports can use this to implement
+    // render-to-texture readback for auxiliary color buffers.
+    void SetColorImageChangeCallback(std::function<void(void*, void*)> cb);
+    void TextureCacheDeleteRange(const uint8_t* start, size_t byteLen);
+
     void SetNativeDimensions(float width, float height);
     void SetResolutionMultiplier(float multiplier);
     void SetMsaaLevel(uint32_t level);
@@ -511,6 +518,8 @@ class Interpreter {
     std::set<std::pair<float, float>> mGetPixelDepthPending; // get_pixel_depth_pending;
     std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff> mGetPixelDepthCached; // get_pixel_depth_cached;
     std::map<std::string, MaskedTextureEntry> mMaskedTextures;
+
+    std::function<void(void*, void*)> mColorImageChangeCb;
 
     const std::unordered_map<Mtx*, MtxF>* mCurMtxReplacements;
     bool mMarkerOn; // This was originally a debug feature. Now it seems to control s2dex?

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -1013,48 +1013,51 @@ void GfxRenderingAPIDX11::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32
     FramebufferDX11& fb = mFrameBuffers[fb_id];
     TextureData& td = mTextures[fb.texture_id];
 
-    ID3D11Texture2D* staging = nullptr;
+    // Query actual texture dimensions — CopyResource requires matching sizes
+    D3D11_TEXTURE2D_DESC srcDesc;
+    td.texture->GetDesc(&srcDesc);
 
-    // Create an staging texture with cpu read access
-    D3D11_TEXTURE2D_DESC texture_desc;
-    texture_desc.Width = width;
-    texture_desc.Height = height;
-    texture_desc.Usage = D3D11_USAGE_STAGING;
-    texture_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    texture_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-    texture_desc.BindFlags = 0;
-    texture_desc.MiscFlags = 0;
-    texture_desc.ArraySize = 1;
-    texture_desc.MipLevels = 1;
-    texture_desc.SampleDesc.Count = 1;
-    texture_desc.SampleDesc.Quality = 0;
+    // Reuse cached staging texture when dimensions match — avoids per-frame CreateTexture2D
+    if (!mReadbackStaging || mReadbackStagingW != srcDesc.Width || mReadbackStagingH != srcDesc.Height) {
+        mReadbackStaging.Reset();
 
-    ThrowIfFailed(mDevice->CreateTexture2D(&texture_desc, nullptr, &staging));
+        D3D11_TEXTURE2D_DESC texture_desc;
+        texture_desc.Width = srcDesc.Width;
+        texture_desc.Height = srcDesc.Height;
+        texture_desc.Usage = D3D11_USAGE_STAGING;
+        texture_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        texture_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+        texture_desc.BindFlags = 0;
+        texture_desc.MiscFlags = 0;
+        texture_desc.ArraySize = 1;
+        texture_desc.MipLevels = 1;
+        texture_desc.SampleDesc.Count = 1;
+        texture_desc.SampleDesc.Quality = 0;
+
+        ThrowIfFailed(mDevice->CreateTexture2D(&texture_desc, nullptr, mReadbackStaging.GetAddressOf()));
+        mReadbackStagingW = srcDesc.Width;
+        mReadbackStagingH = srcDesc.Height;
+    }
 
     // Copy the framebuffer texture to the staging texture
-    mContext->CopyResource(staging, td.texture.Get());
+    mContext->CopyResource(mReadbackStaging.Get(), td.texture.Get());
 
     // Map the staging texture to a resource that we can read
     D3D11_MAPPED_SUBRESOURCE resource = {};
-    ThrowIfFailed(mContext->Map(staging, 0, D3D11_MAP_READ, 0, &resource));
+    ThrowIfFailed(mContext->Map(mReadbackStaging.Get(), 0, D3D11_MAP_READ, 0, &resource));
 
     if (!resource.pData) {
         return;
     }
 
-    // Copy the mapped values to a temp array that we can process later
-    uint32_t* temp = new uint32_t[width * height]();
-    for (size_t i = 0; i < height; i++) {
-        memcpy((uint8_t*)temp + (resource.RowPitch * i), (uint8_t*)resource.pData + (resource.RowPitch * i),
-               resource.RowPitch);
-    }
-
-    mContext->Unmap(staging, 0);
-
-    // Convert the RGBA32 values to RGBA16
-    for (size_t i = 0; i < width; i++) {
-        for (size_t j = 0; j < height; j++) {
-            uint32_t pixel = temp[i + (j * width)];
+    // Convert RGBA32 → RGBA16 with nearest-neighbor scaling from actual texture
+    // dimensions to requested output dimensions, respecting RowPitch for row stride
+    for (uint32_t j = 0; j < height; j++) {
+        uint32_t srcY = j * srcDesc.Height / height;
+        uint8_t* srcRow = (uint8_t*)resource.pData + srcY * resource.RowPitch;
+        for (uint32_t i = 0; i < width; i++) {
+            uint32_t srcX = i * srcDesc.Width / width;
+            uint32_t pixel = ((uint32_t*)srcRow)[srcX];
             uint8_t r = (((pixel & 0xFF) + 4) * 0x1F) / 0xFF;
             uint8_t g = ((((pixel >> 8) & 0xFF) + 4) * 0x1F) / 0xFF;
             uint8_t b = ((((pixel >> 16) & 0xFF) + 4) * 0x1F) / 0xFF;
@@ -1064,11 +1067,7 @@ void GfxRenderingAPIDX11::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32
         }
     }
 
-    // Cleanup
-    staging->Release();
-    staging = nullptr;
-
-    delete[] temp;
+    mContext->Unmap(mReadbackStaging.Get(), 0);
 }
 
 void GfxRenderingAPIDX11::SetTextureFilter(FilteringMode mode) {

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -814,6 +814,17 @@ int GfxRenderingAPIDX11::CreateFramebuffer() {
     return (int)index;
 }
 
+void GfxRenderingAPIDX11::DeleteFramebuffer(int fbId) {
+    FramebufferDX11& fb = mFrameBuffers[fbId];
+    TextureData& tex = mTextures[fb.texture_id];
+    tex.texture.Reset();
+    tex.resource_view.Reset();
+    tex.sampler_state.Reset();
+    fb.render_target_view.Reset();
+    fb.depth_stencil_view.Reset();
+    fb.depth_stencil_srv.Reset();
+}
+
 void GfxRenderingAPIDX11::UpdateFramebufferParameters(int fb_id, uint32_t width, uint32_t height, uint32_t msaa_level,
                                                       bool opengl_invertY, bool render_target, bool has_depth_buffer,
                                                       bool can_extract_depth) {

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -607,6 +607,10 @@ int GfxRenderingAPIMetal::CreateFramebuffer() {
     return (int)index;
 }
 
+void GfxRenderingAPIMetal::DeleteFramebuffer(int fbId) {
+    // TODO: release Metal textures and depth buffers for mFramebuffers[fbId]
+}
+
 void GfxRenderingAPIMetal::SetupScreenFramebuffer(uint32_t width, uint32_t height) {
     mCurrentDrawable = nullptr;
     mCurrentDrawable = mLayer->nextDrawable();

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -940,8 +940,23 @@ void GfxRenderingAPIOGL::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32_
         return;
     }
 
+    // Read as RGBA8 (GL_UNSIGNED_BYTE) then convert to RGBA16 (5551).
+    // GL_RGBA + GL_UNSIGNED_SHORT_5_5_5_1 writes 4 separate u16 components per pixel
+    // (8 bytes) on some drivers (NVIDIA), not the packed 2 bytes the spec implies.
+    // Reading as RGBA8 and converting matches the DX11 path's approach.
     glBindFramebuffer(GL_FRAMEBUFFER, mFrameBuffers[fb_id].fbo);
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_SHORT_5_5_5_1, (void*)rgba16_buf);
+
+    std::vector<uint8_t> rgba8(width * height * 4);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, rgba8.data());
+
+    for (uint32_t i = 0; i < width * height; i++) {
+        uint8_t r = (rgba8[i * 4 + 0] >> 3) & 0x1F;
+        uint8_t g = (rgba8[i * 4 + 1] >> 3) & 0x1F;
+        uint8_t b = (rgba8[i * 4 + 2] >> 3) & 0x1F;
+        uint8_t a = rgba8[i * 4 + 3] ? 1 : 0;
+        rgba16_buf[i] = (r << 11) | (g << 6) | (b << 1) | a;
+    }
+
     glBindFramebuffer(GL_FRAMEBUFFER, mFrameBuffers[mCurrentFrameBuffer].fbo);
 }
 

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -755,6 +755,15 @@ int GfxRenderingAPIOGL::CreateFramebuffer() {
     return i;
 }
 
+void GfxRenderingAPIOGL::DeleteFramebuffer(int fbId) {
+    FramebufferOGL& fb = mFrameBuffers[fbId];
+    glDeleteFramebuffers(1, &fb.fbo);
+    glDeleteTextures(1, &fb.clrbuf);
+    glDeleteRenderbuffers(1, &fb.clrbufMsaa);
+    glDeleteRenderbuffers(1, &fb.rbo);
+    fb = {};
+}
+
 void GfxRenderingAPIOGL::UpdateFramebufferParameters(int fb_id, uint32_t width, uint32_t height, uint32_t msaa_level,
                                                      bool opengl_invertY, bool render_target, bool has_depth_buffer,
                                                      bool can_extract_depth) {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -4585,6 +4585,10 @@ void Interpreter::TextureCacheDeleteRange(const uint8_t* start, size_t byteLen) 
     auto& cmap = mTextureCache.map;
     for (auto it = cmap.begin(); it != cmap.end(); ) {
         if (it->first.texture_addr >= start && it->first.texture_addr < end) {
+            for (int j = 0; j < SHADER_MAX_TEXTURES; j++) {
+                if (mRenderingState.mTextures[j] == &*it)
+                    mRenderingState.mTextures[j] = nullptr;
+            }
             mTextureCache.lru.erase(it->second.lru_location);
             mTextureCache.free_texture_ids.push_back(it->second.texture_id);
             it = cmap.erase(it);

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2540,7 +2540,13 @@ void Interpreter::GfxDpSetZImage(void* zBufAddr) {
 }
 
 void Interpreter::GfxDpSetColorImage(uint32_t format, uint32_t size, uint32_t width, void* address) {
+    void* oldAddr = mRdp->color_image_address;
     mRdp->color_image_address = address;
+
+    if (address != oldAddr && mColorImageChangeCb) {
+        Flush();
+        mColorImageChangeCb(oldAddr, address);
+    }
 }
 
 void Interpreter::GfxSpSetOtherMode(uint32_t shift, uint32_t num_bits, uint64_t mode) {
@@ -4563,6 +4569,24 @@ void Interpreter::CopyFrameBuffer(int fb_dst_id, int fb_src_id, bool copyOnce, b
 
 void Interpreter::ResetFrameBuffer() {
     mRapi->StartDrawToFramebuffer(0, (float)mCurDimensions.height / mNativeDimensions.height);
+}
+
+void Interpreter::SetColorImageChangeCallback(std::function<void(void*, void*)> cb) {
+    mColorImageChangeCb = std::move(cb);
+}
+
+void Interpreter::TextureCacheDeleteRange(const uint8_t* start, size_t byteLen) {
+    const uint8_t* end = start + byteLen;
+    auto& cmap = mTextureCache.map;
+    for (auto it = cmap.begin(); it != cmap.end(); ) {
+        if (it->first.texture_addr >= start && it->first.texture_addr < end) {
+            mTextureCache.lru.erase(it->second.lru_location);
+            mTextureCache.free_texture_ids.push_back(it->second.texture_id);
+            it = cmap.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 
 void Interpreter::AdjustPixelDepthCoordinates(float& x, float& y) {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2506,12 +2506,17 @@ void Interpreter::GfxDpFillRectangle(int32_t ulx, int32_t uly, int32_t lrx, int3
     }
     uint32_t mode = (mRdp->other_mode_h & (3U << G_MDSFT_CYCLETYPE));
 
-    // OTRTODO: This is a bit of a hack for widescreen screen fades, but it'll work for now...
-    if (ulx == 0 && uly == 0 && lrx == (319 * 4) && lry == (239 * 4)) {
-        ulx = -1024;
-        uly = -1024;
-        lrx = 2048;
-        lry = 2048;
+    // Expand fullscreen fill rects to cover widescreen viewports.
+    // Without this, screen clears and fades only cover the native 4:3 area.
+    if (ulx == 0 && uly == 0) {
+        bool isFullScreen = (lrx == ((int32_t)(mNativeDimensions.width - 1) * 4) &&
+                             lry == ((int32_t)(mNativeDimensions.height - 1) * 4));
+        if (isFullScreen) {
+            ulx = -1024;
+            uly = -1024;
+            lrx = 2048;
+            lry = 2048;
+        }
     }
 
     if (mode == G_CYC_COPY || mode == G_CYC_FILL) {


### PR DESCRIPTION
- Add SetColorImageChangeCallback and TextureCacheDeleteRange to LUS interpreter as generic hooks for render-to-texture support
- Handle OpenGL vs DX11 scaling differences in CopyFramebuffer path
- Cache DX11 staging texture in ReadFramebufferToCPU to avoid per-frame CreateTexture2D/Release overhead
- Fix range-based texture cache invalidation so all tiles update