### PR TITLE
Attempt to fix ReadFramebufferToCPU across all three backends

### DIFF
--- a/include/fast/backends/gfx_direct3d_common.h
+++ b/include/fast/backends/gfx_direct3d_common.h
@@ -176,6 +176,11 @@ class GfxRenderingAPIDX11 final : public GfxRenderingAPI {
     Microsoft::WRL::ComPtr<ID3D11SamplerState> mLastSamplerStates[SHADER_MAX_TEXTURES] = { nullptr, nullptr };
 
     D3D_PRIMITIVE_TOPOLOGY mLastPrimitaveTopology = D3D_PRIMITIVE_TOPOLOGY_UNDEFINED;
+
+    // Cached staging texture for ReadFramebufferToCPU — avoids CreateTexture2D/Release per frame
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> mReadbackStaging;
+    uint32_t mReadbackStagingW = 0;
+    uint32_t mReadbackStagingH = 0;
 };
 
 std::string gfx_direct3d_common_build_shader(size_t& numFloats, const CCFeatures& cc_features,

--- a/include/fast/backends/gfx_metal.h
+++ b/include/fast/backends/gfx_metal.h
@@ -29,6 +29,7 @@ class Device;
 class Function;
 class Buffer;
 class RenderPipelineState;
+class ComputePipelineState;
 class CommandQueue;
 class Viewport;
 } // namespace MTL
@@ -199,6 +200,7 @@ class GfxRenderingAPIMetal final : public GfxRenderingAPI {
     size_t mCoordBufferSize;
     MTL::Function* mDepthComputeFunction;
     MTL::Function* mConvertToRgb5a1Function;
+    MTL::ComputePipelineState* mConvertToRgb5a1PipelineState = nullptr;
 
     // Current state
     struct ShaderProgramMetal* mShaderProgram;

--- a/include/fast/backends/gfx_metal.h
+++ b/include/fast/backends/gfx_metal.h
@@ -110,7 +110,6 @@ struct FramebufferMetal {
     // the readback queue instead of the main queue, allowing synchronous
     // commit+waitUntilCompleted without enqueue-ordering deadlocks.
     bool mUseReadbackQueue = false;
-
 };
 
 struct FrameUniforms {

--- a/include/fast/backends/gfx_metal.h
+++ b/include/fast/backends/gfx_metal.h
@@ -106,9 +106,8 @@ struct FramebufferMetal {
     int8_t mLastDepthMask = -1;
     int8_t mLastZmodeDecal = -1;
 
-    // When true, StartDrawToFramebuffer creates this FB's command buffer on
-    // the readback queue instead of the main queue, allowing synchronous
-    // commit+waitUntilCompleted without enqueue-ordering deadlocks.
+    // When true, command buffer is created on the readback queue (no enqueue ordering).
+    // First ReadFramebufferToCPU returns zeros and flips this; real data from frame 2+.
     bool mUseReadbackQueue = false;
 };
 

--- a/include/fast/backends/gfx_metal.h
+++ b/include/fast/backends/gfx_metal.h
@@ -105,6 +105,12 @@ struct FramebufferMetal {
     int8_t mLastDepthTest = -1;
     int8_t mLastDepthMask = -1;
     int8_t mLastZmodeDecal = -1;
+
+    // When true, StartDrawToFramebuffer creates this FB's command buffer on
+    // the readback queue instead of the main queue, allowing synchronous
+    // commit+waitUntilCompleted without enqueue-ordering deadlocks.
+    bool mUseReadbackQueue = false;
+
 };
 
 struct FrameUniforms {
@@ -179,6 +185,7 @@ class GfxRenderingAPIMetal final : public GfxRenderingAPI {
     CA::MetalLayer* mLayer; // CA::MetalLayer*
     MTL::Device* mDevice;
     MTL::CommandQueue* mCommandQueue;
+    MTL::CommandQueue* mReadbackQueue;
 
     int mCurrentVertexBufferPoolIndex = 0;
     MTL::Buffer* mVertexBufferPool[kMaxVertexBufferPoolSize];
@@ -201,6 +208,16 @@ class GfxRenderingAPIMetal final : public GfxRenderingAPI {
     MTL::Function* mDepthComputeFunction;
     MTL::Function* mConvertToRgb5a1Function;
     MTL::ComputePipelineState* mConvertToRgb5a1PipelineState = nullptr;
+
+    // Screen FB deferred readback: blit in EndFrame, CPU conversion next frame.
+    // mScreenReadbackCmdBuf retains the command buffer that encoded the blit so
+    // we can waitUntilCompleted before reading the shared buffer contents.
+    MTL::CommandBuffer* mScreenReadbackCmdBuf = nullptr;
+    MTL::Buffer* mScreenReadbackBuffer = nullptr;
+    uint32_t mScreenReadbackWidth = 0;
+    uint32_t mScreenReadbackHeight = 0;
+    bool mScreenReadbackDataReady = false;
+    bool mScreenReadbackRequested = false;
 
     // Current state
     struct ShaderProgramMetal* mShaderProgram;

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -1023,50 +1023,52 @@ void GfxRenderingAPIDX11::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32
     FramebufferDX11& fb = mFrameBuffers[fb_id];
     TextureData& td = mTextures[fb.texture_id];
 
-    ID3D11Texture2D* staging = nullptr;
+    // Query actual texture dimensions — CopyResource requires matching sizes
+    D3D11_TEXTURE2D_DESC srcDesc;
+    td.texture->GetDesc(&srcDesc);
 
-    // Create an staging texture with cpu read access
-    D3D11_TEXTURE2D_DESC texture_desc;
-    texture_desc.Width = width;
-    texture_desc.Height = height;
-    texture_desc.Usage = D3D11_USAGE_STAGING;
-    texture_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-    texture_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-    texture_desc.BindFlags = 0;
-    texture_desc.MiscFlags = 0;
-    texture_desc.ArraySize = 1;
-    texture_desc.MipLevels = 1;
-    texture_desc.SampleDesc.Count = 1;
-    texture_desc.SampleDesc.Quality = 0;
+    // Reuse cached staging texture when dimensions match — avoids per-frame CreateTexture2D
+    if (!mReadbackStaging || mReadbackStagingW != srcDesc.Width || mReadbackStagingH != srcDesc.Height) {
+        mReadbackStaging.Reset();
 
-    ThrowIfFailed(mDevice->CreateTexture2D(&texture_desc, nullptr, &staging));
+        D3D11_TEXTURE2D_DESC texture_desc;
+        texture_desc.Width = srcDesc.Width;
+        texture_desc.Height = srcDesc.Height;
+        texture_desc.Usage = D3D11_USAGE_STAGING;
+        texture_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        texture_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+        texture_desc.BindFlags = 0;
+        texture_desc.MiscFlags = 0;
+        texture_desc.ArraySize = 1;
+        texture_desc.MipLevels = 1;
+        texture_desc.SampleDesc.Count = 1;
+        texture_desc.SampleDesc.Quality = 0;
+
+        ThrowIfFailed(mDevice->CreateTexture2D(&texture_desc, nullptr, mReadbackStaging.GetAddressOf()));
+        mReadbackStagingW = srcDesc.Width;
+        mReadbackStagingH = srcDesc.Height;
+    }
 
     // Copy the framebuffer texture to the staging texture
-    mContext->CopyResource(staging, td.texture.Get());
+    mContext->CopyResource(mReadbackStaging.Get(), td.texture.Get());
 
     // Map the staging texture to a resource that we can read
     D3D11_MAPPED_SUBRESOURCE resource = {};
-    ThrowIfFailed(mContext->Map(staging, 0, D3D11_MAP_READ, 0, &resource));
+    ThrowIfFailed(mContext->Map(mReadbackStaging.Get(), 0, D3D11_MAP_READ, 0, &resource));
 
     if (!resource.pData) {
-        mContext->Unmap(staging, 0);
-        staging->Release();
+        mContext->Unmap(mReadbackStaging.Get(), 0);
         return;
     }
 
-    // Copy the mapped values to a temp array that we can process later
-    uint32_t* temp = new uint32_t[width * height]();
-    for (size_t i = 0; i < height; i++) {
-        memcpy((uint8_t*)temp + (resource.RowPitch * i), (uint8_t*)resource.pData + (resource.RowPitch * i),
-               resource.RowPitch);
-    }
-
-    mContext->Unmap(staging, 0);
-
-    // Convert the RGBA32 values to RGBA16
-    for (size_t i = 0; i < width; i++) {
-        for (size_t j = 0; j < height; j++) {
-            uint32_t pixel = temp[i + (j * width)];
+    // Convert RGBA32 → RGBA16 with nearest-neighbor scaling from actual texture
+    // dimensions to requested output dimensions, respecting RowPitch for row stride
+    for (uint32_t j = 0; j < height; j++) {
+        uint32_t srcY = j * srcDesc.Height / height;
+        uint8_t* srcRow = (uint8_t*)resource.pData + srcY * resource.RowPitch;
+        for (uint32_t i = 0; i < width; i++) {
+            uint32_t srcX = i * srcDesc.Width / width;
+            uint32_t pixel = ((uint32_t*)srcRow)[srcX];
             uint8_t r = (((pixel & 0xFF) + 4) * 0x1F) / 0xFF;
             uint8_t g = ((((pixel >> 8) & 0xFF) + 4) * 0x1F) / 0xFF;
             uint8_t b = ((((pixel >> 16) & 0xFF) + 4) * 0x1F) / 0xFF;
@@ -1076,11 +1078,7 @@ void GfxRenderingAPIDX11::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32
         }
     }
 
-    // Cleanup
-    staging->Release();
-    staging = nullptr;
-
-    delete[] temp;
+    mContext->Unmap(mReadbackStaging.Get(), 0);
 }
 
 void GfxRenderingAPIDX11::SetTextureFilter(FilteringMode mode) {

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -79,6 +79,7 @@ bool GfxRenderingAPIMetal::MetalInit(SDL_Renderer* renderer) {
 
     mDevice = mLayer->device();
     mCommandQueue = mDevice->newCommandQueue();
+    mReadbackQueue = mDevice->newCommandQueue();
 
     for (size_t i = 0; i < kMaxVertexBufferPoolSize; i++) {
         MTL::Buffer* new_buffer = mDevice->newBuffer(256 * 32 * 3 * sizeof(float) * 50, MTL::ResourceStorageModeShared);
@@ -549,7 +550,7 @@ void GfxRenderingAPIMetal::EndFrame() {
     it++;
 
     while (it != mDrawnFramebuffers.end()) {
-        auto framebuffer = mFramebuffers[*it];
+        auto& framebuffer = mFramebuffers[*it];
 
         if (!framebuffer.mHasEndedEncoding)
             framebuffer.mCommandEncoder->endEncoding();
@@ -558,11 +559,48 @@ void GfxRenderingAPIMetal::EndFrame() {
         it++;
     }
 
-    auto screen_framebuffer = mFramebuffers[0];
-    screen_framebuffer.mCommandEncoder->endEncoding();
+    auto& screen_framebuffer = mFramebuffers[0];
+    if (!screen_framebuffer.mHasEndedEncoding)
+        screen_framebuffer.mCommandEncoder->endEncoding();
+
+    // Deferred screen FB readback: blit the rendered texture into a shared
+    // MTLBuffer using a blit encoder (cheap DMA — no render pass boundary,
+    // no TBDR tile flush/reload).  The CPU reads this buffer next frame in
+    // ReadFramebufferToCPU and converts BGRA8 → RGBA5551 on the CPU side.
+    if (mScreenReadbackRequested) {
+        MTL::Texture* screenTex = mTextures[screen_framebuffer.mTextureId].texture;
+        uint32_t w = mScreenReadbackWidth;
+        uint32_t h = mScreenReadbackHeight;
+        size_t bytesPerRow = w * 4;  // BGRA8 = 4 bytes per pixel
+        size_t bufSize = bytesPerRow * h;
+
+        // Allocate / reuse a persistent shared buffer for CPU readback.
+        if (!mScreenReadbackBuffer || mScreenReadbackBuffer->length() < bufSize) {
+            if (mScreenReadbackBuffer)
+                mScreenReadbackBuffer->release();
+            mScreenReadbackBuffer = mDevice->newBuffer(bufSize, MTL::ResourceStorageModeShared);
+        }
+
+        MTL::BlitCommandEncoder* blit = screen_framebuffer.mCommandBuffer->blitCommandEncoder();
+        blit->copyFromTexture(screenTex, 0, 0, MTL::Origin(0, 0, 0), MTL::Size(w, h, 1),
+                              mScreenReadbackBuffer, 0, bytesPerRow, bufSize);
+        blit->endEncoding();
+
+        // Don't set mScreenReadbackDataReady yet — the blit hasn't executed.
+        // Retain the command buffer so ReadFramebufferToCPU can wait on it.
+        mScreenReadbackRequested = false;
+    }
+
     screen_framebuffer.mCommandBuffer->presentDrawable(mCurrentDrawable);
     mCurrentVertexBufferPoolIndex = (mCurrentVertexBufferPoolIndex + 1) % kMaxVertexBufferPoolSize;
     screen_framebuffer.mCommandBuffer->commit();
+
+    // Now that commit has been called, retain the command buffer for GPU sync
+    // in ReadFramebufferToCPU next frame (waitUntilCompleted before reading).
+    if (mScreenReadbackBuffer && !mScreenReadbackDataReady) {
+        mScreenReadbackCmdBuf = screen_framebuffer.mCommandBuffer->retain();
+        mScreenReadbackDataReady = true;
+    }
 
     mDrawnFramebuffers.clear();
 
@@ -817,12 +855,17 @@ void GfxRenderingAPIMetal::StartDrawToFramebuffer(int fb_id, float noise_scale) 
 
     if (fb.mRenderTarget && fb.mCommandBuffer == nullptr && fb.mCommandEncoder == nullptr &&
         fb.mRenderPassDescriptor != nullptr) {
-        fb.mCommandBuffer = mCommandQueue->commandBuffer();
+        // FBs that are read back to CPU use a separate queue so
+        // commit+waitUntilCompleted doesn't deadlock on enqueue ordering.
+        MTL::CommandQueue* queue = fb.mUseReadbackQueue ? mReadbackQueue : mCommandQueue;
+        fb.mCommandBuffer = queue->commandBuffer();
         std::string fbcb_label = fmt::format("FrameBuffer {} Command Buffer", fb_id);
         fb.mCommandBuffer->setLabel(NS::String::string(fbcb_label.c_str(), NS::UTF8StringEncoding));
 
-        // Queue the command buffers in order of start draw
-        fb.mCommandBuffer->enqueue();
+        if (!fb.mUseReadbackQueue) {
+            // Queue the command buffers in order of start draw
+            fb.mCommandBuffer->enqueue();
+        }
 
         fb.mCommandEncoder = fb.mCommandBuffer->renderCommandEncoder(fb.mRenderPassDescriptor);
         std::string fbce_label = fmt::format("FrameBuffer {} Command Encoder", fb_id);
@@ -1101,8 +1144,8 @@ void GfxRenderingAPIMetal::CopyFramebuffer(int fb_dst_id, int fb_src_id, int src
     source_framebuffer.mLastZmodeDecal = -1;
 }
 
-void GfxRenderingAPIMetal::GfxRenderingAPIMetal::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32_t height,
-                                                                      uint16_t* rgba16_buf) {
+void GfxRenderingAPIMetal::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32_t height,
+                                                uint16_t* rgba16_buf) {
     if (fb_id >= (int)mFramebuffers.size()) {
         return;
     }
@@ -1110,47 +1153,81 @@ void GfxRenderingAPIMetal::GfxRenderingAPIMetal::ReadFramebufferToCPU(int fb_id,
     FramebufferMetal& framebuffer = mFramebuffers[fb_id];
     MTL::Texture* texture = mTextures[framebuffer.mTextureId].texture;
 
-    MTL::Buffer* output_buffer =
-        mDevice->newBuffer(sizeof(uint16_t) * width * height, MTL::ResourceOptionCPUCacheModeDefault);
-    output_buffer->setLabel(NS::String::string("Pixels output buffer", NS::UTF8StringEncoding));
+    if (fb_id == 0) {
+        // Screen Framebuffer: deferred blit (zero encoder overhead)
+        // Return previous frame's data.  Wait on the retained command buffer
+        // to guarantee the GPU blit has finished before reading the shared buffer.
+        if (mScreenReadbackDataReady && mScreenReadbackBuffer && mScreenReadbackCmdBuf) {
+            mScreenReadbackCmdBuf->waitUntilCompleted();
+            mScreenReadbackCmdBuf->release();
+            mScreenReadbackCmdBuf = nullptr;
+            mScreenReadbackDataReady = false;
 
-    NS::AutoreleasePool* autorelease_pool = NS::AutoreleasePool::alloc()->init();
+            uint8_t* bgra = (uint8_t*)mScreenReadbackBuffer->contents();
+            uint32_t count = mScreenReadbackWidth * mScreenReadbackHeight;
+            for (uint32_t i = 0; i < count; i++) {
+                uint8_t b = bgra[i * 4 + 0];
+                uint8_t g = bgra[i * 4 + 1];
+                uint8_t r = bgra[i * 4 + 2];
+                uint8_t a = bgra[i * 4 + 3];
+                rgba16_buf[i] = ((r >> 3) << 11) | ((g >> 3) << 6) | ((b >> 3) << 1) | (a >> 7);
+            }
+        }
 
-    auto command_buffer = mCommandQueue->commandBuffer();
-    command_buffer->setLabel(NS::String::string("Read Pixels Shader Command Buffer", NS::UTF8StringEncoding));
-
-    // Lazily create and cache the compute pipeline state on first use.
-    // newComputePipelineState compiles the shader — expensive per frame, free to reuse.
-    if (!mConvertToRgb5a1PipelineState) {
-        NS::Error* pso_error = nullptr;
-        mConvertToRgb5a1PipelineState = mDevice->newComputePipelineState(mConvertToRgb5a1Function, &pso_error);
-    }
-    MTL::ComputeCommandEncoder* compute_encoder = command_buffer->computeCommandEncoder();
-    compute_encoder->setComputePipelineState(mConvertToRgb5a1PipelineState);
-    compute_encoder->setTexture(texture, 0);
-    compute_encoder->setBuffer(output_buffer, 0, 0);
-
-    MTL::Size thread_group_size = MTL::Size::Make(8, 8, 1);
-    MTL::Size total_threads = MTL::Size::Make(width, height, 1);
-
-    if (mNonUniformThreadgroupSupported) {
-        compute_encoder->dispatchThreads(total_threads, thread_group_size);
+        // Request a blit in EndFrame and we don't touch any encoders here
+        mScreenReadbackRequested = true;
+        mScreenReadbackWidth = width;
+        mScreenReadbackHeight = height;
     } else {
-        MTL::Size thread_group_count = MTL::Size::Make((width + 7) / 8, (height + 7) / 8, 1);
-        compute_encoder->dispatchThreadgroups(thread_group_count, thread_group_size);
+        // Custom Framebuffer: synchronous readback via readback queue
+        if (framebuffer.mCommandEncoder && !framebuffer.mHasEndedEncoding) {
+            framebuffer.mCommandEncoder->endEncoding();
+        }
+
+        if (!mConvertToRgb5a1PipelineState) {
+            NS::Error* pso_error = nullptr;
+            mConvertToRgb5a1PipelineState = mDevice->newComputePipelineState(mConvertToRgb5a1Function, &pso_error);
+        }
+
+        MTL::Buffer* output_buffer =
+            mDevice->newBuffer(sizeof(uint16_t) * width * height, MTL::ResourceStorageModeShared);
+
+        MTL::ComputeCommandEncoder* compute_encoder = framebuffer.mCommandBuffer->computeCommandEncoder();
+        compute_encoder->setComputePipelineState(mConvertToRgb5a1PipelineState);
+        compute_encoder->setTexture(texture, 0);
+        compute_encoder->setBuffer(output_buffer, 0, 0);
+
+        MTL::Size tg = MTL::Size::Make(8, 8, 1);
+        MTL::Size total = MTL::Size::Make(width, height, 1);
+        if (mNonUniformThreadgroupSupported) {
+            compute_encoder->dispatchThreads(total, tg);
+        } else {
+            compute_encoder->dispatchThreadgroups(MTL::Size::Make((width + 7) / 8, (height + 7) / 8, 1), tg);
+        }
+        compute_encoder->endEncoding();
+
+        framebuffer.mCommandBuffer->commit();
+
+        if (framebuffer.mUseReadbackQueue) {
+            framebuffer.mCommandBuffer->waitUntilCompleted();
+            uint16_t* values = (uint16_t*)output_buffer->contents();
+            memcpy(rgba16_buf, values, sizeof(uint16_t) * width * height);
+        } else {
+            // First frame on main queue — can't block without deadlock.
+            // Return zeros so the caller gets black instead of garbage.
+            memset(rgba16_buf, 0, sizeof(uint16_t) * width * height);
+            framebuffer.mUseReadbackQueue = true;
+        }
+
+        output_buffer->release();
+
+        // Reset state so StartDrawToFramebuffer can create a fresh command buffer.
+        // Example case: the FB can be reused for another sprite in the same frame.
+        framebuffer.mCommandBuffer = nullptr;
+        framebuffer.mCommandEncoder = nullptr;
+        framebuffer.mHasEndedEncoding = false;
+        mDrawnFramebuffers.erase(fb_id);
     }
-    compute_encoder->endEncoding();
-
-    // Block until the GPU finishes — the caller expects rgba16_buf to be
-    // filled when this function returns (same as OpenGL's glReadPixels).
-    command_buffer->commit();
-    command_buffer->waitUntilCompleted();
-
-    uint16_t* values = (uint16_t*)output_buffer->contents();
-    memcpy(rgba16_buf, values, sizeof(uint16_t) * width * height);
-
-    output_buffer->release();
-    autorelease_pool->release();
 }
 
 void GfxRenderingAPIMetal::SetTextureFilter(FilteringMode mode) {

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -1119,40 +1119,37 @@ void GfxRenderingAPIMetal::GfxRenderingAPIMetal::ReadFramebufferToCPU(int fb_id,
     auto command_buffer = mCommandQueue->commandBuffer();
     command_buffer->setLabel(NS::String::string("Read Pixels Shader Command Buffer", NS::UTF8StringEncoding));
 
-    NS::Error* error = nullptr;
-    MTL::ComputePipelineState* compute_pipeline_state =
-        mDevice->newComputePipelineState(mConvertToRgb5a1Function, &error);
-
-    // Use a compute encoder to convert the pixel data to rgba16 and transfer to a cpu readable buffer
+    // Lazily create and cache the compute pipeline state on first use.
+    // newComputePipelineState compiles the shader — expensive per frame, free to reuse.
+    if (!mConvertToRgb5a1PipelineState) {
+        NS::Error* pso_error = nullptr;
+        mConvertToRgb5a1PipelineState = mDevice->newComputePipelineState(mConvertToRgb5a1Function, &pso_error);
+    }
     MTL::ComputeCommandEncoder* compute_encoder = command_buffer->computeCommandEncoder();
-    compute_encoder->setComputePipelineState(compute_pipeline_state);
+    compute_encoder->setComputePipelineState(mConvertToRgb5a1PipelineState);
     compute_encoder->setTexture(texture, 0);
     compute_encoder->setBuffer(output_buffer, 0, 0);
 
-    // Use a thread group size and count that covers the whole copy area
-    MTL::Size thread_group_size = MTL::Size::Make(1, 1, 1);
-    MTL::Size thread_group_count = MTL::Size::Make(width, height, 1);
+    MTL::Size thread_group_size = MTL::Size::Make(8, 8, 1);
+    MTL::Size total_threads = MTL::Size::Make(width, height, 1);
 
-    // We validate if the device supports non-uniform threadgroup sizes
     if (mNonUniformThreadgroupSupported) {
-        compute_encoder->dispatchThreads(thread_group_count, thread_group_size);
+        compute_encoder->dispatchThreads(total_threads, thread_group_size);
     } else {
+        MTL::Size thread_group_count = MTL::Size::Make((width + 7) / 8, (height + 7) / 8, 1);
         compute_encoder->dispatchThreadgroups(thread_group_count, thread_group_size);
     }
     compute_encoder->endEncoding();
 
-    // Use a completion handler to wait for the GPU to be done without blocking the thread
-    command_buffer->addCompletedHandler([=](MTL::CommandBuffer* cmd_buffer) {
-        // Now the converted pixel values can be copied from the buffer
-        uint16_t* values = (uint16_t*)output_buffer->contents();
-        memcpy(rgba16_buf, values, sizeof(uint16_t) * width * height);
-
-        output_buffer->release();
-    });
-
+    // Block until the GPU finishes — the caller expects rgba16_buf to be
+    // filled when this function returns (same as OpenGL's glReadPixels).
     command_buffer->commit();
+    command_buffer->waitUntilCompleted();
 
-    compute_pipeline_state->release();
+    uint16_t* values = (uint16_t*)output_buffer->contents();
+    memcpy(rgba16_buf, values, sizeof(uint16_t) * width * height);
+
+    output_buffer->release();
     autorelease_pool->release();
 }
 

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -571,7 +571,7 @@ void GfxRenderingAPIMetal::EndFrame() {
         MTL::Texture* screenTex = mTextures[screen_framebuffer.mTextureId].texture;
         uint32_t w = mScreenReadbackWidth;
         uint32_t h = mScreenReadbackHeight;
-        size_t bytesPerRow = w * 4;  // BGRA8 = 4 bytes per pixel
+        size_t bytesPerRow = w * 4; // BGRA8 = 4 bytes per pixel
         size_t bufSize = bytesPerRow * h;
 
         // Allocate / reuse a persistent shared buffer for CPU readback.
@@ -582,8 +582,8 @@ void GfxRenderingAPIMetal::EndFrame() {
         }
 
         MTL::BlitCommandEncoder* blit = screen_framebuffer.mCommandBuffer->blitCommandEncoder();
-        blit->copyFromTexture(screenTex, 0, 0, MTL::Origin(0, 0, 0), MTL::Size(w, h, 1),
-                              mScreenReadbackBuffer, 0, bytesPerRow, bufSize);
+        blit->copyFromTexture(screenTex, 0, 0, MTL::Origin(0, 0, 0), MTL::Size(w, h, 1), mScreenReadbackBuffer, 0,
+                              bytesPerRow, bufSize);
         blit->endEncoding();
 
         // Don't set mScreenReadbackDataReady yet — the blit hasn't executed.
@@ -1144,8 +1144,7 @@ void GfxRenderingAPIMetal::CopyFramebuffer(int fb_dst_id, int fb_src_id, int src
     source_framebuffer.mLastZmodeDecal = -1;
 }
 
-void GfxRenderingAPIMetal::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32_t height,
-                                                uint16_t* rgba16_buf) {
+void GfxRenderingAPIMetal::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32_t height, uint16_t* rgba16_buf) {
     if (fb_id >= (int)mFramebuffers.size()) {
         return;
     }

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -600,6 +600,14 @@ void GfxRenderingAPIMetal::EndFrame() {
     if (mScreenReadbackBuffer && !mScreenReadbackDataReady) {
         mScreenReadbackCmdBuf = screen_framebuffer.mCommandBuffer->retain();
         mScreenReadbackDataReady = true;
+    } else if (mScreenReadbackDataReady && mScreenReadbackCmdBuf) {
+        // Nobody consumed the readback this frame — data is going stale.
+        // Release the retained command buffer to avoid leaking it, and reset
+        // so the next ReadFramebufferToCPU requests a fresh blit instead of
+        // serving outdated pixels.
+        mScreenReadbackCmdBuf->release();
+        mScreenReadbackCmdBuf = nullptr;
+        mScreenReadbackDataReady = false;
     }
 
     mDrawnFramebuffers.clear();

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -959,8 +959,23 @@ void GfxRenderingAPIOGL::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32_
         return;
     }
 
+    // Read as RGBA8 (GL_UNSIGNED_BYTE) then convert to RGBA16 (5551).
+    // GL_RGBA + GL_UNSIGNED_SHORT_5_5_5_1 writes 4 separate u16 components per pixel
+    // (8 bytes) on some drivers (NVIDIA), not the packed 2 bytes the spec implies.
+    // Reading as RGBA8 and converting matches the DX11 path's approach.
     glBindFramebuffer(GL_FRAMEBUFFER, mFrameBuffers[fb_id].fbo);
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_SHORT_5_5_5_1, (void*)rgba16_buf);
+
+    std::vector<uint8_t> rgba8(width * height * 4);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, rgba8.data());
+
+    for (uint32_t i = 0; i < width * height; i++) {
+        uint8_t r = (rgba8[i * 4 + 0] >> 3) & 0x1F;
+        uint8_t g = (rgba8[i * 4 + 1] >> 3) & 0x1F;
+        uint8_t b = (rgba8[i * 4 + 2] >> 3) & 0x1F;
+        uint8_t a = rgba8[i * 4 + 3] ? 1 : 0;
+        rgba16_buf[i] = (r << 11) | (g << 6) | (b << 1) | a;
+    }
+
     glBindFramebuffer(GL_FRAMEBUFFER, mFrameBuffers[mCurrentFrameBuffer].fbo);
 }
 

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -4707,7 +4707,7 @@ void Interpreter::RunGuiOnly() {
                                        false, true, true, !mRendersToFb);
     mRapi->StartFrame();
     mRapi->StartDrawToFramebuffer(mRendersToFb ? mGameFb : 0, (float)mCurDimensions.height / mNativeDimensions.height);
-    mRapi->ClearFramebuffer(false, true);
+    mRapi->ClearFramebuffer(true, true);
     mRdp->viewport_or_scissor_changed = true;
     mRenderingState.viewport = {};
     mRenderingState.scissor = {};
@@ -4749,7 +4749,7 @@ void Interpreter::Run(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtx_r
                                        false, true, true, !mRendersToFb);
     mRapi->StartFrame();
     mRapi->StartDrawToFramebuffer(mRendersToFb ? mGameFb : 0, (float)mCurDimensions.height / mNativeDimensions.height);
-    mRapi->ClearFramebuffer(false, true);
+    mRapi->ClearFramebuffer(true, true);
     mRdp->viewport_or_scissor_changed = true;
     mRenderingState.viewport = {};
     mRenderingState.scissor = {};


### PR DESCRIPTION
This is 6/7 of splitting up https://github.com/Kenix3/libultraship/pull/1038 into easily digestible chunks for easier review and bisecting.

- **DX11**: Cache the staging texture to avoid per-frame `CreateTexture2D`/`Release`. Query actual source dimensions for `CopyResource` (requires matching sizes) and use nearest-neighbor scaling for dimension mismatches. Remove unnecessary intermediate temp buffer.
- **OpenGL**: Read as `GL_UNSIGNED_BYTE` then convert to RGBA5551 manually. `GL_UNSIGNED_SHORT_5_5_5_1` writes 8 bytes per pixel on some NVIDIA drivers instead of the expected 2, corrupting memory past the output buffer.
- **Metal**: Switch from async `addCompletedHandler` to synchronous `waitUntilCompleted()` so the caller gets valid data on return. Increase threadgroup size from 1x1x1 to 8x8x1 to fill GPU SIMD lanes. *(Disclaimer: this based on research and theory, I do not own a mac and cannot test)*