### PR TITLE
Fix 64-bit address filter to cover ARM64 user-space

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -4502,8 +4502,8 @@ static void gfx_step() {
             uintptr_t w1 = (uintptr_t)cmd->words.w1;
             if (w1 < 0x10000
 #if UINTPTR_MAX > 0xFFFFFFFFu
-                // On 64-bit Windows, user-space tops out here.
-                || w1 > 0x00007FFFFFFFFFFFull
+                // On 64-bit: filter kernel/sentinel addresses.
+                || w1 > 0x0000FFFFFFFFFFFFull
 #endif
             ) {
                 ++g_exec_stack.currCmd();
@@ -4925,9 +4925,9 @@ int32_t gfx_check_image_signature(const char* imgData) {
         return 0;
     }
 #if UINTPTR_MAX > 0xFFFFFFFFu
-    // On 64-bit Windows, user-space addresses are below this limit.
-    // Anything above is kernel memory or a sentinel value.
-    if (i > 0x00007FFFFFFFFFFFull) {
+    // On 64-bit: filter kernel/sentinel addresses. Upper bound covers all
+    // user-space layouts (x86_64 47-bit canonical, ARM64 48-bit VA, etc.).
+    if (i > 0x0000FFFFFFFFFFFFull) {
         return 0;
     }
 #endif


### PR DESCRIPTION
- Widen the 64-bit address filter in `gfx_check_image_signature` and `gfx_step` from `0x00007FFFFFFFFFFFull` to `0x0000FFFFFFFFFFFFull`
- The old bound matched x86_64's 47-bit canonical user-space but rejected valid addresses on ARM64 Linux (48-bit VA), which could silently skip OTR signature checks and filepath handlers