### PR TITLE
Palette/TLUT handling: multi-palette CI4 support and DRAM-based cache keys

### DIFF
--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -257,6 +257,13 @@ struct RSP {
 
 struct RDP {
     const uint8_t* palettes[2];
+    // Original DRAM source address of the most recent TLUT load per palette half.
+    // Used in texture cache keys instead of palettes[] (which always points to staging).
+    const uint8_t* palette_dram_addr[2];
+    // CI4 palette staging buffer: N64 TMEM holds up to 16 CI4 palettes (16 entries x 2 bytes each = 32 bytes per
+    // palette). palettes[0] covers indices 0-7 (256 bytes), palettes[1] covers 8-15 (256 bytes). GfxDpLoadTlut copies
+    // TLUT data here at the correct offset so multi-palette CI4 models work.
+    uint8_t palette_staging[2][256];
     struct {
         const uint8_t* addr;
         uint8_t siz;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -955,6 +955,16 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
     uint8_t paletteIndex = mRdp->texture_tile[tile].palette;
     uint32_t origSizeBytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].orig_size_bytes;
 
+    // Check TLUT mode early -- before cache lookup -- so the fmt override
+    // affects both the cache key and the decode path.
+    // Only override to CI for 4-bit and 8-bit texels, which are valid CI sizes.
+    // 16-bit and 32-bit texels are full-color formats that the N64 RDP decodes
+    // natively regardless of TLUT mode.
+    uint32_t tlutMode = mRdp->other_mode_h & (3U << G_MDSFT_TEXTLUT);
+    if (tlutMode != G_TT_NONE && fmt != G_IM_FMT_CI && (siz == G_IM_SIZ_4b || siz == G_IM_SIZ_8b)) {
+        fmt = G_IM_FMT_CI;
+    }
+
     const RawTexMetadata* metadata = &mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata;
     const uint8_t* origAddr =
         importReplacement && (metadata->resource != nullptr)
@@ -966,9 +976,29 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
         return;
     }
 
+    // Use palette_dram_addr (the original DRAM source) instead of palettes[]
+    // (which always points to the staging buffer) so the same texture drawn
+    // with different palettes gets distinct cache entries.
     TextureCacheKey key;
     if (fmt == G_IM_FMT_CI) {
-        key = { origAddr, { mRdp->palettes[0], mRdp->palettes[1] }, fmt, siz, paletteIndex, origSizeBytes };
+        if (siz == G_IM_SIZ_4b) {
+            uint8_t palSlot = paletteIndex / 8;
+            key = { origAddr,
+                    { palSlot == 0 ? mRdp->palette_dram_addr[0] : nullptr,
+                      palSlot == 1 ? mRdp->palette_dram_addr[1] : nullptr },
+                    fmt,
+                    siz,
+                    paletteIndex,
+                    origSizeBytes };
+        } else {
+            // CI8 uses both palette halves
+            key = { origAddr,
+                    { mRdp->palette_dram_addr[0], mRdp->palette_dram_addr[1] },
+                    fmt,
+                    siz,
+                    paletteIndex,
+                    origSizeBytes };
+        }
     } else {
         key = { origAddr, {}, fmt, siz, paletteIndex, origSizeBytes };
     }

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2088,13 +2088,43 @@ void Interpreter::GfxDpSetTileSize(uint8_t tile, uint16_t uls, uint16_t ult, uin
 void Interpreter::GfxDpLoadTlut(uint8_t tile, uint32_t high_index) {
     SUPPORT_CHECK(mRdp->texture_to_load.siz == G_IM_SIZ_16b);
 
-    if (mRdp->texture_tile[tile].tmem == 256) {
-        mRdp->palettes[0] = mRdp->texture_to_load.addr;
-        if (high_index == 255) {
-            mRdp->palettes[1] = mRdp->texture_to_load.addr + 2 * 128;
+    uint16_t tmem = mRdp->texture_tile[tile].tmem;
+    const uint8_t* src = mRdp->texture_to_load.addr;
+    uint32_t entryCount = high_index + 1;
+    uint32_t byteCount = entryCount * 2;
+
+    if (tmem >= 256) {
+        // N64 TMEM palette area starts at tmem word 256. Each CI4 palette = 16 entries = 16 tmem words.
+        uint32_t paletteByteOffset = (tmem - 256) * 2;
+
+        if (paletteByteOffset < 256) {
+            // Palettes 0-7 range
+            uint32_t copyLen = (paletteByteOffset + byteCount <= 256) ? byteCount : (256 - paletteByteOffset);
+            memcpy(mRdp->palette_staging[0] + paletteByteOffset, src, copyLen);
+            mRdp->palettes[0] = mRdp->palette_staging[0];
+            mRdp->palette_dram_addr[0] = src;
+        } else {
+            // Palettes 8-15 range
+            uint32_t offset = paletteByteOffset - 256;
+            uint32_t copyLen = (offset + byteCount <= 256) ? byteCount : (256 - offset);
+            memcpy(mRdp->palette_staging[1] + offset, src, copyLen);
+            mRdp->palettes[1] = mRdp->palette_staging[1];
+            mRdp->palette_dram_addr[1] = src;
+        }
+
+        // CI8: full 256-entry palette spanning both halves
+        if (high_index == 255 && paletteByteOffset == 0) {
+            memcpy(mRdp->palette_staging[0], src, 256);
+            memcpy(mRdp->palette_staging[1], src + 256, 256);
+            mRdp->palettes[0] = mRdp->palette_staging[0];
+            mRdp->palettes[1] = mRdp->palette_staging[1];
+            mRdp->palette_dram_addr[0] = src;
+            mRdp->palette_dram_addr[1] = src + 256;
         }
     } else {
-        mRdp->palettes[1] = mRdp->texture_to_load.addr;
+        // tmem < 256: non-standard location, fall back to direct pointer
+        mRdp->palettes[1] = src;
+        mRdp->palette_dram_addr[1] = src;
     }
 }
 

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -992,11 +992,7 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
                     origSizeBytes };
         } else {
             // CI8 uses both palette halves
-            key = { origAddr,
-                    { mRdp->palette_dram_addr[0], mRdp->palette_dram_addr[1] },
-                    fmt,
-                    siz,
-                    paletteIndex,
+            key = { origAddr,     { mRdp->palette_dram_addr[0], mRdp->palette_dram_addr[1] }, fmt, siz, paletteIndex,
                     origSizeBytes };
         }
     } else {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2127,7 +2127,15 @@ void Interpreter::GfxDpLoadTlut(uint8_t tile, uint32_t high_index) {
         // N64 TMEM palette area starts at tmem word 256. Each CI4 palette = 16 entries = 16 tmem words.
         uint32_t paletteByteOffset = (tmem - 256) * 2;
 
-        if (paletteByteOffset < 256) {
+        if (high_index == 255 && paletteByteOffset == 0) {
+            // CI8: full 256-entry palette spanning both halves
+            memcpy(mRdp->palette_staging[0], src, 256);
+            memcpy(mRdp->palette_staging[1], src + 256, 256);
+            mRdp->palettes[0] = mRdp->palette_staging[0];
+            mRdp->palettes[1] = mRdp->palette_staging[1];
+            mRdp->palette_dram_addr[0] = src;
+            mRdp->palette_dram_addr[1] = src + 256;
+        } else if (paletteByteOffset < 256) {
             // Palettes 0-7 range
             uint32_t copyLen = (paletteByteOffset + byteCount <= 256) ? byteCount : (256 - paletteByteOffset);
             memcpy(mRdp->palette_staging[0] + paletteByteOffset, src, copyLen);
@@ -2140,16 +2148,6 @@ void Interpreter::GfxDpLoadTlut(uint8_t tile, uint32_t high_index) {
             memcpy(mRdp->palette_staging[1] + offset, src, copyLen);
             mRdp->palettes[1] = mRdp->palette_staging[1];
             mRdp->palette_dram_addr[1] = src;
-        }
-
-        // CI8: full 256-entry palette spanning both halves
-        if (high_index == 255 && paletteByteOffset == 0) {
-            memcpy(mRdp->palette_staging[0], src, 256);
-            memcpy(mRdp->palette_staging[1], src + 256, 256);
-            mRdp->palettes[0] = mRdp->palette_staging[0];
-            mRdp->palettes[1] = mRdp->palette_staging[1];
-            mRdp->palette_dram_addr[0] = src;
-            mRdp->palette_dram_addr[1] = src + 256;
         }
     } else {
         // tmem < 256: non-standard location, fall back to direct pointer


### PR DESCRIPTION
This is 5/7 of splitting up https://github.com/Kenix3/libultraship/pull/1038 into easily digestible chunks for easier review and bisecting.

- Rewrite `GfxDpLoadTlut` to copy TLUT data into a staging buffer at the correct TMEM offset so all 16 CI4 palettes (0-15) work independently
- Track original DRAM palette addresses (`palette_dram_addr`) separately from staging buffer pointers for use in texture cache keys
- Detect TLUT mode in `other_mode_h` before cache lookup and override `fmt` to `G_IM_FMT_CI` for 4-bit and 8-bit texels, matching N64 hardware behavior
- Split CI4 cache keys to only include the relevant palette half, and use `palette_dram_addr` so different palettes produce distinct cache entries