### PR TITLE
macOS: Create bundleID directory in Application Support when checking…

### DIFF
--- a/include/ship/utils/AppleFolderManager.h
+++ b/include/ship/utils/AppleFolderManager.h
@@ -56,6 +56,7 @@ class FolderManager {
     FolderManager();
     ~FolderManager();
 
+    void createAppSupportDirectory(const char* appName);
     const char* getMainBundlePath();
     const char* pathForDirectory(SearchPathDirectory directory, SearchPathDomainMask domainMask);
     const char* pathForDirectoryAppropriateForItemAtPath(SearchPathDirectory directory, SearchPathDomainMask domainMask,

--- a/include/ship/utils/AppleFolderManager.h
+++ b/include/ship/utils/AppleFolderManager.h
@@ -56,7 +56,7 @@ class FolderManager {
     FolderManager();
     ~FolderManager();
 
-    void createAppSupportDirectory(const char* appName);
+    void CreateAppSupportDirectory(const char* appName);
     const char* getMainBundlePath();
     const char* pathForDirectory(SearchPathDirectory directory, SearchPathDomainMask domainMask);
     const char* pathForDirectoryAppropriateForItemAtPath(SearchPathDirectory directory, SearchPathDomainMask domainMask,

--- a/src/ship/Context.cpp
+++ b/src/ship/Context.cpp
@@ -473,7 +473,7 @@ std::string Context::GetAppDirectoryPath(std::string appName) {
     if (char* fpath = std::getenv("SHIP_HOME")) {
         const char* appBundleID = strrchr(fpath, '/');
         if (appBundleID != nullptr) {
-            foldermanager.createAppSupportDirectory(appBundleID+1);
+            foldermanager.createAppSupportDirectory(appBundleID + 1);
         }
         if (fpath[0] == '~') {
             const char* home = getenv("HOME") ? getenv("HOME") : getpwuid(getuid())->pw_dir;

--- a/src/ship/Context.cpp
+++ b/src/ship/Context.cpp
@@ -473,7 +473,7 @@ std::string Context::GetAppDirectoryPath(std::string appName) {
     if (char* fpath = std::getenv("SHIP_HOME")) {
         const char* appBundleID = strrchr(fpath, '/');
         if (appBundleID != nullptr) {
-            foldermanager.createAppSupportDirectory(appBundleID + 1);
+            foldermanager.CreateAppSupportDirectory(appBundleID + 1);
         }
         if (fpath[0] == '~') {
             const char* home = getenv("HOME") ? getenv("HOME") : getpwuid(getuid())->pw_dir;

--- a/src/ship/Context.cpp
+++ b/src/ship/Context.cpp
@@ -1,5 +1,6 @@
 #include "ship/Context.h"
 #include "ship/controller/controldevice/controller/mapping/keyboard/KeyboardScancodes.h"
+#include <cstring>
 #include <iostream>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -468,7 +469,12 @@ std::string Context::GetAppDirectoryPath(std::string appName) {
 #endif
 
 #if defined(__APPLE__)
+    FolderManager foldermanager;
     if (char* fpath = std::getenv("SHIP_HOME")) {
+        const char* appBundleID = strrchr(fpath, '/');
+        if (appBundleID != nullptr) {
+            foldermanager.createAppSupportDirectory(appBundleID+1);
+        }
         if (fpath[0] == '~') {
             const char* home = getenv("HOME") ? getenv("HOME") : getpwuid(getuid())->pw_dir;
             return std::string(home) + std::string(fpath).substr(1);

--- a/src/ship/utils/AppleFolderManager.mm
+++ b/src/ship/utils/AppleFolderManager.mm
@@ -18,7 +18,7 @@ FolderManager::~FolderManager() {
     [(NSAutoreleasePool *)m_autoreleasePool release];
 }
 
-void FolderManager::createAppSupportDirectory(const char * appName) {
+void FolderManager::CreateAppSupportDirectory(const char * appName) {
     NSString *appNameString = [NSString stringWithUTF8String:appName];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSString *appSupportDirectory = [NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory::NSApplicationSupportDirectory, Ship::NSUserDomainMask, YES) firstObject];

--- a/src/ship/utils/AppleFolderManager.mm
+++ b/src/ship/utils/AppleFolderManager.mm
@@ -18,6 +18,20 @@ FolderManager::~FolderManager() {
     [(NSAutoreleasePool *)m_autoreleasePool release];
 }
 
+void FolderManager::createAppSupportDirectory(const char * appName) {
+    NSString *appNameString = [NSString stringWithUTF8String:appName];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *appSupportDirectory = [NSSearchPathForDirectoriesInDomains(NSSearchPathDirectory::NSApplicationSupportDirectory, Ship::NSUserDomainMask, YES) firstObject];
+    NSString *appSpecificDir = [appSupportDirectory stringByAppendingPathComponent:appNameString];
+
+    NSError *error = nil;
+    if (![fileManager fileExistsAtPath:appSpecificDir]) {
+        if (![fileManager createDirectoryAtPath:appSpecificDir withIntermediateDirectories:NO attributes:Nil error:&error]) {
+            NSLog(@"Error creating directory: %@", error);
+        }
+    }
+}
+
 const char * FolderManager::getMainBundlePath() {
     NSString *bundlePath = [[NSBundle mainBundle] resourcePath];
     return [bundlePath UTF8String];


### PR DESCRIPTION
… for it

LUS does not deliberately create the bundleID directory before first use, which can cause problems when trying to do something like make a call to std::filesystem::directory_iterator to a non-existent path. This will ensure com.shipofharkinian.soh in Ship will be created ahead of trying to search it during OTR generation or ROM extraction.

This is essentially the same as the patch I showed in https://github.com/HarbourMasters/Shipwright/issues/6402, except with a nullptr check.