### PR TITLE
fix: restore StringHelper::Implode implementation

### DIFF
--- a/src/ship/utils/StringHelper.cpp
+++ b/src/ship/utils/StringHelper.cpp
@@ -103,12 +103,9 @@ std::string StringHelper::Sprintf(const char* format, ...) {
 }
 
 std::string StringHelper::Implode(std::vector<std::string>& elements, const char* const separator) {
-    return "";
-
-    // return std::accumulate(std::begin(elements), std::end(elements), std::string(),
-    //[separator](std::string& ss, std::string& s) {
-    // return ss.empty() ? s : ss + separator + s;
-    //});
+    return std::accumulate(
+        std::begin(elements), std::end(elements), std::string(),
+        [separator](const std::string& ss, const std::string& s) { return ss.empty() ? s : ss + separator + s; });
 }
 
 int64_t StringHelper::StrToL(const std::string& str, int32_t base) {


### PR DESCRIPTION
Closes #1031.

`Implode` has returned `""` since [HarbourMasters/ZAPDTR@7e82564](https://github.com/HarbourMasters/ZAPDTR/commit/7e82564abe076242d0347622de859778017a8292) (Dec 2021) and propagated into LUS via Shipwright. The working `std::accumulate` implementation still exists in [@NEstelami's ZAPD fork](https://github.com/NEstelami/ZAPD) where the breakage never reached. No code in the HarbourMasters GitHub org calls this function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)