### PR TITLE
Mac: Update spdlog

### DIFF
--- a/cmake/dependencies/mac.cmake
+++ b/cmake/dependencies/mac.cmake
@@ -8,7 +8,7 @@ if (NOT ${spdlog_FOUND})
     FetchContent_Declare(
         spdlog
         GIT_REPOSITORY https://github.com/gabime/spdlog.git
-        GIT_TAG v1.14.1
+        GIT_TAG v1.16.0
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(spdlog)


### PR DESCRIPTION
[mac.cmake](https://github.com/Kenix3/libultraship/blob/46bdbdd143ca9a1fe23226d1df8027083b664e05/cmake/dependencies/mac.cmake#L3) currently pulls in **spdlog 1.14.1** which causes build issues on the latest version of macOS / Xcode / Clang.

Looks like [ios.cmake](https://github.com/Kenix3/libultraship/blob/46bdbdd143ca9a1fe23226d1df8027083b664e05/cmake/dependencies/ios.cmake#L40) is pulling in 1.16.0, so I upgraded the Mac one to match.

### What was the error?
> build-cmake/_deps/spdlog-src/include/spdlog/fmt/bundled/format-inl.h:61:24: error: call to consteval function 'fmt::basic_format_string<char, fmt::basic_string_view<char> &, const char (&)[3]>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression

### When did this break?
It may have started breaking in the latest Xcode, version 26.4. That’s when Apple upgraded Clang from 17 to 21.

### Is this backwards compatible?
I believe so. Shipwright still builds after making this change (see https://github.com/HarbourMasters/Shipwright/pull/6491), and those workflows run on macos-14-arm64. From the SoH build log, it looks like they are using Clang 15.