### PR TITLE
Avoid temporary string allocations in hot per-frame paths

### DIFF
--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <stack>
 #include <string>
+#include <string_view>
 
 #include "fast/lus_gbi.h"
 #include "fast/types.h"
@@ -473,7 +474,7 @@ class Interpreter {
     static const char* CCMUXtoStr(uint32_t ccmux);
     static const char* ACMUXtoStr(uint32_t acmux);
     static void GenerateCC(ColorCombiner* comb, const ColorCombinerKey& key);
-    static std::string GetBaseTexturePath(const std::string& path);
+    static std::string_view GetBaseTexturePath(std::string_view path);
     static void NormalizeVector(float v[3]);
     static void TransposedMatrixMul(float res[3], const float a[3], const float b[4][4]);
     static void MatrixMul(float res[4][4], const float a[4][4], const float b[4][4]);
@@ -517,7 +518,7 @@ class Interpreter {
 
     std::set<std::pair<float, float>> mGetPixelDepthPending; // get_pixel_depth_pending;
     std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff> mGetPixelDepthCached; // get_pixel_depth_cached;
-    std::map<std::string, MaskedTextureEntry> mMaskedTextures;
+    std::map<std::string, MaskedTextureEntry, std::less<>> mMaskedTextures;
 
     const std::unordered_map<Mtx*, MtxF>* mCurMtxReplacements;
     bool mMarkerOn; // This was originally a debug feature. Now it seems to control s2dex?

--- a/include/ship/config/ConsoleVariable.h
+++ b/include/ship/config/ConsoleVariable.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <unordered_map>
 #include <string>
+#include <string_view>
 
 namespace Ship {
 typedef enum class ConsoleVariableType { Integer, Float, String, Color, Color24 } ConsoleVariableType;
@@ -64,6 +65,18 @@ class ConsoleVariable {
     void LoadLegacy();
 
   private:
-    std::unordered_map<std::string, std::shared_ptr<CVar>> mVariables;
+    struct TransparentStringHash {
+        using is_transparent = void;
+        size_t operator()(std::string_view sv) const noexcept {
+            return std::hash<std::string_view>{}(sv);
+        }
+    };
+    struct TransparentStringEqual {
+        using is_transparent = void;
+        bool operator()(std::string_view a, std::string_view b) const noexcept {
+            return a == b;
+        }
+    };
+    std::unordered_map<std::string, std::shared_ptr<CVar>, TransparentStringHash, TransparentStringEqual> mVariables;
 };
 } // namespace Ship

--- a/include/ship/resource/ResourceManager.h
+++ b/include/ship/resource/ResourceManager.h
@@ -34,6 +34,7 @@ struct ResourceIdentifier {
     friend struct ResourceIdentifierHash;
 
     ResourceIdentifier(const std::string& path, const uintptr_t owner, const std::shared_ptr<Archive> parent);
+    ResourceIdentifier(std::string&& path, const uintptr_t owner, const std::shared_ptr<Archive> parent);
     bool operator==(const ResourceIdentifier& rhs) const;
 
     // Must be an exact path. Passing a path with a wildcard will return a fail state

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -461,7 +461,7 @@ bool Interpreter::TextureCacheLookup(int i, const TextureCacheKey& key) {
     return false;
 }
 
-std::string Interpreter::GetBaseTexturePath(const std::string& path) {
+std::string_view Interpreter::GetBaseTexturePath(std::string_view path) {
     if (path.starts_with(Ship::IResource::gAltAssetPrefix)) {
         return path.substr(Ship::IResource::gAltAssetPrefix.length());
     }
@@ -2405,10 +2405,10 @@ void Interpreter::GfxDpLoadBlock(uint8_t tile, uint32_t uls, uint32_t ult, uint3
     // orig_size_bytes,
     //         mRdp->texture_to_load.siz, lrs);
 
-    const std::string& texPath =
+    const std::string_view texPath =
         mRdp->texture_to_load.raw_tex_metadata.resource != nullptr
             ? GetBaseTexturePath(mRdp->texture_to_load.raw_tex_metadata.resource->GetInitData()->Path)
-            : "";
+            : std::string_view{};
     auto maskedTextureIter = mMaskedTextures.find(texPath);
     if (maskedTextureIter != mMaskedTextures.end()) {
         mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].masked = true;
@@ -2475,10 +2475,10 @@ void Interpreter::GfxDpLoadTile(uint8_t tile, uint32_t uls, uint32_t ult, uint32
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata = mRdp->texture_to_load.raw_tex_metadata;
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].addr = mRdp->texture_to_load.addr + start_offset_bytes;
 
-    const std::string& texPath =
+    const std::string_view texPath =
         mRdp->texture_to_load.raw_tex_metadata.resource != nullptr
             ? GetBaseTexturePath(mRdp->texture_to_load.raw_tex_metadata.resource->GetInitData()->Path)
-            : "";
+            : std::string_view{};
     auto maskedTextureIter = mMaskedTextures.find(texPath);
     if (maskedTextureIter != mMaskedTextures.end()) {
         mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].masked = true;

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -26,6 +26,11 @@ ResourceIdentifier::ResourceIdentifier(const std::string& path, const uintptr_t 
     mHash = CalculateHash();
 }
 
+ResourceIdentifier::ResourceIdentifier(std::string&& path, const uintptr_t owner, const std::shared_ptr<Archive> parent)
+    : Path(std::move(path)), Owner(owner), Parent(parent) {
+    mHash = CalculateHash();
+}
+
 bool ResourceIdentifier::operator==(const ResourceIdentifier& rhs) const {
     return Owner == rhs.Owner && Path == rhs.Path && Parent == rhs.Parent;
 }
@@ -101,11 +106,17 @@ std::shared_ptr<IResource> ResourceManager::LoadResourceProcess(const ResourceId
         return LoadResourceProcess({ newFilePath, identifier.Owner, identifier.Parent }, false, initData);
     }
 
+    // Cache the starts_with check to avoid repeated string comparisons
+    const bool isAltPath = identifier.Path.starts_with(IResource::gAltAssetPrefix);
+    const bool shouldCheckAlt = !loadExact && mAltAssetsEnabled && !isAltPath;
+
     // Attempt to load the alternate version of the asset, if we fail then we continue trying to load the standard
     // asset.
-    if (!loadExact && mAltAssetsEnabled && !identifier.Path.starts_with(IResource::gAltAssetPrefix)) {
-        const auto altPath = IResource::gAltAssetPrefix + identifier.Path;
-        auto altResource = LoadResourceProcess({ altPath, identifier.Owner, identifier.Parent }, loadExact, initData);
+    if (shouldCheckAlt) {
+        std::string altPath = IResource::gAltAssetPrefix;
+        altPath += identifier.Path;
+        auto altResource =
+            LoadResourceProcess({ std::move(altPath), identifier.Owner, identifier.Parent }, loadExact, initData);
 
         if (altResource != nullptr) {
             return altResource;
@@ -122,7 +133,7 @@ std::shared_ptr<IResource> ResourceManager::LoadResourceProcess(const ResourceId
 
     // Check for resource load errors which can indicate an alternate asset.
     // If we are attempting to load an alternate asset, we can return null
-    if (!loadExact && mAltAssetsEnabled && identifier.Path.starts_with(IResource::gAltAssetPrefix)) {
+    if (!loadExact && mAltAssetsEnabled && isAltPath) {
         if (std::holds_alternative<ResourceLoadError>(cacheLine)) {
             try {
                 // If we have attempted to cache an alternate asset, but failed, we return nullptr and rely on the


### PR DESCRIPTION
- ConsoleVariable::Get: use transparent hash/equal on mVariables so find(const char*) no longer constructs a temporary std::string
- ResourceIdentifier: add move constructor so altPath strings are moved rather than copied; use += instead of operator+ to avoid a second allocation
- Interpreter::GetBaseTexturePath: return std::string_view instead of std::string to eliminate per-call copies; use std::less<> on mMaskedTextures for zero-alloc heterogeneous lookup

Can help on platforms with slow allocators.