### PR TITLE
Fix race condition in O2rArchive by using per-thread zip handles

### DIFF
--- a/include/ship/resource/archive/O2rArchive.h
+++ b/include/ship/resource/archive/O2rArchive.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <stdint.h>
 #include <string>
+#include <mutex>
+#include <vector>
 
 #include "zip.h"
 
@@ -28,6 +30,10 @@ class O2rArchive final : virtual public Archive {
     std::shared_ptr<File> LoadFile(uint64_t hash);
 
   private:
+    zip_t* GetZipHandle();
+    void ReleaseZipHandle(zip_t* handle);
     zip_t* mZipArchive;
+    std::mutex mPoolMutex;
+    std::vector<zip_t*> mZipArchivePool;
 };
 } // namespace Ship

--- a/src/ship/resource/archive/O2rArchive.cpp
+++ b/src/ship/resource/archive/O2rArchive.cpp
@@ -3,14 +3,35 @@
 #include "ship/Context.h"
 #include "ship/window/Window.h"
 #include "spdlog/spdlog.h"
+#include <unordered_map>
 
 namespace Ship {
 O2rArchive::O2rArchive(const std::string& archivePath) : Archive(archivePath) {
+    mZipArchive = nullptr;
 }
 
 O2rArchive::~O2rArchive() {
     SPDLOG_TRACE("destruct o2rarchive: {}", GetPath());
     Close();
+}
+
+zip_t* O2rArchive::GetZipHandle() {
+    std::lock_guard<std::mutex> lock(mPoolMutex);
+    if (!mZipArchivePool.empty()) {
+        zip_t* handle = mZipArchivePool.back();
+        mZipArchivePool.pop_back();
+        return handle;
+    }
+    return zip_open(GetPath().c_str(), ZIP_RDONLY, nullptr);
+}
+
+void O2rArchive::ReleaseZipHandle(zip_t* handle) {
+    if (handle == nullptr) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(mPoolMutex);
+    mZipArchivePool.push_back(handle);
 }
 
 std::shared_ptr<File> O2rArchive::LoadFile(uint64_t hash) {
@@ -20,33 +41,38 @@ std::shared_ptr<File> O2rArchive::LoadFile(uint64_t hash) {
 }
 
 std::shared_ptr<File> O2rArchive::LoadFile(const std::string& filePath) {
-    if (mZipArchive == nullptr) {
+    zip_t* zipArchive = GetZipHandle();
+    if (zipArchive == nullptr) {
         SPDLOG_TRACE("Failed to open file {} from zip archive {}. Archive not open.", filePath, GetPath());
         return nullptr;
     }
 
-    auto zipEntryIndex = zip_name_locate(mZipArchive, filePath.c_str(), 0);
+    auto zipEntryIndex = zip_name_locate(zipArchive, filePath.c_str(), 0);
     if (zipEntryIndex < 0) {
         SPDLOG_TRACE("Failed to find file {} in zip archive  {}.", filePath, GetPath());
+        ReleaseZipHandle(zipArchive);
         return nullptr;
     }
 
     struct zip_stat zipEntryStat;
     zip_stat_init(&zipEntryStat);
-    if (zip_stat_index(mZipArchive, zipEntryIndex, 0, &zipEntryStat) != 0) {
+    if (zip_stat_index(zipArchive, zipEntryIndex, 0, &zipEntryStat) != 0) {
         SPDLOG_TRACE("Failed to get entry information for file {} in zip archive  {}.", filePath, GetPath());
+        ReleaseZipHandle(zipArchive);
         return nullptr;
     }
 
     // Filesize 0, no logging needed
     if (zipEntryStat.size == 0) {
         SPDLOG_TRACE("Failed to load file {}; filesize 0", filePath, GetPath());
+        ReleaseZipHandle(zipArchive);
         return nullptr;
     }
 
-    struct zip_file* zipEntryFile = zip_fopen_index(mZipArchive, zipEntryIndex, 0);
+    struct zip_file* zipEntryFile = zip_fopen_index(zipArchive, zipEntryIndex, 0);
     if (!zipEntryFile) {
         SPDLOG_TRACE("Failed to open file {} in zip archive  {}.", filePath, GetPath());
+        ReleaseZipHandle(zipArchive);
         return nullptr;
     }
 
@@ -60,6 +86,8 @@ std::shared_ptr<File> O2rArchive::LoadFile(const std::string& filePath) {
     if (zip_fclose(zipEntryFile) != 0) {
         SPDLOG_TRACE("Error closing file {} in zip archive  {}.", filePath, GetPath());
     }
+
+    ReleaseZipHandle(zipArchive);
 
     fileToLoad->IsLoaded = true;
 
@@ -90,18 +118,26 @@ bool O2rArchive::Open() {
 }
 
 bool O2rArchive::Close() {
-    if (mZipArchive == nullptr) {
-        SPDLOG_ERROR("Cannot close zip file. Zip file not loaded. \"{}\"", GetPath());
-        return false;
+    bool success = true;
+
+    if (mZipArchive != nullptr) {
+        if (zip_close(mZipArchive) == -1) {
+            SPDLOG_ERROR("Failed to close zip file \"{}\"", GetPath());
+            success = false;
+        }
+        mZipArchive = nullptr;
     }
 
-    if (zip_close(mZipArchive) == -1) {
-        SPDLOG_ERROR("Failed to close zip file \"{}\"", GetPath());
-        return false;
+    std::lock_guard<std::mutex> lock(mPoolMutex);
+    for (auto* handle : mZipArchivePool) {
+        if (zip_close(handle) == -1) {
+            SPDLOG_ERROR("Failed to close pooled zip file \"{}\"", GetPath());
+            success = false;
+        }
     }
+    mZipArchivePool.clear();
 
-    mZipArchive = nullptr;
-    return true;
+    return success;
 }
 
 bool O2rArchive::WriteFile(const std::string& filePath, const std::vector<uint8_t>& data) {
@@ -131,6 +167,15 @@ bool O2rArchive::WriteFile(const std::string& filePath, const std::vector<uint8_
                      zip_error_code_zip(error));
         zip_discard(mZipArchive); // Close zip and discard changes
         return false;
+    }
+
+    // Clear the pool as the file on disk has likely changed
+    {
+        std::lock_guard<std::mutex> lock(mPoolMutex);
+        for (auto* handle : mZipArchivePool) {
+            zip_close(handle);
+        }
+        mZipArchivePool.clear();
     }
 
     SPDLOG_INFO("Successfully wrote file: {}", filePath);


### PR DESCRIPTION
Replacing sync calls in the interpreter with asynchronous can result in crashes, as the zip_t object is shared among the threads in the thread pool. More info: https://libzip.org/documentation/libzip.html#THREAD_SAFETY.