### PR TITLE
perf: avoid memory copies in resource loading

### DIFF
--- a/include/fast/resource/type/Texture.h
+++ b/include/fast/resource/type/Texture.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "ship/resource/Resource.h"
+#include <memory>
+#include <vector>
 
 #define TEX_FLAG_LOAD_AS_RAW (1 << 0)
 #define TEX_FLAG_LOAD_AS_IMG (1 << 1)
@@ -35,6 +37,8 @@ class Texture final : public Ship::Resource<uint8_t> {
     float VPixelScale = 1.0;
     uint32_t ImageDataSize;
     uint8_t* ImageData = nullptr;
+    // When set, ImageData points into this buffer and must not be delete[]-ed.
+    std::shared_ptr<std::vector<char>> mImageBuffer;
 
     ~Texture();
 };

--- a/include/ship/resource/File.h
+++ b/include/ship/resource/File.h
@@ -32,6 +32,7 @@ struct ResourceInitData {
 
 struct File {
     std::shared_ptr<std::vector<char>> Buffer;
+    size_t BufferOffset = 0;
     std::variant<std::shared_ptr<tinyxml2::XMLDocument>, std::shared_ptr<BinaryReader>> Reader;
     bool IsLoaded = false;
 };

--- a/include/ship/utils/binarytools/MemoryStream.h
+++ b/include/ship/utils/binarytools/MemoryStream.h
@@ -10,6 +10,7 @@ class MemoryStream final : public Stream {
     MemoryStream();
     MemoryStream(char* nBuffer, size_t nBufferSize);
     MemoryStream(std::shared_ptr<std::vector<char>> buffer);
+    MemoryStream(std::shared_ptr<std::vector<char>> buffer, size_t offset);
     ~MemoryStream();
 
     uint64_t GetLength() override;

--- a/src/fast/resource/factory/TextureFactory.cpp
+++ b/src/fast/resource/factory/TextureFactory.cpp
@@ -18,9 +18,8 @@ ResourceFactoryBinaryTextureV0::ReadResource(std::shared_ptr<Ship::File> file,
     texture->Width = reader->ReadUInt32();
     texture->Height = reader->ReadUInt32();
     texture->ImageDataSize = reader->ReadUInt32();
-    texture->ImageData = new uint8_t[texture->ImageDataSize];
-
-    reader->Read((char*)texture->ImageData, texture->ImageDataSize);
+    texture->mImageBuffer = file->Buffer;
+    texture->ImageData = reinterpret_cast<uint8_t*>(file->Buffer->data() + reader->GetBaseAddress());
 
     return texture;
 }
@@ -42,9 +41,8 @@ ResourceFactoryBinaryTextureV1::ReadResource(std::shared_ptr<Ship::File> file,
     texture->HByteScale = reader->ReadFloat();
     texture->VPixelScale = reader->ReadFloat();
     texture->ImageDataSize = reader->ReadUInt32();
-    texture->ImageData = new uint8_t[texture->ImageDataSize];
-
-    reader->Read((char*)texture->ImageData, texture->ImageDataSize);
+    texture->mImageBuffer = file->Buffer;
+    texture->ImageData = reinterpret_cast<uint8_t*>(file->Buffer->data() + reader->GetBaseAddress());
 
     return texture;
 }

--- a/src/fast/resource/type/Texture.cpp
+++ b/src/fast/resource/type/Texture.cpp
@@ -13,7 +13,7 @@ size_t Texture::GetPointerSize() {
 }
 
 Texture::~Texture() {
-    if (ImageData != nullptr) {
+    if (ImageData != nullptr && !mImageBuffer) {
         delete[] ImageData;
     }
 }

--- a/src/ship/resource/ResourceLoader.cpp
+++ b/src/ship/resource/ResourceLoader.cpp
@@ -100,23 +100,19 @@ std::shared_ptr<ResourceInitData> ResourceLoader::ReadResourceInitDataLegacy(con
         }
         return ReadResourceInitDataXml(filePath, xmlReader);
     } else {
-        auto headerBuffer = std::make_shared<std::vector<char>>(fileToLoad->Buffer->begin(),
-                                                                fileToLoad->Buffer->begin() + OTR_HEADER_SIZE);
-
-        if (headerBuffer->size() < OTR_HEADER_SIZE) {
+        if (fileToLoad->Buffer->size() < OTR_HEADER_SIZE) {
             SPDLOG_ERROR("Failed to parse ResourceInitData, buffer size too small. File: {}. Got {} bytes and "
                          "needed {} bytes.",
-                         filePath, headerBuffer->size(), OTR_HEADER_SIZE);
+                         filePath, fileToLoad->Buffer->size(), OTR_HEADER_SIZE);
             return nullptr;
         }
 
-        // Factories expect the buffer to not include the header,
-        // so we need to remove it from the buffer on the file
-        fileToLoad->Buffer = std::make_shared<std::vector<char>>(fileToLoad->Buffer->begin() + OTR_HEADER_SIZE,
-                                                                 fileToLoad->Buffer->end());
+        // Record where the body starts so CreateBinaryReader can skip the header
+        // without copying the buffer.
+        fileToLoad->BufferOffset = OTR_HEADER_SIZE;
 
-        // Create a reader for the header buffer
-        auto headerStream = std::make_shared<MemoryStream>(headerBuffer);
+        // Read the header from the start of the buffer (no copy needed).
+        auto headerStream = std::make_shared<MemoryStream>(fileToLoad->Buffer);
         auto headerReader = std::make_shared<BinaryReader>(headerStream);
         return ReadResourceInitDataBinary(filePath, headerReader);
     }
@@ -124,7 +120,7 @@ std::shared_ptr<ResourceInitData> ResourceLoader::ReadResourceInitDataLegacy(con
 
 std::shared_ptr<BinaryReader> ResourceLoader::CreateBinaryReader(std::shared_ptr<File> fileToLoad,
                                                                  std::shared_ptr<ResourceInitData> initData) {
-    auto stream = std::make_shared<MemoryStream>(fileToLoad->Buffer);
+    auto stream = std::make_shared<MemoryStream>(fileToLoad->Buffer, fileToLoad->BufferOffset);
     auto reader = std::make_shared<BinaryReader>(stream);
     reader->SetEndianness(initData->ByteOrder);
     return reader;

--- a/src/ship/utils/binarytools/MemoryStream.cpp
+++ b/src/ship/utils/binarytools/MemoryStream.cpp
@@ -24,6 +24,12 @@ Ship::MemoryStream::MemoryStream(std::shared_ptr<std::vector<char>> buffer) : Me
     mBaseAddress = 0;
 }
 
+Ship::MemoryStream::MemoryStream(std::shared_ptr<std::vector<char>> buffer, size_t offset) : MemoryStream() {
+    mBuffer = buffer;
+    mBufferSize = buffer->size();
+    mBaseAddress = offset;
+}
+
 Ship::MemoryStream::~MemoryStream() {
 }
 


### PR DESCRIPTION
The resource loading pipeline was making up to three copies of asset data between zip decompression and final use:

1. ReadResourceInitDataLegacy copied the entire file body into a new vector just to strip the OTR header, and separately copied the header into another vector for parsing.

2. TextureFactory allocated a new uint8_t[] buffer and memcpy'd image pixel data out of the already-decompressed file buffer.

This improves performance for large resource packs.