### PR TITLE
Texture handling overhaul, cache stability fixes, and backend improvements

### DIFF
--- a/include/fast/backends/gfx_direct3d_common.h
+++ b/include/fast/backends/gfx_direct3d_common.h
@@ -155,7 +155,7 @@ class GfxRenderingAPIDX11 final : public GfxRenderingAPI {
 
     std::vector<struct TextureData> mTextures;
     int mCurrentTile;
-    uint32_t mCurrentTextureIds[SHADER_MAX_TEXTURES];
+    uint32_t mCurrentTextureIds[SHADER_MAX_TEXTURES]{};
 
     std::vector<FramebufferDX11> mFrameBuffers;
 

--- a/include/fast/backends/gfx_direct3d_common.h
+++ b/include/fast/backends/gfx_direct3d_common.h
@@ -176,6 +176,11 @@ class GfxRenderingAPIDX11 final : public GfxRenderingAPI {
     Microsoft::WRL::ComPtr<ID3D11SamplerState> mLastSamplerStates[SHADER_MAX_TEXTURES] = { nullptr, nullptr };
 
     D3D_PRIMITIVE_TOPOLOGY mLastPrimitaveTopology = D3D_PRIMITIVE_TOPOLOGY_UNDEFINED;
+
+    // Cached staging texture for ReadFramebufferToCPU — avoids CreateTexture2D/Release per frame
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> mReadbackStaging;
+    uint32_t mReadbackStagingW = 0;
+    uint32_t mReadbackStagingH = 0;
 };
 
 std::string gfx_direct3d_common_build_shader(size_t& numFloats, const CCFeatures& cc_features,

--- a/include/fast/backends/gfx_opengl.h
+++ b/include/fast/backends/gfx_opengl.h
@@ -107,7 +107,7 @@ class GfxRenderingAPIOGL final : public GfxRenderingAPI {
     void SetPerDrawUniforms();
 
     std::vector<TextureInfo> textures;
-    GLuint mCurrentTextureIds[SHADER_MAX_TEXTURES];
+    GLuint mCurrentTextureIds[SHADER_MAX_TEXTURES]{};
     GLuint mLastBoundTextures[SHADER_MAX_TEXTURES] = {};
     uint8_t mCurrentTile;
     int8_t mLastActiveTexture = -1;

--- a/include/fast/backends/gfx_opengl.h
+++ b/include/fast/backends/gfx_opengl.h
@@ -89,6 +89,7 @@ class GfxRenderingAPIOGL final : public GfxRenderingAPI {
     void CopyFramebuffer(int fbDstId, int fbSrcId, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0,
                          int dstX1, int dstY1) override;
     void ClearFramebuffer(bool color, bool depth) override;
+    void ClearDepthRegion(int x, int y, int w, int h) override;
     void ReadFramebufferToCPU(int fbId, uint32_t width, uint32_t height, uint16_t* rgba16Buf) override;
     void ResolveMSAAColorBuffer(int fbIdTarger, int fbIdSrc) override;
     std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff>

--- a/include/fast/backends/gfx_rendering_api.h
+++ b/include/fast/backends/gfx_rendering_api.h
@@ -61,6 +61,11 @@ class GfxRenderingAPI {
     virtual void CopyFramebuffer(int fbDstId, int fbSrcId, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0,
                                  int dstY0, int dstX1, int dstY1) = 0;
     virtual void ClearFramebuffer(bool color, bool depth) = 0;
+    virtual void ClearDepthRegion(int x, int y, int w, int h) {
+        // Default: full depth clear. Backends that support scissored depth clears
+        // (e.g. OpenGL) should override for a more precise partial clear.
+        ClearFramebuffer(false, true);
+    }
     virtual void ReadFramebufferToCPU(int fbId, uint32_t width, uint32_t height, uint16_t* rgba16Buf) = 0;
     virtual void ResolveMSAAColorBuffer(int fbIdTarger, int fbIdSrc) = 0;
     virtual std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff>

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -390,6 +390,12 @@ class Interpreter {
     void RegisterBlendedTexture(const char* name, uint8_t* mask, uint8_t* replacement);
     void UnregisterBlendedTexture(const char* name);
 
+    // Register a CPU address as a mirror of a GPU framebuffer texture.
+    // When ImportTexture encounters this address, it uses SelectTextureFb instead
+    // of reading from CPU memory — giving full GPU resolution with no readback.
+    void RegisterFbTexture(const void* cpuAddr, int fbId);
+    void UnregisterFbTexture(const void* cpuAddr);
+
     void SetNativeDimensions(float width, float height);
     void SetResolutionMultiplier(float multiplier);
     void SetMsaaLevel(uint32_t level);
@@ -518,6 +524,7 @@ class Interpreter {
     std::set<std::pair<float, float>> mGetPixelDepthPending; // get_pixel_depth_pending;
     std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff> mGetPixelDepthCached; // get_pixel_depth_cached;
     std::map<std::string, MaskedTextureEntry> mMaskedTextures;
+    std::unordered_map<uintptr_t, int> mFbTextures; // CPU addr -> GPU FB id
 
     const std::unordered_map<Mtx*, MtxF>* mCurMtxReplacements;
     bool mMarkerOn; // This was originally a debug feature. Now it seems to control s2dex?

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -257,6 +257,9 @@ struct RSP {
 
 struct RDP {
     const uint8_t* palettes[2];
+    // Original DRAM source address of the most recent TLUT load per palette half.
+    // Used in texture cache keys instead of palettes[] (which always points to staging).
+    const uint8_t* palette_dram_addr[2];
     // CI4 palette staging buffer: N64 TMEM holds up to 16 CI4 palettes (16 entries x 2 bytes each = 32 bytes per
     // palette). palettes[0] covers indices 0-7 (256 bytes), palettes[1] covers 8-15 (256 bytes). GfxDpLoadTlut copies
     // TLUT data here at the correct offset so multi-palette CI4 models work.

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -257,6 +257,10 @@ struct RSP {
 
 struct RDP {
     const uint8_t* palettes[2];
+    // CI4 palette staging buffer: N64 TMEM holds up to 16 CI4 palettes (16 entries x 2 bytes each = 32 bytes per
+    // palette). palettes[0] covers indices 0-7 (256 bytes), palettes[1] covers 8-15 (256 bytes). GfxDpLoadTlut copies
+    // TLUT data here at the correct offset so multi-palette CI4 models work.
+    uint8_t palette_staging[2][256];
     struct {
         const uint8_t* addr;
         uint8_t siz;

--- a/src/fast/Fast3dWindow.cpp
+++ b/src/fast/Fast3dWindow.cpp
@@ -52,6 +52,7 @@ Fast3dWindow::~Fast3dWindow() {
     SPDLOG_DEBUG("destruct fast3dwindow");
     mInterpreter->Destroy();
     delete mRenderingApi;
+    mWindowManagerApi->Destroy();
     delete mWindowManagerApi;
 }
 

--- a/src/fast/Fast3dWindow.cpp
+++ b/src/fast/Fast3dWindow.cpp
@@ -52,7 +52,6 @@ Fast3dWindow::~Fast3dWindow() {
     SPDLOG_DEBUG("destruct fast3dwindow");
     mInterpreter->Destroy();
     delete mRenderingApi;
-    mWindowManagerApi->Destroy();
     delete mWindowManagerApi;
 }
 

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -712,6 +712,10 @@ void GfxRenderingAPIDX11::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, siz
 
     for (int i = 0; i < SHADER_MAX_TEXTURES; i++) {
         if (mShaderProgram->usedTextures[i]) {
+            // Guard against stale/invalid texture IDs
+            if (mCurrentTextureIds[i] >= mTextures.size()) {
+                continue;
+            }
             if (mLastResourceViews[i].Get() != mTextures[mCurrentTextureIds[i]].resource_view.Get()) {
                 mLastResourceViews[i] = mTextures[mCurrentTextureIds[i]].resource_view.Get();
                 mContext->PSSetShaderResources(i, 1, mTextures[mCurrentTextureIds[i]].resource_view.GetAddressOf());

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -1025,34 +1025,37 @@ void GfxRenderingAPIDX11::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32
     D3D11_TEXTURE2D_DESC srcDesc;
     td.texture->GetDesc(&srcDesc);
 
-    ID3D11Texture2D* staging = nullptr;
+    // Reuse cached staging texture when dimensions match — avoids per-frame CreateTexture2D
+    if (!mReadbackStaging || mReadbackStagingW != srcDesc.Width || mReadbackStagingH != srcDesc.Height) {
+        mReadbackStaging.Reset();
 
-    // Create staging texture matching the SOURCE texture dimensions
-    D3D11_TEXTURE2D_DESC texture_desc;
-    texture_desc.Width = srcDesc.Width;
-    texture_desc.Height = srcDesc.Height;
-    texture_desc.Usage = D3D11_USAGE_STAGING;
-    texture_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    texture_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-    texture_desc.BindFlags = 0;
-    texture_desc.MiscFlags = 0;
-    texture_desc.ArraySize = 1;
-    texture_desc.MipLevels = 1;
-    texture_desc.SampleDesc.Count = 1;
-    texture_desc.SampleDesc.Quality = 0;
+        D3D11_TEXTURE2D_DESC texture_desc;
+        texture_desc.Width = srcDesc.Width;
+        texture_desc.Height = srcDesc.Height;
+        texture_desc.Usage = D3D11_USAGE_STAGING;
+        texture_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        texture_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+        texture_desc.BindFlags = 0;
+        texture_desc.MiscFlags = 0;
+        texture_desc.ArraySize = 1;
+        texture_desc.MipLevels = 1;
+        texture_desc.SampleDesc.Count = 1;
+        texture_desc.SampleDesc.Quality = 0;
 
-    ThrowIfFailed(mDevice->CreateTexture2D(&texture_desc, nullptr, &staging));
+        ThrowIfFailed(mDevice->CreateTexture2D(&texture_desc, nullptr, mReadbackStaging.GetAddressOf()));
+        mReadbackStagingW = srcDesc.Width;
+        mReadbackStagingH = srcDesc.Height;
+    }
 
     // Copy the framebuffer texture to the staging texture
-    mContext->CopyResource(staging, td.texture.Get());
+    mContext->CopyResource(mReadbackStaging.Get(), td.texture.Get());
 
     // Map the staging texture to a resource that we can read
     D3D11_MAPPED_SUBRESOURCE resource = {};
-    ThrowIfFailed(mContext->Map(staging, 0, D3D11_MAP_READ, 0, &resource));
+    ThrowIfFailed(mContext->Map(mReadbackStaging.Get(), 0, D3D11_MAP_READ, 0, &resource));
 
     if (!resource.pData) {
-        mContext->Unmap(staging, 0);
-        staging->Release();
+        mContext->Unmap(mReadbackStaging.Get(), 0);
         return;
     }
 
@@ -1073,9 +1076,7 @@ void GfxRenderingAPIDX11::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32
         }
     }
 
-    // Cleanup
-    mContext->Unmap(staging, 0);
-    staging->Release();
+    mContext->Unmap(mReadbackStaging.Get(), 0);
 }
 
 void GfxRenderingAPIDX11::SetTextureFilter(FilteringMode mode) {

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -1017,12 +1017,16 @@ void GfxRenderingAPIDX11::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32
     FramebufferDX11& fb = mFrameBuffers[fb_id];
     TextureData& td = mTextures[fb.texture_id];
 
+    // Query actual texture dimensions — CopyResource requires matching sizes
+    D3D11_TEXTURE2D_DESC srcDesc;
+    td.texture->GetDesc(&srcDesc);
+
     ID3D11Texture2D* staging = nullptr;
 
-    // Create an staging texture with cpu read access
+    // Create staging texture matching the SOURCE texture dimensions
     D3D11_TEXTURE2D_DESC texture_desc;
-    texture_desc.Width = width;
-    texture_desc.Height = height;
+    texture_desc.Width = srcDesc.Width;
+    texture_desc.Height = srcDesc.Height;
     texture_desc.Usage = D3D11_USAGE_STAGING;
     texture_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
     texture_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
@@ -1043,22 +1047,18 @@ void GfxRenderingAPIDX11::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32
     ThrowIfFailed(mContext->Map(staging, 0, D3D11_MAP_READ, 0, &resource));
 
     if (!resource.pData) {
+        staging->Release();
         return;
     }
 
-    // Copy the mapped values to a temp array that we can process later
-    uint32_t* temp = new uint32_t[width * height]();
-    for (size_t i = 0; i < height; i++) {
-        memcpy((uint8_t*)temp + (resource.RowPitch * i), (uint8_t*)resource.pData + (resource.RowPitch * i),
-               resource.RowPitch);
-    }
-
-    mContext->Unmap(staging, 0);
-
-    // Convert the RGBA32 values to RGBA16
-    for (size_t i = 0; i < width; i++) {
-        for (size_t j = 0; j < height; j++) {
-            uint32_t pixel = temp[i + (j * width)];
+    // Convert RGBA32 → RGBA16 with nearest-neighbor scaling from actual texture
+    // dimensions to requested output dimensions, respecting RowPitch for row stride
+    for (uint32_t j = 0; j < height; j++) {
+        uint32_t srcY = j * srcDesc.Height / height;
+        uint8_t* srcRow = (uint8_t*)resource.pData + srcY * resource.RowPitch;
+        for (uint32_t i = 0; i < width; i++) {
+            uint32_t srcX = i * srcDesc.Width / width;
+            uint32_t pixel = ((uint32_t*)srcRow)[srcX];
             uint8_t r = (((pixel & 0xFF) + 4) * 0x1F) / 0xFF;
             uint8_t g = ((((pixel >> 8) & 0xFF) + 4) * 0x1F) / 0xFF;
             uint8_t b = ((((pixel >> 16) & 0xFF) + 4) * 0x1F) / 0xFF;
@@ -1069,10 +1069,8 @@ void GfxRenderingAPIDX11::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32
     }
 
     // Cleanup
+    mContext->Unmap(staging, 0);
     staging->Release();
-    staging = nullptr;
-
-    delete[] temp;
 }
 
 void GfxRenderingAPIDX11::SetTextureFilter(FilteringMode mode) {

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -1051,6 +1051,7 @@ void GfxRenderingAPIDX11::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32
     ThrowIfFailed(mContext->Map(staging, 0, D3D11_MAP_READ, 0, &resource));
 
     if (!resource.pData) {
+        mContext->Unmap(staging, 0);
         staging->Release();
         return;
     }

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -727,8 +727,8 @@ void GfxRenderingAPIDX11::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, siz
                     mLastSamplerStates[i] = mTextures[mCurrentTextureIds[i]].sampler_state.Get();
                 }
             }
+            mContext->PSSetSamplers(i, 1, mTextures[mCurrentTextureIds[i]].sampler_state.GetAddressOf());
         }
-        mContext->PSSetSamplers(i, 1, mTextures[mCurrentTextureIds[i]].sampler_state.GetAddressOf());
     }
 
     // Set per-draw constant buffer

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -547,6 +547,10 @@ static D3D11_TEXTURE_ADDRESS_MODE gfx_cm_to_d3d11(uint32_t val) {
 }
 
 void GfxRenderingAPIDX11::UploadTexture(const uint8_t* rgba32_buf, uint32_t width, uint32_t height) {
+    if (width == 0 || height == 0) {
+        return;
+    }
+
     // Create texture
 
     TextureData* texture_data = &mTextures[mCurrentTextureIds[mCurrentTile]];

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -357,7 +357,10 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
     char fileName[256];
     Ship::WindowEvent event_impl;
     event_impl.Win32 = { h_wnd, static_cast<int>(message), static_cast<int>(w_param), static_cast<int>(l_param) };
-    Ship::Context::GetInstance()->GetWindow()->GetGui()->HandleWindowEvents(event_impl);
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
+        ctx->GetWindow()->GetGui()->HandleWindowEvents(event_impl);
+    }
     std::tuple<HMONITOR, RECT, BOOL> newMonitor;
     GfxWindowBackendDXGI* self = reinterpret_cast<GfxWindowBackendDXGI*>(GetWindowLongPtr(h_wnd, GWLP_USERDATA));
     switch (message) {

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -952,7 +952,8 @@ void GfxWindowBackendDXGI::SwapBuffersEnd() {
 
     QueryPerformanceCounter(&t2);
 
-    mZeroLatency = mPendingFrameStats.rbegin()->first == stats.PresentCount;
+    mZeroLatency =
+        !mPendingFrameStats.empty() && mPendingFrameStats.rbegin()->first == stats.PresentCount;
 
     // printf(L"done %I64u gpu:%d wait:%d freed:%I64u frame:%u %u monitor:%u t:%I64u\n", (unsigned long
     // long)(t0.QuadPart - qpc_init), (int)(t1.QuadPart - t0.QuadPart), (int)(t2.QuadPart - t0.QuadPart), (unsigned
@@ -1068,7 +1069,12 @@ bool GfxWindowBackendDXGI::CanDisableVsync() {
 }
 
 void GfxWindowBackendDXGI::Destroy() {
-    // TODO: destroy _any_ resources used by dxgi, including the window handle
+    // Iteratively clear frame-stat containers to avoid MSVC's recursive _Erase_tree
+    // stack overflow on deep std::set/std::map trees during destruction.
+    while (!mPendingFrameStats.empty()) {
+        mPendingFrameStats.erase(mPendingFrameStats.begin());
+    }
+    mFrameStats.clear();
 }
 
 bool GfxWindowBackendDXGI::IsFullscreen() {

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -499,8 +499,10 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
             }
             break;
         case WM_KILLFOCUS:
-            if (!Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_ALLOW_BACKGROUND_INPUTS, 1)) {
-                ControllerBlockGameInput(ALLOW_BACKGROUND_INPUTS_BLOCK_ID);
+            if (auto ctx = Ship::Context::GetInstance(); ctx && ctx->GetConsoleVariables()) {
+                if (!ctx->GetConsoleVariables()->GetInteger(CVAR_ALLOW_BACKGROUND_INPUTS, 1)) {
+                    ControllerBlockGameInput(ALLOW_BACKGROUND_INPUTS_BLOCK_ID);
+                }
             }
             self->mInFocus = false;
             break;

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -957,8 +957,7 @@ void GfxWindowBackendDXGI::SwapBuffersEnd() {
 
     QueryPerformanceCounter(&t2);
 
-    mZeroLatency =
-        !mPendingFrameStats.empty() && mPendingFrameStats.rbegin()->first == stats.PresentCount;
+    mZeroLatency = !mPendingFrameStats.empty() && mPendingFrameStats.rbegin()->first == stats.PresentCount;
 
     // printf(L"done %I64u gpu:%d wait:%d freed:%I64u frame:%u %u monitor:%u t:%I64u\n", (unsigned long
     // long)(t0.QuadPart - qpc_init), (int)(t1.QuadPart - t0.QuadPart), (int)(t2.QuadPart - t0.QuadPart), (unsigned

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -320,6 +320,10 @@ void GfxRenderingAPIMetal::SelectTexture(int tile, uint32_t texture_id) {
 }
 
 void GfxRenderingAPIMetal::UploadTexture(const uint8_t* rgba32_buf, uint32_t width, uint32_t height) {
+    if (width == 0 || height == 0) {
+        return;
+    }
+
     TextureDataMetal* texture_data = &mTextures[mCurrentTextureIds[mCurrentTile]];
 
     NS::AutoreleasePool* autorelease_pool = NS::AutoreleasePool::alloc()->init();

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -1116,40 +1116,35 @@ void GfxRenderingAPIMetal::GfxRenderingAPIMetal::ReadFramebufferToCPU(int fb_id,
     auto command_buffer = mCommandQueue->commandBuffer();
     command_buffer->setLabel(NS::String::string("Read Pixels Shader Command Buffer", NS::UTF8StringEncoding));
 
-    NS::Error* error = nullptr;
-    MTL::ComputePipelineState* compute_pipeline_state =
-        mDevice->newComputePipelineState(mConvertToRgb5a1Function, &error);
-
     // Use a compute encoder to convert the pixel data to rgba16 and transfer to a cpu readable buffer
+    NS::Error* pso_error = nullptr;
+    MTL::ComputePipelineState* convert_pipeline = mDevice->newComputePipelineState(mConvertToRgb5a1Function, &pso_error);
     MTL::ComputeCommandEncoder* compute_encoder = command_buffer->computeCommandEncoder();
-    compute_encoder->setComputePipelineState(compute_pipeline_state);
+    compute_encoder->setComputePipelineState(convert_pipeline);
     compute_encoder->setTexture(texture, 0);
     compute_encoder->setBuffer(output_buffer, 0, 0);
 
-    // Use a thread group size and count that covers the whole copy area
-    MTL::Size thread_group_size = MTL::Size::Make(1, 1, 1);
-    MTL::Size thread_group_count = MTL::Size::Make(width, height, 1);
+    MTL::Size thread_group_size = MTL::Size::Make(8, 8, 1);
+    MTL::Size total_threads = MTL::Size::Make(width, height, 1);
 
-    // We validate if the device supports non-uniform threadgroup sizes
     if (mNonUniformThreadgroupSupported) {
-        compute_encoder->dispatchThreads(thread_group_count, thread_group_size);
+        compute_encoder->dispatchThreads(total_threads, thread_group_size);
     } else {
+        MTL::Size thread_group_count = MTL::Size::Make((width + 7) / 8, (height + 7) / 8, 1);
         compute_encoder->dispatchThreadgroups(thread_group_count, thread_group_size);
     }
     compute_encoder->endEncoding();
 
-    // Use a completion handler to wait for the GPU to be done without blocking the thread
-    command_buffer->addCompletedHandler([=](MTL::CommandBuffer* cmd_buffer) {
-        // Now the converted pixel values can be copied from the buffer
-        uint16_t* values = (uint16_t*)output_buffer->contents();
-        memcpy(rgba16_buf, values, sizeof(uint16_t) * width * height);
-
-        output_buffer->release();
-    });
-
+    // Block until the GPU finishes — the caller expects rgba16_buf to be
+    // filled when this function returns (same as OpenGL's glReadPixels).
     command_buffer->commit();
+    command_buffer->waitUntilCompleted();
 
-    compute_pipeline_state->release();
+    uint16_t* values = (uint16_t*)output_buffer->contents();
+    memcpy(rgba16_buf, values, sizeof(uint16_t) * width * height);
+
+    output_buffer->release();
+    convert_pipeline->release();
     autorelease_pool->release();
 }
 

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -1118,7 +1118,8 @@ void GfxRenderingAPIMetal::GfxRenderingAPIMetal::ReadFramebufferToCPU(int fb_id,
 
     // Use a compute encoder to convert the pixel data to rgba16 and transfer to a cpu readable buffer
     NS::Error* pso_error = nullptr;
-    MTL::ComputePipelineState* convert_pipeline = mDevice->newComputePipelineState(mConvertToRgb5a1Function, &pso_error);
+    MTL::ComputePipelineState* convert_pipeline =
+        mDevice->newComputePipelineState(mConvertToRgb5a1Function, &pso_error);
     MTL::ComputeCommandEncoder* compute_encoder = command_buffer->computeCommandEncoder();
     compute_encoder->setComputePipelineState(convert_pipeline);
     compute_encoder->setTexture(texture, 0);

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -834,6 +834,17 @@ void GfxRenderingAPIOGL::ClearFramebuffer(bool color, bool depth) {
     }
 }
 
+void GfxRenderingAPIOGL::ClearDepthRegion(int x, int y, int w, int h) {
+    if (mLastScissorEnabled != 1) {
+        mLastScissorEnabled = 1;
+        glEnable(GL_SCISSOR_TEST);
+    }
+    glScissor(x, y, w, h);
+    glDepthMask(GL_TRUE);
+    glClear(GL_DEPTH_BUFFER_BIT);
+    glDepthMask(mCurrentDepthMask ? GL_TRUE : GL_FALSE);
+}
+
 void GfxRenderingAPIOGL::ResolveMSAAColorBuffer(int fb_id_target, int fb_id_source) {
     FramebufferOGL& fb_dst = mFrameBuffers[fb_id_target];
     FramebufferOGL& fb_src = mFrameBuffers[fb_id_source];

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -943,8 +943,23 @@ void GfxRenderingAPIOGL::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32_
         return;
     }
 
+    // Read as RGBA8 (GL_UNSIGNED_BYTE) then convert to RGBA16 (5551).
+    // GL_RGBA + GL_UNSIGNED_SHORT_5_5_5_1 writes 4 separate u16 components per pixel
+    // (8 bytes) on some drivers (NVIDIA), not the packed 2 bytes the spec implies.
+    // Reading as RGBA8 and converting matches the DX11 path's approach.
     glBindFramebuffer(GL_FRAMEBUFFER, mFrameBuffers[fb_id].fbo);
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_SHORT_5_5_5_1, (void*)rgba16_buf);
+
+    std::vector<uint8_t> rgba8(width * height * 4);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, rgba8.data());
+
+    for (uint32_t i = 0; i < width * height; i++) {
+        uint8_t r = (rgba8[i * 4 + 0] >> 3) & 0x1F;
+        uint8_t g = (rgba8[i * 4 + 1] >> 3) & 0x1F;
+        uint8_t b = (rgba8[i * 4 + 2] >> 3) & 0x1F;
+        uint8_t a = rgba8[i * 4 + 3] ? 1 : 0;
+        rgba16_buf[i] = (r << 11) | (g << 6) | (b << 1) | a;
+    }
+
     glBindFramebuffer(GL_FRAMEBUFFER, mFrameBuffers[mCurrentFrameBuffer].fbo);
 }
 

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -551,6 +551,9 @@ void GfxRenderingAPIOGL::SelectTexture(int tile, GLuint texture_id) {
 }
 
 void GfxRenderingAPIOGL::UploadTexture(const uint8_t* rgba32_buf, uint32_t width, uint32_t height) {
+    if (width == 0 || height == 0) {
+        return;
+    }
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba32_buf);
     textures[mCurrentTextureIds[mCurrentTile]].width = width;
     textures[mCurrentTextureIds[mCurrentTile]].height = height;

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -863,7 +863,14 @@ void* GfxRenderingAPIOGL::GetFramebufferTextureId(int fb_id) {
 void GfxRenderingAPIOGL::SelectTextureFb(int fb_id) {
     // glDisable(GL_DEPTH_TEST);
     int tile = 0;
-    SelectTexture(tile, mFrameBuffers[fb_id].clrbuf);
+    GLuint texId = mFrameBuffers[fb_id].clrbuf;
+    // Ensure the textures metadata vector can hold this FB texture handle.
+    // FB color buffers are created outside NewTexture(), so the vector may
+    // not have been resized for them yet.
+    if (texId >= textures.size()) {
+        textures.resize((size_t)texId + 1);
+    }
+    SelectTexture(tile, texId);
 }
 
 void GfxRenderingAPIOGL::CopyFramebuffer(int fb_dst_id, int fb_src_id, int srcX0, int srcY0, int srcX1, int srcY1,

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1123,6 +1123,18 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
             ? mMaskedTextures.find(GetBaseTexturePath(metadata->resource->GetInitData()->Path))->second.replacementData
             : mRdp->loaded_texture[tmemIdex].addr;
 
+    // Check if this texture address is a registered GPU framebuffer mirror.
+    // If so, bind the GPU FB directly — full resolution, no CPU readback needed.
+    if (origAddr != nullptr && !importReplacement) {
+        auto fbIt = mFbTextures.find((uintptr_t)origAddr);
+        if (fbIt != mFbTextures.end()) {
+            Flush();
+            mRapi->SelectTextureFb(fbIt->second);
+            mRdp->textures_changed[i] = false;
+            return;
+        }
+    }
+
     if (origAddr == nullptr) {
         // Tile has no texture loaded
         // Fall back to the other TMEM slot so multi-tile rendering still works
@@ -4557,6 +4569,14 @@ void Interpreter::SpReset() {
     CalculateNormalDir(&mRsp->lookat[1], mRsp->current_lookat_coeffs[1]);
 }
 
+void Interpreter::RegisterFbTexture(const void* cpuAddr, int fbId) {
+    mFbTextures[(uintptr_t)cpuAddr] = fbId;
+}
+
+void Interpreter::UnregisterFbTexture(const void* cpuAddr) {
+    mFbTextures.erase((uintptr_t)cpuAddr);
+}
+
 void Interpreter::GetDimensions(uint32_t* width, uint32_t* height, int32_t* posX, int32_t* posY) {
     mWapi->GetDimensions(width, height, posX, posY);
 }
@@ -5082,4 +5102,12 @@ extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height, uint32_t 
 
 extern "C" void gfx_texture_cache_clear() {
     Fast::mInstance.lock().get()->TextureCacheClear();
+}
+
+extern "C" void gfx_register_fb_texture(const void* cpuAddr, int fbId) {
+    Fast::mInstance.lock().get()->RegisterFbTexture(cpuAddr, fbId);
+}
+
+extern "C" void gfx_unregister_fb_texture(const void* cpuAddr) {
+    Fast::mInstance.lock().get()->UnregisterFbTexture(cpuAddr);
 }

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -562,11 +562,51 @@ void Interpreter::ImportTextureRgba32(int tile, bool importReplacement) {
     uint32_t full_image_line_size_bytes =
         mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t line_size_bytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
-    SUPPORT_CHECK(full_image_line_size_bytes == line_size_bytes);
+    // Some font glyphs use gDPLoadTextureTile with w (data stride) != x (visible width).
+    // This is valid N64 behavior (sub-tile load from larger image). Original assert was too strict.
+    // SUPPORT_CHECK(full_image_line_size_bytes == line_size_bytes);
 
-    uint32_t width = mRdp->texture_tile[tile].line_size_bytes / 2;
-    uint32_t height = (size_bytes / 2) / mRdp->texture_tile[tile].line_size_bytes;
-    mRapi->UploadTexture(addr, width, height);
+    // Use loaded_texture DRAM stride (4 bytes/pixel for RGBA32), not the TMEM-interleaved
+    // texture_tile line_size (which uses G_IM_SIZ_32b_LINE_BYTES=2). Match ImportTextureRgba16 pattern.
+    uint32_t widthBytes;
+    if (line_size_bytes != size_bytes && line_size_bytes > 0) {
+        widthBytes = line_size_bytes;
+    } else {
+        // Fallback: texture_tile stores TMEM-halved stride for RGBA32, so double it
+        widthBytes = mRdp->texture_tile[tile].line_size_bytes * 2;
+    }
+    uint32_t width = widthBytes / 4; // RGBA32: 4 bytes per pixel
+    uint32_t height = widthBytes > 0 ? size_bytes / widthBytes : 0;
+
+    // Clamp to tile dimensions from SetTileSize
+    uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
+    uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+    if (tile_w > 0 && tile_w < width) {
+        width = tile_w;
+    }
+    if (tile_h > 0 && tile_h < height) {
+        height = tile_h;
+    }
+
+    // A single line of pixels should not equal the entire image
+    if (full_image_line_size_bytes == size_bytes) {
+        full_image_line_size_bytes = width * 4;
+    }
+
+    // Copy pixel by pixel, respecting full image stride (handles sub-tile loads)
+    uint32_t fullImageStridePixels = full_image_line_size_bytes / 4;
+    uint32_t i = 0;
+    for (uint32_t y = 0; y < height; y++) {
+        for (uint32_t x = 0; x < width; x++) {
+            uint32_t srcIdx = y * fullImageStridePixels + x;
+            mTexUploadBuffer[4 * i + 0] = addr[4 * srcIdx + 0];
+            mTexUploadBuffer[4 * i + 1] = addr[4 * srcIdx + 1];
+            mTexUploadBuffer[4 * i + 2] = addr[4 * srcIdx + 2];
+            mTexUploadBuffer[4 * i + 3] = addr[4 * srcIdx + 3];
+            i++;
+        }
+    }
+    mRapi->UploadTexture(mTexUploadBuffer, width, height);
 }
 
 void Interpreter::ImportTextureIA4(int tile, bool importReplacement) {
@@ -1749,10 +1789,6 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             uint8_t cmt = mRdp->texture_tile[tile].cmt;
 
             uint32_t tex_size_bytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].orig_size_bytes;
-
-            // Use the same line_size as the Import functions for UV normalization.
-            // When loaded_texture has real per-line info, use it. Otherwise fall back
-            // to TMEM stride (texture_tile).
             uint32_t loaded_line_size = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
             uint32_t loaded_size = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].size_bytes;
             uint32_t line_size;
@@ -1760,6 +1796,11 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
                 line_size = loaded_line_size;
             } else {
                 line_size = mRdp->texture_tile[tile].line_size_bytes;
+                // RGBA32: texture_tile stores TMEM-interleaved stride (half of actual DRAM stride).
+                // Normalize to actual DRAM stride so the switch below can uniformly divide by bytes-per-pixel.
+                if (mRdp->texture_tile[tile].siz == G_IM_SIZ_32b) {
+                    line_size *= 2;
+                }
             }
 
             if (line_size == 0) {
@@ -1777,8 +1818,7 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
                     line_size /= G_IM_SIZ_16b_LINE_BYTES;
                     break;
                 case G_IM_SIZ_32b:
-                    line_size /= G_IM_SIZ_32b_LINE_BYTES; // this is 2!
-                    tex_height[i] /= 2;
+                    line_size /= 4; // RGBA32: 4 bytes per pixel (line_size is now actual DRAM stride)
                     break;
             }
             tex_width[i] = line_size;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2837,8 +2837,7 @@ void Interpreter::GfxDpImageRectangle(int32_t tile, int32_t w, int32_t h, int32_
 void Interpreter::GfxDpFillRectangle(int32_t ulx, int32_t uly, int32_t lrx, int32_t lry) {
     if (mRdp->color_image_address == mRdp->z_buf_address) {
         // Fullscreen Z clears are redundant — already done by glClear at frame start.
-        bool isFullScreen = (ulx <= 0 && uly <= 0 &&
-                             lrx >= (int32_t)(mNativeDimensions.width - 1) * 4 &&
+        bool isFullScreen = (ulx <= 0 && uly <= 0 && lrx >= (int32_t)(mNativeDimensions.width - 1) * 4 &&
                              lry >= (int32_t)(mNativeDimensions.height - 1) * 4);
         if (isFullScreen) {
             return;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1126,20 +1126,22 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
     }
 
     // Include palette in cache key when fmt is CI (including TLUT-overridden).
-    // CI4: only include the relevant palette half to avoid spurious cache invalidation.
+    // Use palette_dram_addr (the original DRAM source) instead of palettes[] (which always
+    // points to the staging buffer). This ensures that the same texture drawn with different
+    // palettes produces distinct cache keys.
     TextureCacheKey key;
     if (fmt == G_IM_FMT_CI) {
         if (siz == G_IM_SIZ_4b) {
             uint8_t palSlot = paletteIndex / 8;
             key = { origAddr,
-                    { palSlot == 0 ? mRdp->palettes[0] : nullptr, palSlot == 1 ? mRdp->palettes[1] : nullptr },
+                    { palSlot == 0 ? mRdp->palette_dram_addr[0] : nullptr, palSlot == 1 ? mRdp->palette_dram_addr[1] : nullptr },
                     fmt,
                     siz,
                     paletteIndex,
                     origSizeBytes };
         } else {
             // CI8 uses both palette halves
-            key = { origAddr, { mRdp->palettes[0], mRdp->palettes[1] }, fmt, siz, paletteIndex, origSizeBytes };
+            key = { origAddr, { mRdp->palette_dram_addr[0], mRdp->palette_dram_addr[1] }, fmt, siz, paletteIndex, origSizeBytes };
         }
     } else {
         key = { origAddr, {}, fmt, siz, paletteIndex, origSizeBytes };
@@ -2298,12 +2300,14 @@ void Interpreter::GfxDpLoadTlut(uint8_t tile, uint32_t high_index) {
             uint32_t copyLen = (paletteByteOffset + byteCount <= 256) ? byteCount : (256 - paletteByteOffset);
             memcpy(mRdp->palette_staging[0] + paletteByteOffset, src, copyLen);
             mRdp->palettes[0] = mRdp->palette_staging[0];
+            mRdp->palette_dram_addr[0] = src;
         } else {
             // Palettes 8-15 range
             uint32_t offset = paletteByteOffset - 256;
             uint32_t copyLen = (offset + byteCount <= 256) ? byteCount : (256 - offset);
             memcpy(mRdp->palette_staging[1] + offset, src, copyLen);
             mRdp->palettes[1] = mRdp->palette_staging[1];
+            mRdp->palette_dram_addr[1] = src;
         }
 
         // CI8: full 256-entry palette spanning both halves
@@ -2312,10 +2316,13 @@ void Interpreter::GfxDpLoadTlut(uint8_t tile, uint32_t high_index) {
             memcpy(mRdp->palette_staging[1], src + 256, 256);
             mRdp->palettes[0] = mRdp->palette_staging[0];
             mRdp->palettes[1] = mRdp->palette_staging[1];
+            mRdp->palette_dram_addr[0] = src;
+            mRdp->palette_dram_addr[1] = src + 256;
         }
     } else {
         // tmem < 256: non-standard location, fall back to direct pointer
         mRdp->palettes[1] = src;
+        mRdp->palette_dram_addr[1] = src;
     }
 }
 

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1803,15 +1803,18 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             uint8_t cms = mRdp->texture_tile[tile].cms;
             uint8_t cmt = mRdp->texture_tile[tile].cmt;
 
-            uint32_t tex_size_bytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].orig_size_bytes;
             uint32_t loaded_line_size = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
             uint32_t loaded_size = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].size_bytes;
             uint32_t loaded_full_line = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes;
+            uint32_t tex_size_bytes;
             uint32_t line_size;
             if ((loaded_line_size != loaded_size || loaded_full_line != loaded_size) && loaded_line_size > 0) {
+                // Use loaded sizes together — they're consistently scaled (e.g. HD replacements).
                 line_size = loaded_line_size;
+                tex_size_bytes = loaded_size;
             } else {
                 line_size = mRdp->texture_tile[tile].line_size_bytes;
+                tex_size_bytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].orig_size_bytes;
                 // RGBA32: texture_tile stores TMEM-interleaved stride (half of actual DRAM stride).
                 // Normalize to actual DRAM stride so the switch below can uniformly divide by bytes-per-pixel.
                 if (mRdp->texture_tile[tile].siz == G_IM_SIZ_32b) {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1739,6 +1739,15 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
         use_alpha = true;
     }
 
+    // N64 coverage simulation: When ALPHA_CVG_SEL is set, the RDP blender uses
+    // coverage as its alpha input instead of the combiner output. On N64, coverage
+    // for textured pixels is derived from texture alpha — zero-alpha texels produce
+    // zero coverage and are never written, regardless of OPA/XLU blender mode.
+    if (!use_alpha && (mRdp->other_mode_l & ALPHA_CVG_SEL)) {
+        use_alpha = true;
+        alpha_threshold = true;
+    }
+
     if (use_alpha) {
         cc_options |= SHADER_OPT(ALPHA);
     }

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1410,7 +1410,10 @@ void Interpreter::GfxSpPopMatrix(uint32_t count) {
 }
 
 float Interpreter::AdjXForAspectRatio(float x) const {
-    if (mFbActive) {
+    // Skip widescreen adjustment for fixed-size off-screen FBs (HUD elements,
+    // small capture buffers). But resizable FBs (resize=true) are capturing
+    // the main scene and should match the window's aspect ratio.
+    if (mFbActive && mActiveFrameBuffer != mFrameBuffers.end() && !mActiveFrameBuffer->second.resize) {
         return x;
     } else {
         return x * (4.0f / 3.0f) / ((float)mCurDimensions.width / (float)mCurDimensions.height);

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2813,8 +2813,15 @@ void Interpreter::GfxDpImageRectangle(int32_t tile, int32_t w, int32_t h, int32_
 
 void Interpreter::GfxDpFillRectangle(int32_t ulx, int32_t uly, int32_t lrx, int32_t lry) {
     if (mRdp->color_image_address == mRdp->z_buf_address) {
-        // Don't clear Z buffer here since we already did it with glClear
-        return;
+        // Fullscreen Z clears are redundant — already done by glClear at frame start.
+        // But partial Z clears (e.g. HUD model scissor regions) must go through so
+        // overlay models can use DEPTH_FULL without clipping behind world geometry.
+        bool isFullScreen = (ulx <= 0 && uly <= 0 &&
+                             lrx >= (int32_t)(mNativeDimensions.width - 1) * 4 &&
+                             lry >= (int32_t)(mNativeDimensions.height - 1) * 4);
+        if (isFullScreen) {
+            return;
+        }
     }
     uint32_t mode = (mRdp->other_mode_h & (3U << G_MDSFT_CYCLETYPE));
 

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -411,6 +411,9 @@ void Interpreter::TextureCacheClear() {
     }
     mTextureCache.map.clear();
     mTextureCache.lru.clear();
+    // Pre-allocate buckets so the map never rehashes during normal operation.
+    // Rehashing invalidates all iterators, including those stored in LRU entries.
+    mTextureCache.map.reserve(TEXTURE_CACHE_MAX_SIZE);
 }
 
 bool Interpreter::TextureCacheLookup(int i, const TextureCacheKey& key) {
@@ -4566,6 +4569,9 @@ void Interpreter::Init(class GfxWindowBackend* wapi, class GfxRenderingAPI* rapi
     }
 
     ucode_handler_index = UcodeHandlers::ucode_f3dex2;
+
+    // Pre-allocate texture cache buckets to prevent rehash-induced iterator invalidation.
+    mTextureCache.map.reserve(TEXTURE_CACHE_MAX_SIZE);
 }
 
 void Interpreter::Destroy() {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -4501,12 +4501,13 @@ static void gfx_step() {
     }
 
     if (otrHandlers.contains(opcode)) {
-        // OTR filepath handlers expect w1 to be a valid __OTR__ string pointer.
-        // If w1 is not a valid OTR path, skip to avoid crashing in strlen/strncmp.
+        // OTR filepath handlers expect w1 to be a valid string pointer (bare path or __OTR__ path).
+        // Guard against null/N64-segment addresses to avoid crashing in strlen/strncmp.
         if (opcode == OTR_G_VTX_OTR_FILEPATH || opcode == OTR_G_SETTIMG_OTR_FILEPATH ||
             opcode == OTR_G_DL_OTR_FILEPATH || opcode == OTR_G_PUSHCD || opcode == OTR_G_MTX_OTR_FILEPATH ||
             opcode == OTR_G_LOAD_SHADER) {
-            if (!gfx_check_image_signature((const char*)cmd->words.w1)) {
+            uintptr_t w1 = (uintptr_t)cmd->words.w1;
+            if (w1 < 0x10000 || w1 > 0x00007FFFFFFFFFFFull) {
                 ++g_exec_stack.currCmd();
                 return;
             }
@@ -4927,8 +4928,8 @@ int32_t gfx_check_image_signature(const char* imgData) {
         return 0;
     }
 #if UINTPTR_MAX > 0xFFFFFFFFu
-    // On 64-bit: filter truncated 32-bit pointers AND kernel/sentinel addresses
-    if (i < 0x100000000ull || i > 0x00007FFFFFFFFFFFull) {
+    // Filter kernel/sentinel addresses
+    if (i > 0x00007FFFFFFFFFFFull) {
         return 0;
     }
 #endif

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -414,6 +414,8 @@ void Interpreter::TextureCacheClear() {
     // Pre-allocate buckets so the map never rehashes during normal operation.
     // Rehashing invalidates all iterators, including those stored in LRU entries.
     mTextureCache.map.reserve(TEXTURE_CACHE_MAX_SIZE);
+    // Null rendering-state pointers — they pointed into map nodes that are now freed.
+    std::fill(std::begin(mRenderingState.mTextures), std::end(mRenderingState.mTextures), nullptr);
 }
 
 bool Interpreter::TextureCacheLookup(int i, const TextureCacheKey& key) {
@@ -432,6 +434,10 @@ bool Interpreter::TextureCacheLookup(int i, const TextureCacheKey& key) {
         // Remove the texture that was least recently used
         it = mTextureCache.lru.front().it;
         mTextureCache.free_texture_ids.push_back(it->second.texture_id);
+        for (int j = 0; j < SHADER_MAX_TEXTURES; j++) {
+            if (mRenderingState.mTextures[j] == &*it)
+                mRenderingState.mTextures[j] = nullptr;
+        }
         mTextureCache.map.erase(it);
         mTextureCache.lru.pop_front();
     }
@@ -470,6 +476,10 @@ void Interpreter::TextureCacheDelete(const uint8_t* origAddr) {
         bool again = false;
         for (auto it = mTextureCache.map.begin(bucket); it != mTextureCache.map.end(bucket); ++it) {
             if (it->first.texture_addr == origAddr) {
+                for (int j = 0; j < SHADER_MAX_TEXTURES; j++) {
+                    if (mRenderingState.mTextures[j] == &*it)
+                        mRenderingState.mTextures[j] = nullptr;
+                }
                 mTextureCache.lru.erase(it->second.lru_location);
                 mTextureCache.free_texture_ids.push_back(it->second.texture_id);
                 mTextureCache.map.erase(it->first);

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2791,12 +2791,17 @@ void Interpreter::GfxDpFillRectangle(int32_t ulx, int32_t uly, int32_t lrx, int3
     }
     uint32_t mode = (mRdp->other_mode_h & (3U << G_MDSFT_CYCLETYPE));
 
-    // OTRTODO: This is a bit of a hack for widescreen screen fades, but it'll work for now...
-    if (ulx == 0 && uly == 0 && lrx == (319 * 4) && lry == (239 * 4)) {
-        ulx = -1024;
-        uly = -1024;
-        lrx = 2048;
-        lry = 2048;
+    // Expand fullscreen fill rects to cover widescreen viewports.
+    // Without this, screen clears and fades only cover the native 4:3 area.
+    if (ulx == 0 && uly == 0) {
+        bool isFullScreen = (lrx == ((int32_t)(mNativeDimensions.width - 1) * 4) &&
+                             lry == ((int32_t)(mNativeDimensions.height - 1) * 4));
+        if (isFullScreen) {
+            ulx = -1024;
+            uly = -1024;
+            lrx = 2048;
+            lry = 2048;
+        }
     }
 
     if (mode == G_CYC_COPY || mode == G_CYC_FILL) {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -497,8 +497,26 @@ void Interpreter::ImportTextureRgba16(int tile, bool importReplacement) {
         mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t line_size_bytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
 
-    uint32_t width = mRdp->texture_tile[tile].line_size_bytes / 2;
-    uint32_t height = sizeBytes / mRdp->texture_tile[tile].line_size_bytes;
+    // Prefer the per-line DRAM stride when available, as TMEM tile line size
+    // is 8-byte aligned and may overstate the actual pixel width.
+    uint32_t widthBytes;
+    if (line_size_bytes != sizeBytes && line_size_bytes > 0) {
+        widthBytes = line_size_bytes;
+    } else {
+        widthBytes = mRdp->texture_tile[tile].line_size_bytes;
+    }
+    uint32_t width = widthBytes / 2;
+    uint32_t height = widthBytes > 0 ? sizeBytes / widthBytes : 0;
+
+    // Clamp to tile dimensions from SetTileSize (mipmap pyramids include all levels).
+    uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
+    uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+    if (tile_w > 0 && tile_w < width) {
+        width = tile_w;
+    }
+    if (tile_h > 0 && tile_h < height) {
+        height = tile_h;
+    }
 
     // A single line of pixels should not equal the entire image (height == 1 non-withstanding)
     if (fullImageLineSizeBytes == sizeBytes) {
@@ -567,24 +585,36 @@ void Interpreter::ImportTextureIA4(int tile, bool importReplacement) {
     uint32_t fullImageLineSizeBytes =
         mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t lineSizeBytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
-    SUPPORT_CHECK(fullImageLineSizeBytes == lineSizeBytes);
 
-    for (uint32_t i = 0; i < sizeBytes * 2; i++) {
-        uint8_t byte = addr[i / 2];
-        uint8_t part = (byte >> (4 - (i % 2) * 4)) & 0xf;
-        uint8_t intensity = part >> 1;
-        uint8_t alpha = part & 1;
-        uint8_t r = intensity;
-        uint8_t g = intensity;
-        uint8_t b = intensity;
-        mTexUploadBuffer[4 * i + 0] = SCALE_3_8(r);
-        mTexUploadBuffer[4 * i + 1] = SCALE_3_8(g);
-        mTexUploadBuffer[4 * i + 2] = SCALE_3_8(b);
-        mTexUploadBuffer[4 * i + 3] = alpha ? 255 : 0;
+    // IA4: 2 pixels per byte, so width in pixels = line_size_bytes * 2
+    uint32_t widthBytes;
+    if (lineSizeBytes != sizeBytes && lineSizeBytes > 0) {
+        widthBytes = lineSizeBytes;
+    } else {
+        widthBytes = mRdp->texture_tile[tile].line_size_bytes;
+    }
+    uint32_t width = widthBytes * 2;
+    uint32_t height = widthBytes > 0 ? sizeBytes / widthBytes : 0;
+
+    if (fullImageLineSizeBytes == sizeBytes) {
+        fullImageLineSizeBytes = widthBytes;
     }
 
-    uint32_t width = mRdp->texture_tile[tile].line_size_bytes * 2;
-    uint32_t height = sizeBytes / mRdp->texture_tile[tile].line_size_bytes;
+    uint32_t i = 0;
+    for (uint32_t y = 0; y < height; y++) {
+        for (uint32_t x = 0; x < width; x++) {
+            uint32_t srcPixelIdx = y * (fullImageLineSizeBytes * 2) + x;
+            uint8_t byte = addr[srcPixelIdx / 2];
+            uint8_t part = (byte >> (4 - (srcPixelIdx % 2) * 4)) & 0xf;
+            uint8_t intensity = part >> 1;
+            uint8_t alpha = part & 1;
+            mTexUploadBuffer[4 * i + 0] = SCALE_3_8(intensity);
+            mTexUploadBuffer[4 * i + 1] = SCALE_3_8(intensity);
+            mTexUploadBuffer[4 * i + 2] = SCALE_3_8(intensity);
+            mTexUploadBuffer[4 * i + 3] = alpha ? 255 : 0;
+            i++;
+        }
+    }
 
     mRapi->UploadTexture(mTexUploadBuffer, width, height);
 }
@@ -605,22 +635,37 @@ void Interpreter::ImportTextureIA8(int tile, bool importReplacement) {
     uint32_t fullImageLineSizeBytes =
         mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t lineSizeBytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
-    SUPPORT_CHECK(fullImageLineSizeBytes == lineSizeBytes);
+    // fullImageLineSizeBytes may differ from lineSizeBytes for sub-texture loads.
+    // The 2D stride-aware loop below handles this, so no assert is needed.
 
-    for (uint32_t i = 0; i < sizeBytes; i++) {
-        uint8_t intensity = addr[i] >> 4;
-        uint8_t alpha = addr[i] & 0xf;
-        uint8_t r = intensity;
-        uint8_t g = intensity;
-        uint8_t b = intensity;
-        mTexUploadBuffer[4 * i + 0] = SCALE_4_8(r);
-        mTexUploadBuffer[4 * i + 1] = SCALE_4_8(g);
-        mTexUploadBuffer[4 * i + 2] = SCALE_4_8(b);
-        mTexUploadBuffer[4 * i + 3] = SCALE_4_8(alpha);
+    uint32_t width, height;
+    if (lineSizeBytes != sizeBytes && lineSizeBytes > 0) {
+        width = lineSizeBytes;
+        height = sizeBytes / lineSizeBytes;
+    } else {
+        width = mRdp->texture_tile[tile].line_size_bytes;
+        height = width > 0 ? sizeBytes / width : 0;
     }
 
-    uint32_t width = mRdp->texture_tile[tile].line_size_bytes;
-    uint32_t height = sizeBytes / mRdp->texture_tile[tile].line_size_bytes;
+    // When fullImageLineSizeBytes differs from the tile width, the source image
+    // is wider than the tile — use 2D stride-aware indexing below.
+    if (fullImageLineSizeBytes == sizeBytes) {
+        fullImageLineSizeBytes = width;
+    }
+
+    uint32_t i = 0;
+    for (uint32_t y = 0; y < height; y++) {
+        for (uint32_t x = 0; x < width; x++) {
+            uint32_t srcIdx = y * fullImageLineSizeBytes + x;
+            uint8_t intensity = addr[srcIdx] >> 4;
+            uint8_t alpha = addr[srcIdx] & 0xf;
+            mTexUploadBuffer[4 * i + 0] = SCALE_4_8(intensity);
+            mTexUploadBuffer[4 * i + 1] = SCALE_4_8(intensity);
+            mTexUploadBuffer[4 * i + 2] = SCALE_4_8(intensity);
+            mTexUploadBuffer[4 * i + 3] = SCALE_4_8(alpha);
+            i++;
+        }
+    }
 
     mRapi->UploadTexture(mTexUploadBuffer, width, height);
 }
@@ -642,8 +687,14 @@ void Interpreter::ImportTextureIA16(int tile, bool importReplacement) {
         mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t line_size_bytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
 
-    uint32_t width = mRdp->texture_tile[tile].line_size_bytes / 2;
-    uint32_t height = size_bytes / mRdp->texture_tile[tile].line_size_bytes;
+    uint32_t widthBytes;
+    if (line_size_bytes != size_bytes && line_size_bytes > 0) {
+        widthBytes = line_size_bytes;
+    } else {
+        widthBytes = mRdp->texture_tile[tile].line_size_bytes;
+    }
+    uint32_t width = widthBytes / 2;
+    uint32_t height = widthBytes > 0 ? size_bytes / widthBytes : 0;
 
     // A single line of pixels should not equal the entire image (height == 1 non-withstanding)
     if (full_image_line_size_bytes == size_bytes) {
@@ -690,8 +741,14 @@ void Interpreter::ImportTextureI4(int tile, bool importReplacement) {
         mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t lineSizeBytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
 
-    uint32_t width = mRdp->texture_tile[tile].line_size_bytes * 2;
-    uint32_t height = sizeBytes / mRdp->texture_tile[tile].line_size_bytes;
+    uint32_t widthBytes;
+    if (lineSizeBytes != sizeBytes && lineSizeBytes > 0) {
+        widthBytes = lineSizeBytes;
+    } else {
+        widthBytes = mRdp->texture_tile[tile].line_size_bytes;
+    }
+    uint32_t width = widthBytes * 2;
+    uint32_t height = widthBytes > 0 ? sizeBytes / widthBytes : 0;
 
     // A single line of pixels should not equal the entire image (height == 1 non-withstanding)
     if (fullImageLineSizeBytes == sizeBytes) {
@@ -736,20 +793,37 @@ void Interpreter::ImportTextureI8(int tile, bool importReplacement) {
     }
 
     uint32_t sizeBytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].size_bytes;
-    uint32_t full_image_line_size_bytes =
+    uint32_t fullImageLineSizeBytes =
         mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes;
-    uint32_t line_size_bytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
+    uint32_t lineSizeBytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
 
-    for (uint32_t i = 0; i < sizeBytes; i++) {
-        uint8_t intensity = addr[i];
-        mTexUploadBuffer[4 * i + 0] = intensity;
-        mTexUploadBuffer[4 * i + 1] = intensity;
-        mTexUploadBuffer[4 * i + 2] = intensity;
-        mTexUploadBuffer[4 * i + 3] = intensity;
+    // Use actual per-line size when available (LoadTile, or LoadBlock with
+    // real width). Fall back to TMEM stride for LoadBlock with width=1 (indicated
+    // by lineSizeBytes == sizeBytes).
+    uint32_t width, height;
+    if (lineSizeBytes != sizeBytes && lineSizeBytes > 0) {
+        width = lineSizeBytes;
+        height = sizeBytes / lineSizeBytes;
+    } else {
+        width = mRdp->texture_tile[tile].line_size_bytes;
+        height = width > 0 ? sizeBytes / width : 0;
     }
 
-    uint32_t width = mRdp->texture_tile[tile].line_size_bytes;
-    uint32_t height = sizeBytes / mRdp->texture_tile[tile].line_size_bytes;
+    if (fullImageLineSizeBytes == sizeBytes) {
+        fullImageLineSizeBytes = width;
+    }
+
+    uint32_t i = 0;
+    for (uint32_t y = 0; y < height; y++) {
+        for (uint32_t x = 0; x < width; x++) {
+            uint8_t intensity = addr[y * fullImageLineSizeBytes + x];
+            mTexUploadBuffer[4 * i + 0] = intensity;
+            mTexUploadBuffer[4 * i + 1] = intensity;
+            mTexUploadBuffer[4 * i + 2] = intensity;
+            mTexUploadBuffer[4 * i + 3] = intensity;
+            i++;
+        }
+    }
 
     mRapi->UploadTexture(mTexUploadBuffer, width, height);
 }
@@ -774,34 +848,50 @@ void Interpreter::ImportTextureCi4(int tile, bool importReplacement) {
 
     const uint8_t* palette;
 
-    if (palIdx > 7)
-        palette = mRdp->palettes[palIdx / 8]; // 16 pixel entries, 16 bits each
-    else
-        palette = mRdp->palettes[palIdx / 8] + (palIdx % 8) * 16 * 2;
-
-    SUPPORT_CHECK(fullImageLineSizeBytes == lineSizeBytes);
-
-    for (uint32_t i = 0; i < sizeBytes * 2; i++) {
-        uint8_t byte = addr[i / 2];
-        uint8_t idx = (byte >> (4 - (i % 2) * 4)) & 0xf;
-        uint16_t col16 = (palette[idx * 2] << 8) | palette[idx * 2 + 1]; // Big endian load
-        uint8_t a = col16 & 1;
-        uint8_t r = col16 >> 11;
-        uint8_t g = (col16 >> 6) & 0x1f;
-        uint8_t b = (col16 >> 1) & 0x1f;
-        mTexUploadBuffer[4 * i + 0] = SCALE_5_8(r);
-        mTexUploadBuffer[4 * i + 1] = SCALE_5_8(g);
-        mTexUploadBuffer[4 * i + 2] = SCALE_5_8(b);
-        mTexUploadBuffer[4 * i + 3] = a ? 255 : 0;
+    if (mRdp->palettes[palIdx / 8] == nullptr) {
+        SPDLOG_WARN("CI4: null palette slot {} for palIdx={}", palIdx / 8, palIdx);
+        return;
     }
+    palette = mRdp->palettes[palIdx / 8] + (palIdx % 8) * 16 * 2;
 
-    uint32_t resultLineSizeBytes = mRdp->texture_tile[tile].line_size_bytes;
+    uint32_t baseLineSizeBytes;
+    if (lineSizeBytes != sizeBytes && lineSizeBytes > 0) {
+        baseLineSizeBytes = lineSizeBytes;
+    } else {
+        baseLineSizeBytes = mRdp->texture_tile[tile].line_size_bytes;
+    }
+    uint32_t resultLineSizeBytes = baseLineSizeBytes;
+
     if (metadata->h_byte_scale != 1) {
         resultLineSizeBytes *= metadata->h_byte_scale;
     }
 
+    // CI4: 2 pixels per byte
     uint32_t width = resultLineSizeBytes * 2;
-    uint32_t height = sizeBytes / resultLineSizeBytes;
+    uint32_t height = resultLineSizeBytes > 0 ? sizeBytes / resultLineSizeBytes : 0;
+
+    if (fullImageLineSizeBytes == sizeBytes) {
+        fullImageLineSizeBytes = resultLineSizeBytes;
+    }
+
+    uint32_t i = 0;
+    for (uint32_t y = 0; y < height; y++) {
+        for (uint32_t x = 0; x < width; x++) {
+            uint32_t srcPixelIdx = y * (fullImageLineSizeBytes * 2) + x;
+            uint8_t byte = addr[srcPixelIdx / 2];
+            uint8_t idx = (byte >> (4 - (srcPixelIdx % 2) * 4)) & 0xf;
+            uint16_t col16 = (palette[idx * 2] << 8) | palette[idx * 2 + 1]; // Big endian load
+            uint8_t a = col16 & 1;
+            uint8_t r = col16 >> 11;
+            uint8_t g = (col16 >> 6) & 0x1f;
+            uint8_t b = (col16 >> 1) & 0x1f;
+            mTexUploadBuffer[4 * i + 0] = SCALE_5_8(r);
+            mTexUploadBuffer[4 * i + 1] = SCALE_5_8(g);
+            mTexUploadBuffer[4 * i + 2] = SCALE_5_8(b);
+            mTexUploadBuffer[4 * i + 3] = a ? 255 : 0;
+            i++;
+        }
+    }
 
     mRapi->UploadTexture(mTexUploadBuffer, width, height);
 }
@@ -823,6 +913,12 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
         mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes;
     uint32_t lineSizeBytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
 
+    if (mRdp->palettes[0] == nullptr || mRdp->palettes[1] == nullptr) {
+        SPDLOG_WARN("CI8: null palette (pal0={}, pal1={})", static_cast<const void*>(mRdp->palettes[0]),
+                    static_cast<const void*>(mRdp->palettes[1]));
+        return;
+    }
+
     for (uint32_t i = 0, j = 0; i < sizeBytes; j += fullImageLineSizeBytes - lineSizeBytes) {
         for (uint32_t k = 0; k < lineSizeBytes; i++, k++, j++) {
             uint8_t idx = addr[j];
@@ -839,13 +935,19 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
         }
     }
 
-    uint32_t resultLineSizeBytes = mRdp->texture_tile[tile].line_size_bytes;
+    uint32_t baseLineSizeBytes;
+    if (lineSizeBytes != sizeBytes && lineSizeBytes > 0) {
+        baseLineSizeBytes = lineSizeBytes;
+    } else {
+        baseLineSizeBytes = mRdp->texture_tile[tile].line_size_bytes;
+    }
+    uint32_t resultLineSizeBytes = baseLineSizeBytes;
     if (metadata->h_byte_scale != 1) {
         resultLineSizeBytes *= metadata->h_byte_scale;
     }
 
     uint32_t width = resultLineSizeBytes;
-    uint32_t height = sizeBytes / resultLineSizeBytes;
+    uint32_t height = resultLineSizeBytes > 0 ? sizeBytes / resultLineSizeBytes : 0;
 
     mRapi->UploadTexture(mTexUploadBuffer, width, height);
 }
@@ -955,6 +1057,13 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
     uint8_t paletteIndex = mRdp->texture_tile[tile].palette;
     uint32_t origSizeBytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].orig_size_bytes;
 
+    // Check TLUT mode early — before cache lookup — so the fmt override
+    // affects both the cache key and the decode path.
+    uint32_t tlutMode = mRdp->other_mode_h & (3U << G_MDSFT_TEXTLUT);
+    if (tlutMode != G_TT_NONE && fmt != G_IM_FMT_CI) {
+        fmt = G_IM_FMT_CI;
+    }
+
     const RawTexMetadata* metadata = &mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata;
     const uint8_t* origAddr =
         importReplacement && (metadata->resource != nullptr)
@@ -962,18 +1071,48 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
             : mRdp->loaded_texture[tmemIdex].addr;
 
     if (origAddr == nullptr) {
-        SPDLOG_ERROR("ImportTexture: null texture address for tile {}", tile);
-        return;
+        // Tile has no texture loaded
+        // Fall back to the other TMEM slot so multi-tile rendering still works
+        uint32_t otherTmem = tmemIdex ^ 1;
+        origAddr = mRdp->loaded_texture[otherTmem].addr;
+        if (origAddr == nullptr) {
+            SPDLOG_WARN("ImportTexture: null texture address for tile {} (both TMEM slots empty)", tile);
+            return;
+        }
+        // Use the other slot's metadata too so size/line calculations are valid
+        tmemIdex = otherTmem;
+        origSizeBytes = mRdp->loaded_texture[otherTmem].orig_size_bytes;
+        texFlags = mRdp->loaded_texture[otherTmem].tex_flags;
     }
 
+    // Include palette in cache key when fmt is CI (including TLUT-overridden).
+    // CI4: only include the relevant palette half to avoid spurious cache invalidation.
     TextureCacheKey key;
     if (fmt == G_IM_FMT_CI) {
-        key = { origAddr, { mRdp->palettes[0], mRdp->palettes[1] }, fmt, siz, paletteIndex, origSizeBytes };
+        if (siz == G_IM_SIZ_4b) {
+            uint8_t palSlot = paletteIndex / 8;
+            key = { origAddr,
+                    { palSlot == 0 ? mRdp->palettes[0] : nullptr, palSlot == 1 ? mRdp->palettes[1] : nullptr },
+                    fmt,
+                    siz,
+                    paletteIndex,
+                    origSizeBytes };
+        } else {
+            // CI8 uses both palette halves
+            key = { origAddr, { mRdp->palettes[0], mRdp->palettes[1] }, fmt, siz, paletteIndex, origSizeBytes };
+        }
     } else {
         key = { origAddr, {}, fmt, siz, paletteIndex, origSizeBytes };
     }
 
-    if (TextureCacheLookup(i, key)) {
+    bool cached = TextureCacheLookup(i, key);
+    if (cached)
+        return;
+
+    // Guard against zero-sized textures from raw N64 sprite data that
+    // would cause divide-by-zero or D3D11/OpenGL errors in UploadTexture.
+    if (mRdp->texture_tile[tile].line_size_bytes == 0 || mRdp->loaded_texture[tmemIdex].size_bytes == 0 ||
+        origAddr == nullptr) {
         return;
     }
 
@@ -1582,9 +1721,17 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
 
     uint32_t tm = 0;
     uint32_t tex_width[2], tex_height[2], tex_width2[2], tex_height2[2];
+    uint32_t effective_tile[2];
 
     for (int i = 0; i < 2; i++) {
         uint32_t tile = mRdp->first_tile_index + i;
+
+        // No LOD support: force both slots to the base mip level.
+        if (i == 1 && mRdp->first_tile_index >= 2) {
+            tile = mRdp->first_tile_index;
+        }
+        effective_tile[i] = tile;
+
         if (comb->usedTextures[i]) {
             if (mRdp->textures_changed[i]) {
                 Flush();
@@ -1602,7 +1749,18 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             uint8_t cmt = mRdp->texture_tile[tile].cmt;
 
             uint32_t tex_size_bytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].orig_size_bytes;
-            uint32_t line_size = mRdp->texture_tile[tile].line_size_bytes;
+
+            // Use the same line_size as the Import functions for UV normalization.
+            // When loaded_texture has real per-line info, use it. Otherwise fall back
+            // to TMEM stride (texture_tile).
+            uint32_t loaded_line_size = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
+            uint32_t loaded_size = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].size_bytes;
+            uint32_t line_size;
+            if (loaded_line_size != loaded_size && loaded_line_size > 0) {
+                line_size = loaded_line_size;
+            } else {
+                line_size = mRdp->texture_tile[tile].line_size_bytes;
+            }
 
             if (line_size == 0) {
                 line_size = 1;
@@ -1627,6 +1785,14 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
 
             tex_width2[i] = (mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4;
             tex_height2[i] = (mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4;
+
+            // Clamp to tile bounds (mipmap loads include all levels).
+            if (tex_width2[i] > 0 && tex_width2[i] < tex_width[i]) {
+                tex_width[i] = tex_width2[i];
+            }
+            if (tex_height2[i] > 0 && tex_height2[i] < tex_height[i]) {
+                tex_height[i] = tex_height2[i];
+            }
 
             uint32_t tex_width1 = tex_width[i] << (cms & G_TX_MIRROR);
             uint32_t tex_height1 = tex_height[i] << (cmt & G_TX_MIRROR);
@@ -1703,8 +1869,9 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             float u = v_arr[i]->u / 32.0f;
             float v = v_arr[i]->v / 32.0f;
 
-            int shifts = mRdp->texture_tile[mRdp->first_tile_index + t].shifts;
-            int shiftt = mRdp->texture_tile[mRdp->first_tile_index + t].shiftt;
+            uint32_t uv_tile = effective_tile[t];
+            int shifts = mRdp->texture_tile[uv_tile].shifts;
+            int shiftt = mRdp->texture_tile[uv_tile].shiftt;
             if (shifts != 0) {
                 if (shifts <= 10) {
                     u /= 1 << shifts;
@@ -1720,8 +1887,8 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
                 }
             }
 
-            u -= mRdp->texture_tile[mRdp->first_tile_index + t].uls / 4.0f;
-            v -= mRdp->texture_tile[mRdp->first_tile_index + t].ult / 4.0f;
+            u -= mRdp->texture_tile[uv_tile].uls / 4.0f;
+            v -= mRdp->texture_tile[uv_tile].ult / 4.0f;
 
             if ((mRdp->other_mode_h & (3U << G_MDSFT_TEXTFILT)) != G_TF_POINT) {
                 // Linear filter adds 0.5f to the coordinates
@@ -2077,13 +2244,38 @@ void Interpreter::GfxDpSetTileSize(uint8_t tile, uint16_t uls, uint16_t ult, uin
 void Interpreter::GfxDpLoadTlut(uint8_t tile, uint32_t high_index) {
     SUPPORT_CHECK(mRdp->texture_to_load.siz == G_IM_SIZ_16b);
 
-    if (mRdp->texture_tile[tile].tmem == 256) {
-        mRdp->palettes[0] = mRdp->texture_to_load.addr;
-        if (high_index == 255) {
-            mRdp->palettes[1] = mRdp->texture_to_load.addr + 2 * 128;
+    uint16_t tmem = mRdp->texture_tile[tile].tmem;
+    const uint8_t* src = mRdp->texture_to_load.addr;
+    uint32_t entryCount = high_index + 1;
+    uint32_t byteCount = entryCount * 2;
+
+    if (tmem >= 256) {
+        // N64 TMEM palette area starts at tmem word 256. Each CI4 palette = 16 entries = 16 tmem words.
+        uint32_t paletteByteOffset = (tmem - 256) * 2;
+
+        if (paletteByteOffset < 256) {
+            // Palettes 0-7 range
+            uint32_t copyLen = (paletteByteOffset + byteCount <= 256) ? byteCount : (256 - paletteByteOffset);
+            memcpy(mRdp->palette_staging[0] + paletteByteOffset, src, copyLen);
+            mRdp->palettes[0] = mRdp->palette_staging[0];
+        } else {
+            // Palettes 8-15 range
+            uint32_t offset = paletteByteOffset - 256;
+            uint32_t copyLen = (offset + byteCount <= 256) ? byteCount : (256 - offset);
+            memcpy(mRdp->palette_staging[1] + offset, src, copyLen);
+            mRdp->palettes[1] = mRdp->palette_staging[1];
+        }
+
+        // CI8: full 256-entry palette spanning both halves
+        if (high_index == 255 && paletteByteOffset == 0) {
+            memcpy(mRdp->palette_staging[0], src, 256);
+            memcpy(mRdp->palette_staging[1], src + 256, 256);
+            mRdp->palettes[0] = mRdp->palette_staging[0];
+            mRdp->palettes[1] = mRdp->palette_staging[1];
         }
     } else {
-        mRdp->palettes[1] = mRdp->texture_to_load.addr;
+        // tmem < 256: non-standard location, fall back to direct pointer
+        mRdp->palettes[1] = src;
     }
 }
 
@@ -2117,8 +2309,37 @@ void Interpreter::GfxDpLoadBlock(uint8_t tile, uint32_t uls, uint32_t ult, uint3
     }
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].orig_size_bytes = orig_size_bytes;
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].size_bytes = size_bytes;
-    mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes = size_bytes;
-    mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes = size_bytes;
+
+    // Compute actual per-line DRAM stride from SetTextureImage width when available.
+    // The standard gDPLoadTextureBlock macro sets width=1, but manually-built DL
+    // commands may set the real pixel width. When width > 1 and divides evenly into
+    // size_bytes, use it for non-power-of-2 textures. Otherwise fall back to size_bytes.
+    uint32_t actual_line_bytes = size_bytes; // default: whole block (no per-line info)
+    if (mRdp->texture_to_load.width > 1) {
+        uint32_t candidate;
+        switch (mRdp->texture_to_load.siz) {
+            case G_IM_SIZ_4b:
+                candidate = (mRdp->texture_to_load.width + 1) / 2;
+                break;
+            case G_IM_SIZ_8b:
+                candidate = mRdp->texture_to_load.width;
+                break;
+            case G_IM_SIZ_16b:
+                candidate = mRdp->texture_to_load.width * 2;
+                break;
+            case G_IM_SIZ_32b:
+                candidate = mRdp->texture_to_load.width * 4;
+                break;
+            default:
+                candidate = mRdp->texture_to_load.width;
+                break;
+        }
+        if (candidate > 0 && candidate < size_bytes && size_bytes % candidate == 0) {
+            actual_line_bytes = candidate;
+        }
+    }
+    mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes = actual_line_bytes;
+    mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes = actual_line_bytes;
     // assert(size_bytes <= 4096 && "bug: too big texture");
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].tex_flags = mRdp->texture_to_load.tex_flags;
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata = mRdp->texture_to_load.raw_tex_metadata;
@@ -3408,6 +3629,10 @@ bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
     char* imgData = (char*)i;
     uint32_t texFlags = 0;
     RawTexMetadata rawTexMetdata = {};
+    // Default scale factors to 1 for raw N64 textures. OTR textures set these
+    // from the resource, but raw textures would leave them at 0.
+    rawTexMetdata.h_byte_scale = 1;
+    rawTexMetdata.v_pixel_scale = 1;
 
     if ((i & 1) != 1) {
         if (gfx_check_image_signature(imgData) == 1) {
@@ -3428,6 +3653,12 @@ bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
             rawTexMetdata.type = tex->Type;
             rawTexMetdata.resource = tex;
         }
+    }
+
+    // If the resolved address is still in the N64 segmented range, SegAddr failed
+    // to resolve it (segment not set up). Skip to avoid dereferencing invalid memory.
+    if (i <= 0x0FFFFFFF) {
+        return false;
     }
 
     gfx->GfxDpSetTextureImage(C0(21, 3), C0(19, 2), C0(0, 12) + 1, imgData, texFlags, rawTexMetdata, (void*)i);
@@ -4206,6 +4437,16 @@ static void gfx_step() {
     }
 
     if (otrHandlers.contains(opcode)) {
+        // OTR filepath handlers expect w1 to be a valid __OTR__ string pointer.
+        // If w1 is not a valid OTR path, skip to avoid crashing in strlen/strncmp.
+        if (opcode == OTR_G_VTX_OTR_FILEPATH || opcode == OTR_G_SETTIMG_OTR_FILEPATH ||
+            opcode == OTR_G_DL_OTR_FILEPATH || opcode == OTR_G_PUSHCD || opcode == OTR_G_MTX_OTR_FILEPATH ||
+            opcode == OTR_G_LOAD_SHADER) {
+            if (!gfx_check_image_signature((const char*)cmd->words.w1)) {
+                ++g_exec_stack.currCmd();
+                return;
+            }
+        }
         if (otrHandlers.at(opcode).second(&cmd)) {
             return;
         }
@@ -4612,11 +4853,20 @@ int32_t gfx_check_image_signature(const char* imgData) {
         return 0;
     }
 
-    if (i != 0) {
-        return Ship::Context::GetInstance()->GetResourceManager()->OtrSignatureCheck(imgData);
+    // Games may pass raw heap pointers as addresses in GBI commands. These
+    // arbitrary addresses cannot be safely dereferenced to check for "__OTR__".
+    // Filter out addresses that are obviously not valid string pointers:
+    if (i == 0 || i < 0x10000) {
+        return 0;
     }
+#if UINTPTR_MAX > 0xFFFFFFFFu
+    // On 64-bit: filter truncated 32-bit pointers AND kernel/sentinel addresses
+    if (i < 0x100000000ull || i > 0x00007FFFFFFFFFFFull) {
+        return 0;
+    }
+#endif
 
-    return 0;
+    return Ship::Context::GetInstance()->GetResourceManager()->OtrSignatureCheck(imgData);
 }
 
 void Interpreter::RegisterBlendedTexture(const char* name, uint8_t* mask, uint8_t* replacement) {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2837,14 +2837,38 @@ void Interpreter::GfxDpImageRectangle(int32_t tile, int32_t w, int32_t h, int32_
 void Interpreter::GfxDpFillRectangle(int32_t ulx, int32_t uly, int32_t lrx, int32_t lry) {
     if (mRdp->color_image_address == mRdp->z_buf_address) {
         // Fullscreen Z clears are redundant — already done by glClear at frame start.
-        // But partial Z clears (e.g. HUD model scissor regions) must go through so
-        // overlay models can use DEPTH_FULL without clipping behind world geometry.
         bool isFullScreen = (ulx <= 0 && uly <= 0 &&
                              lrx >= (int32_t)(mNativeDimensions.width - 1) * 4 &&
                              lry >= (int32_t)(mNativeDimensions.height - 1) * 4);
         if (isFullScreen) {
             return;
         }
+
+        // Partial depth clear (e.g. HUD model regions): clear the actual depth buffer
+        // via a scissored depth clear instead of drawing a colored rect to the color buffer.
+        Flush();
+
+        // Convert U10.2 coords to pixel coords and add +1 pixel for fill mode
+        int32_t expanded_lrx = lrx + (1 << 2);
+        int32_t expanded_lry = lry + (1 << 2);
+        float x = ulx / 4.0f;
+        float y = expanded_lry / 4.0f;
+        float w = (expanded_lrx - ulx) / 4.0f;
+        float h = (expanded_lry - uly) / 4.0f;
+
+        struct XYWidthHeight area;
+        area.x = (int16_t)x;
+        area.y = (int16_t)y;
+        area.width = (uint32_t)w;
+        area.height = (uint32_t)h;
+        AdjustVIewportOrScissor(&area);
+
+        mRapi->ClearDepthRegion(area.x, area.y, area.width, area.height);
+
+        // Invalidate cached scissor so it gets restored on next draw
+        mRenderingState.scissor = {};
+        mRdp->viewport_or_scissor_changed = true;
+        return;
     }
     uint32_t mode = (mRdp->other_mode_h & (3U << G_MDSFT_CYCLETYPE));
 

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -572,7 +572,7 @@ void Interpreter::ImportTextureRgba32(int tile, bool importReplacement) {
     // Use loaded_texture DRAM stride (4 bytes/pixel for RGBA32), not the TMEM-interleaved
     // texture_tile line_size (which uses G_IM_SIZ_32b_LINE_BYTES=2). Match ImportTextureRgba16 pattern.
     uint32_t widthBytes;
-    if (line_size_bytes != size_bytes && line_size_bytes > 0) {
+    if ((line_size_bytes != size_bytes || full_image_line_size_bytes != size_bytes) && line_size_bytes > 0) {
         widthBytes = line_size_bytes;
     } else {
         // Fallback: texture_tile stores TMEM-halved stride for RGBA32, so double it
@@ -631,7 +631,7 @@ void Interpreter::ImportTextureIA4(int tile, bool importReplacement) {
 
     // IA4: 2 pixels per byte, so width in pixels = line_size_bytes * 2
     uint32_t widthBytes;
-    if (lineSizeBytes != sizeBytes && lineSizeBytes > 0) {
+    if ((lineSizeBytes != sizeBytes || fullImageLineSizeBytes != sizeBytes) && lineSizeBytes > 0) {
         widthBytes = lineSizeBytes;
     } else {
         widthBytes = mRdp->texture_tile[tile].line_size_bytes;
@@ -682,7 +682,7 @@ void Interpreter::ImportTextureIA8(int tile, bool importReplacement) {
     // The 2D stride-aware loop below handles this, so no assert is needed.
 
     uint32_t width, height;
-    if (lineSizeBytes != sizeBytes && lineSizeBytes > 0) {
+    if ((lineSizeBytes != sizeBytes || fullImageLineSizeBytes != sizeBytes) && lineSizeBytes > 0) {
         width = lineSizeBytes;
         height = sizeBytes / lineSizeBytes;
     } else {
@@ -785,7 +785,7 @@ void Interpreter::ImportTextureI4(int tile, bool importReplacement) {
     uint32_t lineSizeBytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
 
     uint32_t widthBytes;
-    if (lineSizeBytes != sizeBytes && lineSizeBytes > 0) {
+    if ((lineSizeBytes != sizeBytes || fullImageLineSizeBytes != sizeBytes) && lineSizeBytes > 0) {
         widthBytes = lineSizeBytes;
     } else {
         widthBytes = mRdp->texture_tile[tile].line_size_bytes;
@@ -842,9 +842,9 @@ void Interpreter::ImportTextureI8(int tile, bool importReplacement) {
 
     // Use actual per-line size when available (LoadTile, or LoadBlock with
     // real width). Fall back to TMEM stride for LoadBlock with width=1 (indicated
-    // by lineSizeBytes == sizeBytes).
+    // by lineSizeBytes == sizeBytes AND fullImageLineSizeBytes == sizeBytes).
     uint32_t width, height;
-    if (lineSizeBytes != sizeBytes && lineSizeBytes > 0) {
+    if ((lineSizeBytes != sizeBytes || fullImageLineSizeBytes != sizeBytes) && lineSizeBytes > 0) {
         width = lineSizeBytes;
         height = sizeBytes / lineSizeBytes;
     } else {
@@ -898,7 +898,7 @@ void Interpreter::ImportTextureCi4(int tile, bool importReplacement) {
     palette = mRdp->palettes[palIdx / 8] + (palIdx % 8) * 16 * 2;
 
     uint32_t baseLineSizeBytes;
-    if (lineSizeBytes != sizeBytes && lineSizeBytes > 0) {
+    if ((lineSizeBytes != sizeBytes || fullImageLineSizeBytes != sizeBytes) && lineSizeBytes > 0) {
         baseLineSizeBytes = lineSizeBytes;
     } else {
         baseLineSizeBytes = mRdp->texture_tile[tile].line_size_bytes;
@@ -979,7 +979,7 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
     }
 
     uint32_t baseLineSizeBytes;
-    if (lineSizeBytes != sizeBytes && lineSizeBytes > 0) {
+    if ((lineSizeBytes != sizeBytes || fullImageLineSizeBytes != sizeBytes) && lineSizeBytes > 0) {
         baseLineSizeBytes = lineSizeBytes;
     } else {
         baseLineSizeBytes = mRdp->texture_tile[tile].line_size_bytes;
@@ -1796,8 +1796,9 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             uint32_t tex_size_bytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].orig_size_bytes;
             uint32_t loaded_line_size = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
             uint32_t loaded_size = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].size_bytes;
+            uint32_t loaded_full_line = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes;
             uint32_t line_size;
-            if (loaded_line_size != loaded_size && loaded_line_size > 0) {
+            if ((loaded_line_size != loaded_size || loaded_full_line != loaded_size) && loaded_line_size > 0) {
                 line_size = loaded_line_size;
             } else {
                 line_size = mRdp->texture_tile[tile].line_size_bytes;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1147,14 +1147,16 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
         if (siz == G_IM_SIZ_4b) {
             uint8_t palSlot = paletteIndex / 8;
             key = { origAddr,
-                    { palSlot == 0 ? mRdp->palette_dram_addr[0] : nullptr, palSlot == 1 ? mRdp->palette_dram_addr[1] : nullptr },
+                    { palSlot == 0 ? mRdp->palette_dram_addr[0] : nullptr,
+                      palSlot == 1 ? mRdp->palette_dram_addr[1] : nullptr },
                     fmt,
                     siz,
                     paletteIndex,
                     origSizeBytes };
         } else {
             // CI8 uses both palette halves
-            key = { origAddr, { mRdp->palette_dram_addr[0], mRdp->palette_dram_addr[1] }, fmt, siz, paletteIndex, origSizeBytes };
+            key = { origAddr,     { mRdp->palette_dram_addr[0], mRdp->palette_dram_addr[1] }, fmt, siz, paletteIndex,
+                    origSizeBytes };
         }
     } else {
         key = { origAddr, {}, fmt, siz, paletteIndex, origSizeBytes };
@@ -1805,7 +1807,8 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
 
             uint32_t loaded_line_size = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].line_size_bytes;
             uint32_t loaded_size = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].size_bytes;
-            uint32_t loaded_full_line = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes;
+            uint32_t loaded_full_line =
+                mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].full_image_line_size_bytes;
             uint32_t tex_size_bytes;
             uint32_t line_size;
             if ((loaded_line_size != loaded_size || loaded_full_line != loaded_size) && loaded_line_size > 0) {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1135,8 +1135,11 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
 
     // Check TLUT mode early — before cache lookup — so the fmt override
     // affects both the cache key and the decode path.
+    // Only override to CI for 4-bit and 8-bit texels, which are valid CI sizes.
+    // 16-bit and 32-bit texels are full-color formats that the N64 RDP decodes
+    // natively regardless of TLUT mode — forcing them through CI produces garbage.
     uint32_t tlutMode = mRdp->other_mode_h & (3U << G_MDSFT_TEXTLUT);
-    if (tlutMode != G_TT_NONE && fmt != G_IM_FMT_CI) {
+    if (tlutMode != G_TT_NONE && fmt != G_IM_FMT_CI && (siz == G_IM_SIZ_4b || siz == G_IM_SIZ_8b)) {
         fmt = G_IM_FMT_CI;
     }
 
@@ -1248,8 +1251,15 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
                 ImportTextureCi4(tile, importReplacement);
             } else if (siz == G_IM_SIZ_8b) {
                 ImportTextureCi8(tile, importReplacement);
+            } else if (siz == G_IM_SIZ_16b) {
+                // CI+16b is hardware-invalid on N64. The tile's fmt is likely
+                // stale from a prior draw. Decode as RGBA16 to avoid a garbage
+                // cache entry and produce visible output.
+                ImportTextureRgba16(tile, importReplacement);
+            } else if (siz == G_IM_SIZ_32b) {
+                ImportTextureRgba32(tile, importReplacement);
             } else {
-                SPDLOG_ERROR("CI Texture that isn't 4 or 8 bit. Size = {}", siz);
+                SPDLOG_ERROR("CI Texture with unexpected size = {}", siz);
             }
             break;
         case G_IM_FMT_I:

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -34,6 +34,7 @@
 #include "ship/utils/Utils.h"
 #include "ship/Context.h"
 #include "ship/config/ConsoleVariable.h"
+#include "libultraship/bridge/consolevariablebridge.h"
 
 #include "libultraship/libultra/os.h"
 
@@ -923,6 +924,17 @@ void Interpreter::ImportTextureCi4(int tile, bool importReplacement) {
     uint32_t width = resultLineSizeBytes * 2;
     uint32_t height = resultLineSizeBytes > 0 ? sizeBytes / resultLineSizeBytes : 0;
 
+    // Clamp to tile dimensions from SetTileSize — the TMEM line stride can be
+    // larger than the actual texture width (e.g. 32-wide CI4 with line=4).
+    uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
+    uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+    if (tile_w > 0 && tile_w < width) {
+        width = tile_w;
+    }
+    if (tile_h > 0 && tile_h < height) {
+        height = tile_h;
+    }
+
     if (fullImageLineSizeBytes == sizeBytes) {
         fullImageLineSizeBytes = resultLineSizeBytes;
     }
@@ -1001,6 +1013,17 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
 
     uint32_t width = resultLineSizeBytes;
     uint32_t height = resultLineSizeBytes > 0 ? sizeBytes / resultLineSizeBytes : 0;
+
+    // Clamp to tile dimensions from SetTileSize — the TMEM line stride can be
+    // larger than the actual texture width.
+    uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
+    uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+    if (tile_w > 0 && tile_w < width) {
+        width = tile_w;
+    }
+    if (tile_h > 0 && tile_h < height) {
+        height = tile_h;
+    }
 
     mRapi->UploadTexture(mTexUploadBuffer, width, height);
 }

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -424,8 +424,10 @@ bool ResourceManager::WriteResource(const ResourceIdentifier& identifier, const 
 }
 
 bool ResourceManager::OtrSignatureCheck(const char* fileName) {
-    static const char* sOtrSignature = "__OTR__";
-    return strncmp(fileName, sOtrSignature, strlen(sOtrSignature)) == 0;
+    // Byte-by-byte compare with short-circuit evaluation. fileName may point
+    // to an arbitrary address (e.g. a raw texture pointer), so strncmp is unsafe.
+    return fileName[0] == '_' && fileName[1] == '_' && fileName[2] == 'O' && fileName[3] == 'T' && fileName[4] == 'R' &&
+           fileName[5] == '_' && fileName[6] == '_';
 }
 
 bool ResourceManager::IsAltAssetsEnabled() {


### PR DESCRIPTION
## Summary

Major overhaul of the Fast3D interpreter's texture handling — fixes crashes, rendering corruption, and adds robustness for games that use advanced N64 texture features (sub-tile loads, multi-palette CI4, TLUT mode overrides, mipmap tile descriptors). Also includes backend stability fixes, a partial depth clear API, GPU framebuffer texture passthrough, and N64 coverage simulation.

### Texture Import Refactor
- All texture decode functions (RGBA16, RGBA32, IA4, IA8, IA16, I4, I8, CI4, CI8) now use the actual DRAM line stride from `loaded_texture` instead of the TMEM-interleaved `texture_tile.line_size_bytes`, which is 8-byte aligned and can overstate the real pixel width
- Added 2D stride-aware pixel copy loops to correctly handle sub-tile loads where the source image is wider than the tile region being loaded
- Clamp decoded dimensions to `SetTileSize` bounds so mipmap pyramids don't produce oversized textures
- Guard all import paths against zero-width/zero-height to prevent divide-by-zero and GPU API errors

### Palette / TLUT Handling
- Rewrote `GfxDpLoadTlut` to support CI4 multi-palette rendering: TLUT data is now copied into a staging buffer at the correct TMEM offset, so palettes 0–15 all work independently
- Track original DRAM palette addresses (`palette_dram_addr`) separately from the staging buffer pointers, and use them in texture cache keys so the same texture drawn with different palettes gets distinct cache entries
- Detect TLUT mode in `other_mode_h` before cache lookup and override `fmt` to `G_IM_FMT_CI` when active, matching hardware behavior

### Texture Cache Stability
- **Fix dangling pointer crash**: `mRenderingState.mTextures[]` stores raw pointers into `unordered_map` nodes. When entries were evicted, these pointers weren't nulled, so `GfxSpTri1` could write sampler params through freed memory — showing up as a random crash in `lru.splice`. All eviction and deletion sites now null out matching slots.
- Pre-allocate cache map buckets (`reserve(TEXTURE_CACHE_MAX_SIZE)`) at init and after clear to prevent rehash-induced iterator invalidation

### Mipmap Stub
- Force both texture slots to the base mip level when `first_tile_index >= 2` (no LOD interpolation), preventing out-of-bounds tile access and garbled textures from unhandled mipmap tile descriptors

### LoadBlock Line Stride
- `GfxDpLoadBlock` now computes actual per-line DRAM stride from `SetTextureImage` width when it's greater than 1, instead of treating the entire block as one line. Handles manually-built display lists that don't use the standard `gDPLoadTextureBlock` macro.

### N64 Coverage Simulation
- When `ALPHA_CVG_SEL` is set, the RDP blender uses coverage as alpha instead of the combiner output. Zero-alpha texels produce zero coverage and are never written, regardless of blender mode. The interpreter now enables alpha testing in this case, which is needed for OPA particle effects and similar transparent-cutout geometry.

### Partial Depth Clears
- Added `ClearDepthRegion(x, y, w, h)` to the rendering API with a default fallback and an OpenGL scissored implementation
- `GfxDpFillRectangle` now distinguishes fullscreen Z clears (skipped, already done by `glClear`) from partial Z clears (e.g. HUD regions) and issues a proper scissored depth clear instead of drawing a colored rect

### GPU Framebuffer Texture Passthrough
- New `RegisterFbTexture` / `UnregisterFbTexture` API lets ports map a CPU address to a GPU framebuffer ID
- When `ImportTexture` encounters a registered address, it binds the GPU FB directly via `SelectTextureFb` — full resolution, no CPU readback needed
- Fixed `SelectTextureFb` in OpenGL to resize the texture metadata vector when FB color buffer handles fall outside the range created by `NewTexture()`

### Widescreen for Resizable Off-Screen FBs
- `AdjXForAspectRatio` now applies widescreen correction to off-screen framebuffers that have `resize=true`, since those are capturing the main scene and should match the window's aspect ratio. Fixed-size FBs (HUD elements, capture buffers) are still skipped.

### Metal Backend Fixes
- `ReadFramebufferToCPU`: switched from async `addCompletedHandler` + `commit()` to synchronous `waitUntilCompleted()` — the caller expects the buffer filled on return, matching OpenGL's blocking `glReadPixels`
- Compute pipeline state for RGBA32 -> RGB5A1 conversion is now created once per call as a local variable instead of rebuilding every frame as a member
- Threadgroup size increased from 1×1×1 to 8×8×1, reducing GPU thread waste from ~97% to near zero

* Note this all comes from research and theory as I don't own a mac, so untested.

### DX11 Backend Fixes
- `UploadTexture`: early return on zero dimensions
- `DrawTriangles`: bounds-check `mCurrentTextureIds` before indexing into `mTextures`; move `PSSetSamplers` inside the `usedTextures[i]` guard
- `ReadFramebufferToCPU`: query actual source texture dimensions for the staging copy (CopyResource requires matching sizes); nearest-neighbor scaling for dimension mismatches; fix resource leak on early-return; remove unnecessary temp buffer allocation
- `Destroy`: iteratively erase deep `std::set`/`std::map` frame-stat containers to avoid MSVC's recursive `_Erase_tree` stack overflow

### DXGI Fixes
- Null-check the `Context -> Window -> Gui` chain in `wnd_proc` (can be null during init/teardown)
- Guard `mPendingFrameStats.rbegin()` against empty container
- Null-check DX11 device before releasing in window teardown

### Safety / Robustness
- `OtrSignatureCheck`: replaced `strncmp` with byte-by-byte comparison — the input might be a raw texture pointer, not a valid C string
- `gfx_check_image_signature`: filter obviously-invalid addresses (null, low, truncated 32-bit on 64-bit builds, kernel-range) before trying to dereference
- Guard OTR filepath opcode handlers against non-OTR `w1` values
- Skip unresolved N64 segment addresses (`<= 0x0FFFFFFF`) in `SetTextureImage`
- Default `h_byte_scale` and `v_pixel_scale` to 1 for raw (non-OTR) textures
- Value-initialize `mCurrentTextureIds` arrays in DX11 and OpenGL headers
- If a tile's TMEM slot is empty, try the other slot before giving up
