### PR TITLE
Backend safety guards: null-checks, zero-dimension guards, and resource leak fixes

### DIFF
--- a/include/fast/backends/gfx_direct3d_common.h
+++ b/include/fast/backends/gfx_direct3d_common.h
@@ -155,7 +155,7 @@ class GfxRenderingAPIDX11 final : public GfxRenderingAPI {
 
     std::vector<struct TextureData> mTextures;
     int mCurrentTile;
-    uint32_t mCurrentTextureIds[SHADER_MAX_TEXTURES];
+    uint32_t mCurrentTextureIds[SHADER_MAX_TEXTURES]{};
 
     std::vector<FramebufferDX11> mFrameBuffers;
 

--- a/include/fast/backends/gfx_direct3d_common.h
+++ b/include/fast/backends/gfx_direct3d_common.h
@@ -155,7 +155,7 @@ class GfxRenderingAPIDX11 final : public GfxRenderingAPI {
 
     std::vector<struct TextureData> mTextures;
     int mCurrentTile;
-    uint32_t mCurrentTextureIds[SHADER_MAX_TEXTURES]{};
+    uint32_t mCurrentTextureIds[SHADER_MAX_TEXTURES] = {};
 
     std::vector<FramebufferDX11> mFrameBuffers;
 

--- a/include/fast/backends/gfx_opengl.h
+++ b/include/fast/backends/gfx_opengl.h
@@ -107,7 +107,7 @@ class GfxRenderingAPIOGL final : public GfxRenderingAPI {
     void SetPerDrawUniforms();
 
     std::vector<TextureInfo> textures;
-    GLuint mCurrentTextureIds[SHADER_MAX_TEXTURES]{};
+    GLuint mCurrentTextureIds[SHADER_MAX_TEXTURES] = {};
     GLuint mLastBoundTextures[SHADER_MAX_TEXTURES] = {};
     uint8_t mCurrentTile;
     int8_t mLastActiveTexture = -1;

--- a/include/fast/backends/gfx_opengl.h
+++ b/include/fast/backends/gfx_opengl.h
@@ -107,7 +107,7 @@ class GfxRenderingAPIOGL final : public GfxRenderingAPI {
     void SetPerDrawUniforms();
 
     std::vector<TextureInfo> textures;
-    GLuint mCurrentTextureIds[SHADER_MAX_TEXTURES];
+    GLuint mCurrentTextureIds[SHADER_MAX_TEXTURES]{};
     GLuint mLastBoundTextures[SHADER_MAX_TEXTURES] = {};
     uint8_t mCurrentTile;
     int8_t mLastActiveTexture = -1;

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -1047,6 +1047,8 @@ void GfxRenderingAPIDX11::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32
     ThrowIfFailed(mContext->Map(staging, 0, D3D11_MAP_READ, 0, &resource));
 
     if (!resource.pData) {
+        mContext->Unmap(staging, 0);
+        staging->Release();
         return;
     }
 

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -727,8 +727,8 @@ void GfxRenderingAPIDX11::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, siz
                     mLastSamplerStates[i] = mTextures[mCurrentTextureIds[i]].sampler_state.Get();
                 }
             }
+            mContext->PSSetSamplers(i, 1, mTextures[mCurrentTextureIds[i]].sampler_state.GetAddressOf());
         }
-        mContext->PSSetSamplers(i, 1, mTextures[mCurrentTextureIds[i]].sampler_state.GetAddressOf());
     }
 
     // Set per-draw constant buffer

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -547,6 +547,10 @@ static D3D11_TEXTURE_ADDRESS_MODE gfx_cm_to_d3d11(uint32_t val) {
 }
 
 void GfxRenderingAPIDX11::UploadTexture(const uint8_t* rgba32_buf, uint32_t width, uint32_t height) {
+    if (width == 0 || height == 0) {
+        return;
+    }
+
     // Create texture
 
     TextureData* texture_data = &mTextures[mCurrentTextureIds[mCurrentTile]];

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -708,6 +708,10 @@ void GfxRenderingAPIDX11::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, siz
 
     for (int i = 0; i < SHADER_MAX_TEXTURES; i++) {
         if (mShaderProgram->usedTextures[i]) {
+            // Guard against stale/invalid texture IDs
+            if (mCurrentTextureIds[i] >= mTextures.size()) {
+                continue;
+            }
             if (mLastResourceViews[i].Get() != mTextures[mCurrentTextureIds[i]].resource_view.Get()) {
                 mLastResourceViews[i] = mTextures[mCurrentTextureIds[i]].resource_view.Get();
                 mContext->PSSetShaderResources(i, 1, mTextures[mCurrentTextureIds[i]].resource_view.GetAddressOf());

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -712,7 +712,9 @@ void GfxRenderingAPIDX11::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, siz
 
     for (int i = 0; i < SHADER_MAX_TEXTURES; i++) {
         if (mShaderProgram->usedTextures[i]) {
-            // Guard against stale/invalid texture IDs
+            // mTextures is append-only (NewTexture just resizes +1, DeleteTexture is a no-op),
+            // so this is really just catching stale IDs left over from before we zero-initialized
+            // mCurrentTextureIds. No entries are ever removed, so gaps aren't a concern.
             if (mCurrentTextureIds[i] >= mTextures.size()) {
                 continue;
             }

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -357,7 +357,10 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
     char fileName[256];
     Ship::WindowEvent event_impl;
     event_impl.Win32 = { h_wnd, static_cast<int>(message), static_cast<int>(w_param), static_cast<int>(l_param) };
-    Ship::Context::GetInstance()->GetWindow()->GetGui()->HandleWindowEvents(event_impl);
+    auto ctx = Ship::Context::GetInstance();
+    if (ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
+        ctx->GetWindow()->GetGui()->HandleWindowEvents(event_impl);
+    }
     std::tuple<HMONITOR, RECT, BOOL> newMonitor;
     GfxWindowBackendDXGI* self = reinterpret_cast<GfxWindowBackendDXGI*>(GetWindowLongPtr(h_wnd, GWLP_USERDATA));
     switch (message) {
@@ -952,7 +955,8 @@ void GfxWindowBackendDXGI::SwapBuffersEnd() {
 
     QueryPerformanceCounter(&t2);
 
-    mZeroLatency = mPendingFrameStats.rbegin()->first == stats.PresentCount;
+    mZeroLatency =
+        !mPendingFrameStats.empty() && mPendingFrameStats.rbegin()->first == stats.PresentCount;
 
     // printf(L"done %I64u gpu:%d wait:%d freed:%I64u frame:%u %u monitor:%u t:%I64u\n", (unsigned long
     // long)(t0.QuadPart - qpc_init), (int)(t1.QuadPart - t0.QuadPart), (int)(t2.QuadPart - t0.QuadPart), (unsigned
@@ -1068,7 +1072,14 @@ bool GfxWindowBackendDXGI::CanDisableVsync() {
 }
 
 void GfxWindowBackendDXGI::Destroy() {
-    // TODO: destroy _any_ resources used by dxgi, including the window handle
+    // Iteratively clear frame-stat containers to avoid MSVC's recursive _Erase_tree
+    // stack overflow on deep std::set/std::map trees during destruction.
+    while (!mPendingFrameStats.empty()) {
+        mPendingFrameStats.erase(mPendingFrameStats.begin());
+    }
+    while (!mFrameStats.empty()) {
+        mFrameStats.erase(mFrameStats.begin());
+    }
 }
 
 bool GfxWindowBackendDXGI::IsFullscreen() {

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -499,8 +499,10 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
             }
             break;
         case WM_KILLFOCUS:
-            if (!Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_ALLOW_BACKGROUND_INPUTS, 1)) {
-                ControllerBlockGameInput(ALLOW_BACKGROUND_INPUTS_BLOCK_ID);
+            if (auto ctx = Ship::Context::GetInstance(); ctx && ctx->GetConsoleVariables()) {
+                if (!ctx->GetConsoleVariables()->GetInteger(CVAR_ALLOW_BACKGROUND_INPUTS, 1)) {
+                    ControllerBlockGameInput(ALLOW_BACKGROUND_INPUTS_BLOCK_ID);
+                }
             }
             self->mInFocus = false;
             break;

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -1073,6 +1073,7 @@ bool GfxWindowBackendDXGI::CanDisableVsync() {
 }
 
 void GfxWindowBackendDXGI::Destroy() {
+    // During messy teardowns, it doesn't take a huge tree to eat through the stack.
     // Iteratively clear frame-stat containers to avoid MSVC's recursive _Erase_tree
     // stack overflow on deep std::set/std::map trees during destruction.
     while (!mPendingFrameStats.empty()) {

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -957,8 +957,7 @@ void GfxWindowBackendDXGI::SwapBuffersEnd() {
 
     QueryPerformanceCounter(&t2);
 
-    mZeroLatency =
-        !mPendingFrameStats.empty() && mPendingFrameStats.rbegin()->first == stats.PresentCount;
+    mZeroLatency = !mPendingFrameStats.empty() && mPendingFrameStats.rbegin()->first == stats.PresentCount;
 
     // printf(L"done %I64u gpu:%d wait:%d freed:%I64u frame:%u %u monitor:%u t:%I64u\n", (unsigned long
     // long)(t0.QuadPart - qpc_init), (int)(t1.QuadPart - t0.QuadPart), (int)(t2.QuadPart - t0.QuadPart), (unsigned

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -320,6 +320,10 @@ void GfxRenderingAPIMetal::SelectTexture(int tile, uint32_t texture_id) {
 }
 
 void GfxRenderingAPIMetal::UploadTexture(const uint8_t* rgba32_buf, uint32_t width, uint32_t height) {
+    if (width == 0 || height == 0) {
+        return;
+    }
+
     TextureDataMetal* texture_data = &mTextures[mCurrentTextureIds[mCurrentTile]];
 
     NS::AutoreleasePool* autorelease_pool = NS::AutoreleasePool::alloc()->init();

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -551,6 +551,9 @@ void GfxRenderingAPIOGL::SelectTexture(int tile, GLuint texture_id) {
 }
 
 void GfxRenderingAPIOGL::UploadTexture(const uint8_t* rgba32_buf, uint32_t width, uint32_t height) {
+    if (width == 0 || height == 0) {
+        return;
+    }
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba32_buf);
     textures[mCurrentTextureIds[mCurrentTile]].width = width;
     textures[mCurrentTextureIds[mCurrentTile]].height = height;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -3422,6 +3422,10 @@ bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
     char* imgData = (char*)i;
     uint32_t texFlags = 0;
     RawTexMetadata rawTexMetdata = {};
+    // Default scale factors to 1 for raw N64 textures. OTR textures set these
+    // from the resource, but raw textures would leave them at 0.
+    rawTexMetdata.h_byte_scale = 1;
+    rawTexMetdata.v_pixel_scale = 1;
 
     if ((i & 1) != 1) {
         if (gfx_check_image_signature(imgData) == 1) {


### PR DESCRIPTION
This is 1/7 of splitting up #1038 into easily digestible chunks for easier review and bisecting.

- Value-initialize `mCurrentTextureIds` arrays in DX11 and OpenGL to prevent stale out-of-bounds reads
- Move `PSSetSamplers` inside the `usedTextures[i]` guard so it doesn't index with a stale texture ID
- Early-return from `UploadTexture` in all three backends (DX11, OpenGL, Metal) when width or height is zero
- Default `h_byte_scale` and `v_pixel_scale` to 1 for raw N64 textures to avoid divide-by-zero in CI paths
- Null-check the `Context->Window->Gui` chain in DXGI `wnd_proc` and `WM_KILLFOCUS` for teardown safety
- Guard `mPendingFrameStats.rbegin()` against empty container
- Iteratively erase frame-stat containers in `Destroy()` to avoid MSVC recursive `_Erase_tree` stack overflow
- Unmap and Release the DX11 staging texture on early-return in `ReadFramebufferToCPU`