### PR TITLE
Rendering features: partial depth clears, FB texture passthrough, coverage sim, and widescreen fixes

### DIFF
--- a/include/fast/backends/gfx_opengl.h
+++ b/include/fast/backends/gfx_opengl.h
@@ -89,6 +89,7 @@ class GfxRenderingAPIOGL final : public GfxRenderingAPI {
     void CopyFramebuffer(int fbDstId, int fbSrcId, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0,
                          int dstX1, int dstY1) override;
     void ClearFramebuffer(bool color, bool depth) override;
+    void ClearDepthRegion(int x, int y, int w, int h) override;
     void ReadFramebufferToCPU(int fbId, uint32_t width, uint32_t height, uint16_t* rgba16Buf) override;
     void ResolveMSAAColorBuffer(int fbIdTarger, int fbIdSrc) override;
     std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff>

--- a/include/fast/backends/gfx_rendering_api.h
+++ b/include/fast/backends/gfx_rendering_api.h
@@ -61,6 +61,11 @@ class GfxRenderingAPI {
     virtual void CopyFramebuffer(int fbDstId, int fbSrcId, int srcX0, int srcY0, int srcX1, int srcY1, int dstX0,
                                  int dstY0, int dstX1, int dstY1) = 0;
     virtual void ClearFramebuffer(bool color, bool depth) = 0;
+    virtual void ClearDepthRegion(int x, int y, int w, int h) {
+        // Default: full depth clear. Backends that support scissored depth clears
+        // (e.g. OpenGL) should override for a more precise partial clear.
+        ClearFramebuffer(false, true);
+    }
     virtual void ReadFramebufferToCPU(int fbId, uint32_t width, uint32_t height, uint16_t* rgba16Buf) = 0;
     virtual void ResolveMSAAColorBuffer(int fbIdTarger, int fbIdSrc) = 0;
     virtual std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff>

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -388,6 +388,12 @@ class Interpreter {
     void RegisterBlendedTexture(const char* name, uint8_t* mask, uint8_t* replacement);
     void UnregisterBlendedTexture(const char* name);
 
+    // Register a CPU address as a mirror of a GPU framebuffer texture.
+    // When ImportTexture encounters this address, it uses SelectTextureFb instead
+    // of reading from CPU memory — giving full GPU resolution with no readback.
+    void RegisterFbTexture(const void* cpuAddr, int fbId);
+    void UnregisterFbTexture(const void* cpuAddr);
+
     void SetNativeDimensions(float width, float height);
     void SetResolutionMultiplier(float multiplier);
     void SetMsaaLevel(uint32_t level);
@@ -515,6 +521,7 @@ class Interpreter {
     std::set<std::pair<float, float>> mGetPixelDepthPending; // get_pixel_depth_pending;
     std::unordered_map<std::pair<float, float>, uint16_t, hash_pair_ff> mGetPixelDepthCached; // get_pixel_depth_cached;
     std::map<std::string, MaskedTextureEntry, std::less<>> mMaskedTextures;
+    std::unordered_map<uintptr_t, int> mFbTextures; // CPU addr -> GPU FB id
 
     const std::unordered_map<Mtx*, MtxF>* mCurMtxReplacements;
     bool mMarkerOn; // This was originally a debug feature. Now it seems to control s2dex?

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -850,6 +850,25 @@ void GfxRenderingAPIOGL::ClearFramebuffer(bool color, bool depth) {
     }
 }
 
+void GfxRenderingAPIOGL::ClearDepthRegion(int x, int y, int w, int h) {
+    // Save current scissor state so callers don't need to manually invalidate.
+    GLint prevScissor[4];
+    GLboolean scissorWasEnabled = glIsEnabled(GL_SCISSOR_TEST);
+    glGetIntegerv(GL_SCISSOR_BOX, prevScissor);
+
+    glEnable(GL_SCISSOR_TEST);
+    glScissor(x, y, w, h);
+    glDepthMask(GL_TRUE);
+    glClear(GL_DEPTH_BUFFER_BIT);
+    glDepthMask(mCurrentDepthMask ? GL_TRUE : GL_FALSE);
+
+    // Restore previous scissor state.
+    glScissor(prevScissor[0], prevScissor[1], prevScissor[2], prevScissor[3]);
+    if (!scissorWasEnabled) {
+        glDisable(GL_SCISSOR_TEST);
+    }
+}
+
 void GfxRenderingAPIOGL::ResolveMSAAColorBuffer(int fb_id_target, int fb_id_source) {
     FramebufferOGL& fb_dst = mFrameBuffers[fb_id_target];
     FramebufferOGL& fb_src = mFrameBuffers[fb_id_source];
@@ -879,7 +898,14 @@ void* GfxRenderingAPIOGL::GetFramebufferTextureId(int fb_id) {
 void GfxRenderingAPIOGL::SelectTextureFb(int fb_id) {
     // glDisable(GL_DEPTH_TEST);
     int tile = 0;
-    SelectTexture(tile, mFrameBuffers[fb_id].clrbuf);
+    GLuint texId = mFrameBuffers[fb_id].clrbuf;
+    // Ensure the textures metadata vector can hold this FB texture handle.
+    // FB color buffers are created outside NewTexture(), so the vector may
+    // not have been resized for them yet.
+    if (texId >= textures.size()) {
+        textures.resize((size_t)texId + 1);
+    }
+    SelectTexture(tile, texId);
 }
 
 void GfxRenderingAPIOGL::CopyFramebuffer(int fb_dst_id, int fb_src_id, int srcX0, int srcY0, int srcX1, int srcY1,

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1115,6 +1115,18 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
             ? mMaskedTextures.find(GetBaseTexturePath(metadata->resource->GetInitData()->Path))->second.replacementData
             : mRdp->loaded_texture[tmemIdex].addr;
 
+    // Check if this texture address is a registered GPU framebuffer mirror.
+    // If so, bind the GPU FB directly — full resolution, no CPU readback needed.
+    if (origAddr != nullptr && !importReplacement) {
+        auto fbIt = mFbTextures.find((uintptr_t)origAddr);
+        if (fbIt != mFbTextures.end()) {
+            Flush();
+            mRapi->SelectTextureFb(fbIt->second);
+            mRdp->textures_changed[i] = false;
+            return;
+        }
+    }
+
     if (origAddr == nullptr) {
         // Try the other TMEM slot -- some multi-tile setups only load one slot
         // and expect both tiles to reference it.
@@ -1395,7 +1407,10 @@ void Interpreter::GfxSpPopMatrix(uint32_t count) {
 }
 
 float Interpreter::AdjXForAspectRatio(float x) const {
-    if (mFbActive) {
+    // Skip widescreen adjustment for fixed-size off-screen FBs (HUD elements,
+    // small capture buffers). But resizable FBs (resize=true) are capturing
+    // the main scene and should match the window's aspect ratio.
+    if (mFbActive && mActiveFrameBuffer != mFrameBuffers.end() && !mActiveFrameBuffer->second.resize) {
         return x;
     } else {
         return x * (4.0f / 3.0f) / ((float)mCurDimensions.width / (float)mCurDimensions.height);
@@ -1703,9 +1718,7 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
                       (mRdp->other_mode_l & (3 << 16)) == (G_BL_1MA << 16)) ||
                      ((mRdp->other_mode_l & (3 << 22)) == (G_BL_CLR_MEM << 22) &&
                       (mRdp->other_mode_l & (3 << 18)) == (G_BL_1MA << 18));
-    uint8_t blend_src = mRdp->other_mode_l >> 30;
-    bool use_blend_color = blend_src == G_BL_CLR_BL;
-    bool use_fog = blend_src == G_BL_CLR_FOG || use_blend_color;
+    bool use_fog = (mRdp->other_mode_l >> 30) == G_BL_CLR_FOG;
     bool texture_edge = (mRdp->other_mode_l & CVG_X_ALPHA) == CVG_X_ALPHA;
     bool use_noise = (mRdp->other_mode_l & (3U << G_MDSFT_ALPHACOMPARE)) == G_AC_DITHER;
     bool use_2cyc = (mRdp->other_mode_h & (3U << G_MDSFT_CYCLETYPE)) == G_CYC_2CYCLE;
@@ -1720,6 +1733,15 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             texture_edge = false;
         }
         use_alpha = true;
+    }
+
+    // N64 coverage simulation: When ALPHA_CVG_SEL is set, the RDP blender uses
+    // coverage as its alpha input instead of the combiner output. On N64, coverage
+    // for textured pixels is derived from texture alpha — zero-alpha texels produce
+    // zero coverage and are never written, regardless of OPA/XLU blender mode.
+    if (!use_alpha && (mRdp->other_mode_l & ALPHA_CVG_SEL)) {
+        use_alpha = true;
+        alpha_threshold = true;
     }
 
     if (use_alpha) {
@@ -1970,18 +1992,10 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
         }
 
         if (use_fog) {
-            if (use_blend_color) {
-                // Shroud/blend mode: blend toward blend_color using fog alpha as factor
-                mBufVbo[mBufVboLen++] = mRdp->blend_color.r / 255.0f;
-                mBufVbo[mBufVboLen++] = mRdp->blend_color.g / 255.0f;
-                mBufVbo[mBufVboLen++] = mRdp->blend_color.b / 255.0f;
-                mBufVbo[mBufVboLen++] = mRdp->fog_color.a / 255.0f;
-            } else {
-                mBufVbo[mBufVboLen++] = mRdp->fog_color.r / 255.0f;
-                mBufVbo[mBufVboLen++] = mRdp->fog_color.g / 255.0f;
-                mBufVbo[mBufVboLen++] = mRdp->fog_color.b / 255.0f;
-                mBufVbo[mBufVboLen++] = v_arr[i]->color.a / 255.0f; // fog factor (not alpha)
-            }
+            mBufVbo[mBufVboLen++] = mRdp->fog_color.r / 255.0f;
+            mBufVbo[mBufVboLen++] = mRdp->fog_color.g / 255.0f;
+            mBufVbo[mBufVboLen++] = mRdp->fog_color.b / 255.0f;
+            mBufVbo[mBufVboLen++] = v_arr[i]->color.a / 255.0f; // fog factor (not alpha)
         }
 
         if (use_grayscale) {
@@ -2053,9 +2067,8 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
                     mBufVbo[mBufVboLen++] = color->g / 255.0f;
                     mBufVbo[mBufVboLen++] = color->b / 255.0f;
                 } else {
-                    if (use_fog && !use_blend_color && color == &v_arr[i]->color) {
-                        // Shade alpha is 100% for standard fog, blend color mode preserves
-                        // it since fog alpha is the blend factor
+                    if (use_fog && color == &v_arr[i]->color) {
+                        // Shade alpha is 100% for fog
                         mBufVbo[mBufVboLen++] = 1.0f;
                     } else {
                         mBufVbo[mBufVboLen++] = color->a / 255.0f;
@@ -2580,10 +2593,7 @@ void Interpreter::GfxDpSetFogColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
 }
 
 void Interpreter::GfxDpSetBlendColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
-    mRdp->blend_color.r = r;
-    mRdp->blend_color.g = g;
-    mRdp->blend_color.b = b;
-    mRdp->blend_color.a = a;
+    // TODO: Implement this command.
 }
 
 void Interpreter::GfxDpSetFillColor(uint32_t packed_color) {
@@ -2791,17 +2801,48 @@ void Interpreter::GfxDpImageRectangle(int32_t tile, int32_t w, int32_t h, int32_
 
 void Interpreter::GfxDpFillRectangle(int32_t ulx, int32_t uly, int32_t lrx, int32_t lry) {
     if (mRdp->color_image_address == mRdp->z_buf_address) {
-        // Don't clear Z buffer here since we already did it with glClear
+        // Fullscreen Z clears are redundant — already done by glClear at frame start.
+        bool isFullScreen = (ulx <= 0 && uly <= 0 && lrx >= (int32_t)(mNativeDimensions.width - 1) * 4 &&
+                             lry >= (int32_t)(mNativeDimensions.height - 1) * 4);
+        if (isFullScreen) {
+            return;
+        }
+
+        // Partial depth clear (e.g. HUD model regions): clear the actual depth buffer
+        // via a scissored depth clear instead of drawing a colored rect to the color buffer.
+        Flush();
+
+        // Convert U10.2 coords to pixel coords and add +1 pixel for fill mode
+        int32_t expanded_lrx = lrx + (1 << 2);
+        int32_t expanded_lry = lry + (1 << 2);
+        float x = ulx / 4.0f;
+        float y = expanded_lry / 4.0f;
+        float w = (expanded_lrx - ulx) / 4.0f;
+        float h = (expanded_lry - uly) / 4.0f;
+
+        struct XYWidthHeight area;
+        area.x = (int16_t)x;
+        area.y = (int16_t)y;
+        area.width = (uint32_t)w;
+        area.height = (uint32_t)h;
+        AdjustVIewportOrScissor(&area);
+
+        mRapi->ClearDepthRegion(area.x, area.y, area.width, area.height);
         return;
     }
     uint32_t mode = (mRdp->other_mode_h & (3U << G_MDSFT_CYCLETYPE));
 
-    // OTRTODO: This is a bit of a hack for widescreen screen fades, but it'll work for now...
-    if (ulx == 0 && uly == 0 && lrx == (319 * 4) && lry == (239 * 4)) {
-        ulx = -1024;
-        uly = -1024;
-        lrx = 2048;
-        lry = 2048;
+    // Expand fullscreen fill rects to cover widescreen viewports.
+    // Without this, screen clears and fades only cover the native 4:3 area.
+    if (ulx == 0 && uly == 0) {
+        bool isFullScreen = (lrx == ((int32_t)(mNativeDimensions.width - 1) * 4) &&
+                             lry == ((int32_t)(mNativeDimensions.height - 1) * 4));
+        if (isFullScreen) {
+            ulx = -1024;
+            uly = -1024;
+            lrx = 2048;
+            lry = 2048;
+        }
     }
 
     if (mode == G_CYC_COPY || mode == G_CYC_FILL) {
@@ -4567,6 +4608,14 @@ void Interpreter::SpReset() {
     CalculateNormalDir(&mRsp->lookat[1], mRsp->current_lookat_coeffs[1]);
 }
 
+void Interpreter::RegisterFbTexture(const void* cpuAddr, int fbId) {
+    mFbTextures[(uintptr_t)cpuAddr] = fbId;
+}
+
+void Interpreter::UnregisterFbTexture(const void* cpuAddr) {
+    mFbTextures.erase((uintptr_t)cpuAddr);
+}
+
 void Interpreter::GetDimensions(uint32_t* width, uint32_t* height, int32_t* posX, int32_t* posY) {
     mWapi->GetDimensions(width, height, posX, posY);
 }
@@ -5090,4 +5139,12 @@ extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height, uint32_t 
 
 extern "C" void gfx_texture_cache_clear() {
     Fast::mInstance.lock().get()->TextureCacheClear();
+}
+
+extern "C" void gfx_register_fb_texture(const void* cpuAddr, int fbId) {
+    Fast::mInstance.lock().get()->RegisterFbTexture(cpuAddr, fbId);
+}
+
+extern "C" void gfx_unregister_fb_texture(const void* cpuAddr) {
+    Fast::mInstance.lock().get()->UnregisterFbTexture(cpuAddr);
 }


### PR DESCRIPTION
This is 7/7 of splitting up https://github.com/Kenix3/libultraship/pull/1038 into easily digestible chunks for easier review and bisecting.

- Add `RegisterFbTexture`/`UnregisterFbTexture` API to map CPU addresses to GPU framebuffer IDs for direct texture sampling without CPU readback
- Resize OpenGL texture metadata vector in `SelectTextureFb` for FB color buffer handles created outside `NewTexture()`
- Apply widescreen aspect ratio correction to resizable off-screen framebuffers (`resize=true`) while still skipping fixed-size HUD/capture FBs
- Simulate N64 coverage-as-alpha when `ALPHA_CVG_SEL` is set, enabling alpha testing for OPA particle effects and similar transparent-cutout geometry
- Distinguish fullscreen vs partial depth clears in `GfxDpFillRectangle` — skip redundant fullscreen Z fills, issue proper scissored depth clears for sub-regions
- Add `ClearDepthRegion` to the rendering API with a default fallback and scissored OpenGL implementation
- Use `mNativeDimensions` instead of hardcoded 319/239 for fullscreen fill rect widescreen expansion
- Remove broken `use_blend_color` fog path — standard fog (`G_BL_CLR_FOG`) is the only blender source that works with the current shader setup