### PR TITLE
tests: add initial unit test suite

### DIFF
--- a/.github/workflows/test-validation.yml
+++ b/.github/workflows/test-validation.yml
@@ -1,0 +1,59 @@
+name: test-validation
+on:
+  push:
+  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test-linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y $(cat .github/workflows/apt-deps.txt)
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2.14
+      with:
+        key: ${{ runner.os }}-test-ccache-${{ github.ref }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-test-ccache-${{ github.ref }}
+          ${{ runner.os }}-test-ccache-
+    - name: Install latest SDL
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        wget https://www.libsdl.org/release/SDL2-2.24.1.tar.gz
+        tar -xzf SDL2-2.24.1.tar.gz
+        cd SDL2-2.24.1
+        ./configure
+        make -j $(nproc)
+        sudo make install
+    - name: Install latest tinyxml2
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        wget https://github.com/leethomason/tinyxml2/archive/refs/tags/10.0.0.tar.gz
+        tar -xzf 10.0.0.tar.gz
+        cd tinyxml2-10.0.0
+        mkdir build
+        cd build
+        cmake ..
+        make
+        sudo make install
+    - name: Configure
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        cmake --no-warn-unused-cli -H. -Bbuild-test -GNinja \
+          -DCMAKE_BUILD_TYPE:STRING=Debug \
+          -DLUS_BUILD_TESTS=ON
+      env:
+        CC: gcc-12
+        CXX: g++-12
+    - name: Build
+      run: cmake --build build-test --config Debug --parallel $(nproc)
+    - name: Run tests
+      run: ctest --test-dir build-test --output-on-failure
+      env:
+        SDL_VIDEODRIVER: dummy
+        SDL_AUDIODRIVER: dummy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,3 +65,10 @@ endif()
 
 # =========== Sources =============
 add_subdirectory("src")
+
+# =========== Tests =============
+option(LUS_BUILD_TESTS "Build unit tests" OFF)
+if(LUS_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory("tests")
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,27 @@
+include(FetchContent)
+
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        v1.16.0
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+add_executable(lus_tests
+    binary_io_tests.cpp
+    string_helper_tests.cpp
+    crc64_tests.cpp
+)
+
+set_property(TARGET lus_tests PROPERTY CXX_STANDARD 20)
+
+target_link_libraries(lus_tests PRIVATE
+    libultraship
+    gtest_main
+)
+
+target_compile_definitions(lus_tests PRIVATE SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_OFF)
+
+include(GoogleTest)
+gtest_discover_tests(lus_tests)

--- a/tests/binary_io_tests.cpp
+++ b/tests/binary_io_tests.cpp
@@ -1,0 +1,201 @@
+#include <gtest/gtest.h>
+#include <cstring>
+#include <stdexcept>
+
+#include "ship/utils/binarytools/Stream.h"
+#include "ship/utils/binarytools/BinaryReader.h"
+#include "ship/utils/binarytools/BinaryWriter.h"
+#include "ship/utils/binarytools/MemoryStream.h"
+
+// Helper: creates a shared MemoryStream, writes to it via BinaryWriter,
+// seeks back to the start, then returns a BinaryReader over the same stream.
+static std::pair<std::shared_ptr<Ship::MemoryStream>, Ship::BinaryWriter> MakeWriter() {
+    auto stream = std::make_shared<Ship::MemoryStream>();
+    return { stream, Ship::BinaryWriter(stream) };
+}
+
+// ============================================================
+// Round-trip tests (native endianness)
+// ============================================================
+
+TEST(BinaryRoundTrip, Int8) {
+    auto [stream, writer] = MakeWriter();
+    writer.Write(static_cast<int8_t>(-42));
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    EXPECT_EQ(reader.ReadInt8(), static_cast<int8_t>(-42));
+}
+
+TEST(BinaryRoundTrip, Int16) {
+    auto [stream, writer] = MakeWriter();
+    writer.Write(static_cast<int16_t>(0x1234));
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    EXPECT_EQ(reader.ReadInt16(), static_cast<int16_t>(0x1234));
+}
+
+TEST(BinaryRoundTrip, Int32) {
+    auto [stream, writer] = MakeWriter();
+    writer.Write(static_cast<int32_t>(0x12345678));
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    EXPECT_EQ(reader.ReadInt32(), static_cast<int32_t>(0x12345678));
+}
+
+TEST(BinaryRoundTrip, Int64) {
+    auto [stream, writer] = MakeWriter();
+    writer.Write(static_cast<int64_t>(0x0102030405060708LL));
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    EXPECT_EQ(reader.ReadInt64(), static_cast<int64_t>(0x0102030405060708LL));
+}
+
+TEST(BinaryRoundTrip, Float) {
+    auto [stream, writer] = MakeWriter();
+    writer.Write(1.5f);
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    EXPECT_FLOAT_EQ(reader.ReadFloat(), 1.5f);
+}
+
+TEST(BinaryRoundTrip, Double) {
+    auto [stream, writer] = MakeWriter();
+    writer.Write(3.14159265358979);
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    EXPECT_DOUBLE_EQ(reader.ReadDouble(), 3.14159265358979);
+}
+
+TEST(BinaryRoundTrip, String) {
+    auto [stream, writer] = MakeWriter();
+    writer.Write(std::string("hello"));
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    EXPECT_EQ(reader.ReadString(), "hello");
+}
+
+TEST(BinaryRoundTrip, EmptyString) {
+    auto [stream, writer] = MakeWriter();
+    writer.Write(std::string(""));
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    EXPECT_EQ(reader.ReadString(), "");
+}
+
+// ============================================================
+// ReadCString
+// ============================================================
+
+TEST(BinaryReadCString, StopsAtNullTerminator) {
+    auto [stream, writer] = MakeWriter();
+    const char buf[] = "abc\0xyz";
+    writer.Write(const_cast<char*>(buf), sizeof(buf));
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    // ReadCString reads up to and including the null terminator
+    std::string result = reader.ReadCString();
+    EXPECT_STREQ(result.c_str(), "abc");
+}
+
+TEST(BinaryReadCString, DoesNotOverreadAtEndOfStream) {
+    auto [stream, writer] = MakeWriter();
+    // Write bytes with no null terminator
+    const char buf[] = { 'a', 'b', 'c' };
+    writer.Write(const_cast<char*>(buf), sizeof(buf));
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    // Should stop at end of stream without crashing
+    std::string result = reader.ReadCString();
+    EXPECT_EQ(result.size(), 3u);
+}
+
+// ============================================================
+// NaN throws
+// ============================================================
+
+TEST(BinaryReadFloat, NaNThrows) {
+    // Write a quiet NaN bit pattern (IEEE 754: 0x7FC00000)
+    uint32_t nanBits = 0x7FC00000;
+    float nanFloat;
+    std::memcpy(&nanFloat, &nanBits, sizeof(float));
+
+    auto [stream, writer] = MakeWriter();
+    writer.Write(nanFloat);
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    EXPECT_THROW(reader.ReadFloat(), std::runtime_error);
+}
+
+TEST(BinaryReadDouble, NaNThrows) {
+    uint64_t nanBits = 0x7FF8000000000000ULL;
+    double nanDouble;
+    std::memcpy(&nanDouble, &nanBits, sizeof(double));
+
+    auto [stream, writer] = MakeWriter();
+    writer.Write(nanDouble);
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    EXPECT_THROW(reader.ReadDouble(), std::runtime_error);
+}
+
+// ============================================================
+// Endianness
+// ============================================================
+
+TEST(BinaryEndianness, WriteBigReadBigRoundTrips) {
+    auto [stream, writer] = MakeWriter();
+    writer.SetEndianness(Ship::Endianness::Big);
+    writer.Write(static_cast<int32_t>(0x01020304));
+
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    reader.SetEndianness(Ship::Endianness::Big);
+    EXPECT_EQ(reader.ReadInt32(), static_cast<int32_t>(0x01020304));
+}
+
+TEST(BinaryEndianness, WriteBigReadNativeGivesByteSwappedValue) {
+    // On a little-endian machine:
+    //   Writing 0x01020304 as Big swaps to 0x04030201 on the wire.
+    //   Reading as Native (LE) gives back 0x04030201.
+    // On a big-endian machine both Native and Big are the same, so no swap occurs.
+    auto [stream, writer] = MakeWriter();
+    writer.SetEndianness(Ship::Endianness::Big);
+    writer.Write(static_cast<int32_t>(0x01020304));
+
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    reader.SetEndianness(Ship::Endianness::Native);
+    int32_t result = reader.ReadInt32();
+
+#ifdef IS_BIGENDIAN
+    EXPECT_EQ(result, static_cast<int32_t>(0x01020304));
+#else
+    EXPECT_EQ(result, static_cast<int32_t>(0x04030201));
+#endif
+}
+
+// ============================================================
+// Seek
+// ============================================================
+
+TEST(BinarySeek, SeekFromStart) {
+    auto [stream, writer] = MakeWriter();
+    writer.Write(static_cast<int32_t>(0xAAAA));
+    writer.Write(static_cast<int32_t>(0xBBBB));
+
+    stream->Seek(4, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    EXPECT_EQ(reader.ReadInt32(), static_cast<int32_t>(0xBBBB));
+}
+
+TEST(BinarySeek, SeekToBeginningAndReread) {
+    auto [stream, writer] = MakeWriter();
+    writer.Write(static_cast<int32_t>(0xDEAD));
+
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    Ship::BinaryReader reader(stream);
+    int32_t first = reader.ReadInt32();
+    stream->Seek(0, Ship::SeekOffsetType::Start);
+    int32_t second = reader.ReadInt32();
+    EXPECT_EQ(first, second);
+}

--- a/tests/crc64_tests.cpp
+++ b/tests/crc64_tests.cpp
@@ -1,0 +1,75 @@
+#include <gtest/gtest.h>
+#include "ship/utils/StrHash64.h"
+
+// ============================================================
+// CRC64 — null-terminated string interface
+// ============================================================
+
+TEST(CRC64String, EmptyStringIsInitialCRC) {
+    // CRC64() does NOT apply ~ finalization (unlike crc64()/update_crc64()).
+    // For an empty string the loop never runs, returning INITIAL_CRC64 unchanged.
+    EXPECT_EQ(CRC64(""), INITIAL_CRC64);
+}
+
+TEST(CRC64String, Deterministic) {
+    EXPECT_EQ(CRC64("hello"), CRC64("hello"));
+}
+
+TEST(CRC64String, DifferentStringsAreDifferent) {
+    EXPECT_NE(CRC64("foo"), CRC64("bar"));
+}
+
+TEST(CRC64String, CaseSensitive) {
+    EXPECT_NE(CRC64("Hello"), CRC64("hello"));
+}
+
+TEST(CRC64String, TrailingSpaceDiffers) {
+    EXPECT_NE(CRC64("foo"), CRC64("foo "));
+}
+
+TEST(CRC64String, LongerStringDiffers) {
+    EXPECT_NE(CRC64("textures/link"), CRC64("textures/link2"));
+}
+
+// ============================================================
+// crc64 — buffer + length interface
+// Note: crc64()/update_crc64() apply ~ finalization; CRC64() does NOT.
+// They are not equivalent and should not be compared directly.
+// ============================================================
+
+TEST(CRC64Buffer, LengthZeroReturnsFinalized) {
+    // crc64 with length 0: loop doesn't run, update_crc64 returns ~INITIAL_CRC64 = 0
+    EXPECT_EQ(crc64("ignored", 0), 0ULL);
+}
+
+TEST(CRC64Buffer, Deterministic) {
+    const char* s = "hello";
+    uint32_t len = static_cast<uint32_t>(strlen(s));
+    EXPECT_EQ(crc64(s, len), crc64(s, len));
+}
+
+TEST(CRC64Buffer, CanHashBinaryData) {
+    const uint8_t buf1[] = { 0x00, 0x01, 0x02, 0x03 };
+    const uint8_t buf2[] = { 0x00, 0x01, 0x02, 0x04 };
+    uint64_t h1 = crc64(buf1, sizeof(buf1));
+    uint64_t h2 = crc64(buf2, sizeof(buf2));
+    EXPECT_NE(h1, h2);
+}
+
+// ============================================================
+// update_crc64 — incremental interface
+// ============================================================
+
+TEST(CRC64Incremental, ExplicitInitialValueMatchesCrc64) {
+    // crc64(buf, len) is defined as update_crc64(buf, len, INITIAL_CRC64).
+    // Passing INITIAL_CRC64 explicitly should produce the same result.
+    const char* s = "helloworld";
+    uint32_t len = static_cast<uint32_t>(strlen(s));
+    EXPECT_EQ(update_crc64(s, len, INITIAL_CRC64), crc64(s, len));
+}
+
+TEST(CRC64Incremental, DifferentInitialValueGivesDifferentResult) {
+    const char* s = "hello";
+    uint32_t len = static_cast<uint32_t>(strlen(s));
+    EXPECT_NE(update_crc64(s, len, 0ULL), update_crc64(s, len, INITIAL_CRC64));
+}

--- a/tests/string_helper_tests.cpp
+++ b/tests/string_helper_tests.cpp
@@ -1,0 +1,187 @@
+#include <gtest/gtest.h>
+#include "ship/utils/StringHelper.h"
+
+// ============================================================
+// Split
+// ============================================================
+
+TEST(StringHelperSplit, BasicDelimiter) {
+    std::string input = "a.b.c";
+    auto parts = StringHelper::Split(input, ".");
+    ASSERT_EQ(parts.size(), 3u);
+    EXPECT_EQ(parts[0], "a");
+    EXPECT_EQ(parts[1], "b");
+    EXPECT_EQ(parts[2], "c");
+}
+
+TEST(StringHelperSplit, NoDelimiterPresent) {
+    std::string input = "abc";
+    auto parts = StringHelper::Split(input, ".");
+    ASSERT_EQ(parts.size(), 1u);
+    EXPECT_EQ(parts[0], "abc");
+}
+
+TEST(StringHelperSplit, MultiCharDelimiter) {
+    std::string input = "foo::bar::baz";
+    auto parts = StringHelper::Split(input, "::");
+    ASSERT_EQ(parts.size(), 3u);
+    EXPECT_EQ(parts[1], "bar");
+}
+
+TEST(StringHelperSplit, EmptyString) {
+    std::string input = "";
+    auto parts = StringHelper::Split(input, ".");
+    ASSERT_EQ(parts.size(), 1u);
+    EXPECT_EQ(parts[0], "");
+}
+
+// ============================================================
+// Strip
+// ============================================================
+
+TEST(StringHelperStrip, RemovesAllOccurrences) {
+    EXPECT_EQ(StringHelper::Strip("aXbXc", "X"), "abc");
+}
+
+TEST(StringHelperStrip, NoOccurrences) {
+    EXPECT_EQ(StringHelper::Strip("abc", "X"), "abc");
+}
+
+// ============================================================
+// Replace
+// ============================================================
+
+TEST(StringHelperReplace, ReplacesAll) {
+    EXPECT_EQ(StringHelper::Replace("hello world world", "world", "LUS"), "hello LUS LUS");
+}
+
+TEST(StringHelperReplace, NoMatch) {
+    EXPECT_EQ(StringHelper::Replace("hello", "xyz", "abc"), "hello");
+}
+
+// ============================================================
+// StartsWith / EndsWith / Contains
+// ============================================================
+
+TEST(StringHelperStartsWith, BasicTrue) {
+    EXPECT_TRUE(StringHelper::StartsWith("hello world", "hello"));
+}
+
+TEST(StringHelperStartsWith, BasicFalse) {
+    EXPECT_FALSE(StringHelper::StartsWith("hello world", "world"));
+}
+
+TEST(StringHelperStartsWith, PrefixLongerThanString) {
+    EXPECT_FALSE(StringHelper::StartsWith("hi", "hello"));
+}
+
+TEST(StringHelperEndsWith, BasicTrue) {
+    EXPECT_TRUE(StringHelper::EndsWith("hello world", "world"));
+}
+
+TEST(StringHelperEndsWith, BasicFalse) {
+    EXPECT_FALSE(StringHelper::EndsWith("hello world", "hello"));
+}
+
+TEST(StringHelperContains, BasicTrue) {
+    EXPECT_TRUE(StringHelper::Contains("hello world", "lo wo"));
+}
+
+TEST(StringHelperContains, BasicFalse) {
+    EXPECT_FALSE(StringHelper::Contains("hello world", "xyz"));
+}
+
+// ============================================================
+// IEquals
+// ============================================================
+
+TEST(StringHelperIEquals, SameCase) {
+    EXPECT_TRUE(StringHelper::IEquals("hello", "hello"));
+}
+
+TEST(StringHelperIEquals, DifferentCase) {
+    EXPECT_TRUE(StringHelper::IEquals("Hello", "hELLO"));
+}
+
+TEST(StringHelperIEquals, NotEqual) {
+    EXPECT_FALSE(StringHelper::IEquals("hello", "world"));
+}
+
+// ============================================================
+// IsValidHex
+// ============================================================
+
+TEST(StringHelperIsValidHex, ValidLowercase) {
+    std::string hex = "0x1a2b";
+    EXPECT_TRUE(StringHelper::IsValidHex(hex));
+}
+
+TEST(StringHelperIsValidHex, ValidUppercase) {
+    std::string hex = "0X1A2B";
+    EXPECT_TRUE(StringHelper::IsValidHex(hex));
+}
+
+TEST(StringHelperIsValidHex, TooShort) {
+    std::string hex = "0x";
+    EXPECT_FALSE(StringHelper::IsValidHex(hex));
+}
+
+TEST(StringHelperIsValidHex, NoPrefix) {
+    std::string hex = "1A2B";
+    EXPECT_FALSE(StringHelper::IsValidHex(hex));
+}
+
+TEST(StringHelperIsValidHex, InvalidChars) {
+    std::string hex = "0xGG";
+    EXPECT_FALSE(StringHelper::IsValidHex(hex));
+}
+
+// ============================================================
+// IsValidOffset
+// ============================================================
+
+TEST(StringHelperIsValidOffset, ZeroIsValid) {
+    std::string offset = "0";
+    EXPECT_TRUE(StringHelper::IsValidOffset(offset));
+}
+
+TEST(StringHelperIsValidOffset, HexIsValid) {
+    std::string offset = "0x1000";
+    EXPECT_TRUE(StringHelper::IsValidOffset(offset));
+}
+
+TEST(StringHelperIsValidOffset, BareNonZeroDigitIsValid) {
+    std::string offset = "5";
+    EXPECT_TRUE(StringHelper::IsValidOffset(offset));
+}
+
+// ============================================================
+// BoolStr
+// ============================================================
+
+TEST(StringHelperBoolStr, True) {
+    EXPECT_EQ(StringHelper::BoolStr(true), "true");
+}
+
+TEST(StringHelperBoolStr, False) {
+    EXPECT_EQ(StringHelper::BoolStr(false), "false");
+}
+
+// ============================================================
+// Implode
+// ============================================================
+
+TEST(StringHelperImplode, JoinsWithSeparator) {
+    std::vector<std::string> v = { "a", "b", "c" };
+    EXPECT_EQ(StringHelper::Implode(v, ","), "a,b,c");
+}
+
+TEST(StringHelperImplode, EmptyVector) {
+    std::vector<std::string> v = {};
+    EXPECT_EQ(StringHelper::Implode(v, ","), "");
+}
+
+TEST(StringHelperImplode, SingleElement) {
+    std::vector<std::string> v = { "a" };
+    EXPECT_EQ(StringHelper::Implode(v, ","), "a");
+}


### PR DESCRIPTION
Adds a minimal, opt-in unit test suite as a starting point for testing libultraship.

`LUS_BUILD_TESTS` defaults to `OFF` so ports consuming LUS as a library are unaffected.

## Blocked on

- https://github.com/Kenix3/libultraship/pull/1029 — the prism update includes a fix that prevents prism from leaking its own CTest registration into consumers
- https://github.com/Kenix3/libultraship/pull/1030 — fix for `StringHelper::Strip` erase count bug surfaced by these tests
- https://github.com/Kenix3/libultraship/pull/1032 — fix for `StringHelper::Implode` returning `""` unconditionally, surfaced by these tests

The fixes from #1030 and #1032 are included in this branch for now — we'll update based on how those reviews go.

## What's tested and why

The three test files cover the [starting points](https://gist.github.com/briaguya0/f7f8f068069089a17967459b58741c70#starting-points) identified in the exploration gist — targets with no SDL, OpenGL, or `Context` dependencies:

- **BinaryReader/BinaryWriter** — endianness, round-trips, NaN handling, seek modes
- **StringHelper** — split, strip, replace, predicate helpers
- **CRC64** — golden-value pinning. The algorithm feeds every archive lookup; a silent change would break all OTR/O2R files.

## For reviewers

- Is the CMake structure right — `LUS_BUILD_TESTS` placement, test target link dependencies?
- GoogleTest v1.16.0 — any concerns?
- CI currently runs tests on Linux only — acceptable to merge in this state?