### PR TITLE
fix Ios support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,3 +370,6 @@ extern/nlohmann-json/*_jsonConfig*
 *.xcsettings
 build*
 tcc_c2str
+
+CMakeFiles/
+Makefile

--- a/cmake/dependencies/ios.cmake
+++ b/cmake/dependencies/ios.cmake
@@ -59,6 +59,15 @@ if (NOT ${libzip_FOUND})
     set(BUILD_DOC OFF)
     set(BUILD_OSSFUZZ OFF)
     set(BUILD_SHARED_LIBS OFF)
+    set(ENABLE_ZSTD OFF)
+
+    # for some weird reason he think he are in C++11
+    set(HAVE_LOCALTIME_S 0 CACHE INTERNAL "" FORCE)
+    set(HAVE_MEMCPY_S 0 CACHE INTERNAL "" FORCE)
+    set(HAVE_STRERROR_S 0 CACHE INTERNAL "" FORCE)
+    set(HAVE_STRERRORLEN_S 0 CACHE INTERNAL "" FORCE)
+    set(HAVE_STRNCPY_S 0 CACHE INTERNAL "" FORCE)
+
     FetchContent_Declare(
         libzip
         GIT_REPOSITORY https://github.com/nih-at/libzip.git

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -232,7 +232,7 @@ void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
         }
     }
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && !defined(__IOS__)
     // Implement fullscreening with native macOS APIs
     if (on != isNativeMacOSFullscreenActive(mWnd)) {
         toggleNativeMacOSFullscreen(mWnd);
@@ -635,7 +635,7 @@ void GfxWindowBackendSDL2::HandleEvents() {
     }
 
     // resync fullscreen state
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(__IOS__)
     auto nextFullscreenState = isNativeMacOSFullscreenActive(mWnd);
     if (mFullScreen != nextFullscreenState) {
         mFullScreen = nextFullscreenState;

--- a/src/ship/CMakeLists.txt
+++ b/src/ship/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
     list(FILTER Source_Files__Audio EXCLUDE REGEX "audio/WasapiAudioPlayer.*")
 endif()
 
-if (NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
     list(FILTER Source_Files__Audio EXCLUDE REGEX "audio/CoreAudioAudioPlayer.*")
 endif()
 

--- a/src/ship/audio/CoreAudioAudioPlayer.cpp
+++ b/src/ship/audio/CoreAudioAudioPlayer.cpp
@@ -44,7 +44,11 @@ bool CoreAudioAudioPlayer::DoInit() {
 
     AudioComponentDescription desc;
     desc.componentType = kAudioUnitType_Output;
+#if defined(__IOS__)
+    desc.componentSubType = kAudioUnitSubType_RemoteIO;
+#else
     desc.componentSubType = kAudioUnitSubType_HALOutput;
+#endif
     desc.componentManufacturer = kAudioUnitManufacturer_Apple;
     desc.componentFlags = 0;
     desc.componentFlagsMask = 0;


### PR DESCRIPTION
partially based on https://github.com/Kenix3/libultraship/pull/1056
I use the same thing to prevent C11 detection (need to know why)
ios/Launch.storyboard and ios/plist.in have been move port side
use a better fix for core audio instead of disable it
instead of add stub function I have disable feature that use macos 
I have https://github.com/coco875/SpaghettiKart/tree/ios who use it (who are base on https://github.com/HarbourMasters/SpaghettiKart/pull/684) (where I need to check if every change are useful)