### PR TITLE
build: update prism bbcbc7e -> e313fa8

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -108,6 +108,6 @@ option(PRISM_STANDALONE "Build prism as a standalone library" OFF)
 FetchContent_Declare(
     prism
     GIT_REPOSITORY https://github.com/KiritoDv/prism-processor.git
-    GIT_TAG f8c3ec2f986b69bd7d4d07b9639f2e3d60d548f0
+    GIT_TAG 1de054450e7b3c5f777d2e3dfcb228ad120c329d
 )
 FetchContent_MakeAvailable(prism)

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -108,6 +108,6 @@ option(PRISM_STANDALONE "Build prism as a standalone library" OFF)
 FetchContent_Declare(
     prism
     GIT_REPOSITORY https://github.com/KiritoDv/prism-processor.git
-    GIT_TAG bbcbc7e3f890a5806b579361e7aa0336acd547e7
+    GIT_TAG e313fa86a0e2abfb2370de8560ee815a3db0dcc8
 )
 FetchContent_MakeAvailable(prism)

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -107,7 +107,7 @@ list(APPEND ADDITIONAL_LIB_INCLUDES ${threadpool_SOURCE_DIR}/include)
 option(PRISM_STANDALONE "Build prism as a standalone library" OFF)
 FetchContent_Declare(
     prism
-    GIT_REPOSITORY https://github.com/briaguya0/prism-processor.git
-    GIT_TAG db9052d8f48cd37791f4c60438fedde001331563
+    GIT_REPOSITORY https://github.com/KiritoDv/prism-processor.git
+    GIT_TAG f8c3ec2f986b69bd7d4d07b9639f2e3d60d548f0
 )
 FetchContent_MakeAvailable(prism)

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -107,7 +107,7 @@ list(APPEND ADDITIONAL_LIB_INCLUDES ${threadpool_SOURCE_DIR}/include)
 option(PRISM_STANDALONE "Build prism as a standalone library" OFF)
 FetchContent_Declare(
     prism
-    GIT_REPOSITORY https://github.com/KiritoDv/prism-processor.git
-    GIT_TAG e313fa86a0e2abfb2370de8560ee815a3db0dcc8
+    GIT_REPOSITORY https://github.com/briaguya0/prism-processor.git
+    GIT_TAG db9052d8f48cd37791f4c60438fedde001331563
 )
 FetchContent_MakeAvailable(prism)


### PR DESCRIPTION
## Summary

Updates prism from [`bbcbc7e`](https://github.com/KiritoDv/prism-processor/commit/bbcbc7e) to [`1de054`](https://github.com/KiritoDv/prism-processor/commit/1de054450e7b3c5f777d2e3dfcb228ad120c329d).

## TODO

- [x] Land PR fixing spdlog breakage on prism side (https://github.com/KiritoDv/prism-processor/pull/8)
- [x] Land PR fixing prism CTest leaking into consumers (https://github.com/KiritoDv/prism-processor/pull/10)
- [x] Verify all changes between [`bbcbc7e...1de054`](https://github.com/KiritoDv/prism-processor/compare/bbcbc7e...1de054450e7b3c5f777d2e3dfcb228ad120c329d) are non-breaking
  - workflow files don't affect consumers
  - CMake changes are minimal (bigobj flag, MSVC guard tweak, spdlog handling fixed in https://github.com/KiritoDv/prism-processor/pull/8, ctest leak fixed in https://github.com/KiritoDv/prism-processor/pull/10)
  - toolchain files only apply when building prism standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)