### PR TITLE
fix: correct StringHelper::Strip erase count

### DIFF
--- a/src/ship/utils/StringHelper.cpp
+++ b/src/ship/utils/StringHelper.cpp
@@ -45,7 +45,7 @@ std::string StringHelper::Strip(std::string s, const std::string& delimiter) {
 
     while ((pos = s.find(delimiter)) != std::string::npos) {
         token = s.substr(0, pos);
-        s.erase(pos, pos + delimiter.length());
+        s.erase(pos, delimiter.length());
     }
 
     return s;


### PR DESCRIPTION
`std::string::erase(pos, count)` takes a count, not an end position. Passing `pos + delimiter.length()` caused too many characters to be erased whenever `pos > 0`, e.g. `Strip("aXbXc", "X")` returned `"a"` instead of `"abc"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)