### PR TITLE
Apply tile-size clamps only for mipmap pyramids and CLAMP tiles

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -547,13 +547,21 @@ void Interpreter::ImportTextureRgba16(int tile, bool importReplacement) {
     uint32_t width = widthBytes / 2;
     uint32_t height = widthBytes > 0 ? sizeBytes / widthBytes : 0;
 
-    // Clamp to tile dimensions from SetTileSize (mipmap pyramids include all levels).
+    // Clamp to the rendered region only when the loaded buffer is ~1.33x of it (mipmap
+    // pyramid signature). Window-scrolling tiles have loaded ≈ rendered or loaded >> rendered;
+    // skip both. CLAMP wrap mode always opts in.
     uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
     uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
-    if (tile_w > 0 && tile_w < width) {
+    uint32_t loadedPixels = width * height;
+    uint32_t renderedPixels = tile_w * tile_h;
+    bool pyramidLike =
+        renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13; // < 1.625x
+    bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
+    bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
+    if ((pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if (tile_h > 0 && tile_h < height) {
+    if ((pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -607,13 +615,20 @@ void Interpreter::ImportTextureRgba32(int tile, bool importReplacement) {
     uint32_t width = widthBytes / 4;
     uint32_t height = widthBytes > 0 ? size_bytes / widthBytes : 0;
 
-    // Clamp to tile dimensions from SetTileSize
+    // Clamp to the rendered region only when the loaded buffer is ~1.33x of it (mipmap
+    // pyramid signature). Window-scrolling tiles have loaded ≈ rendered or loaded >> rendered;
+    // skip both. CLAMP wrap mode always opts in.
     uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
     uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
-    if (tile_w > 0 && tile_w < width) {
+    uint32_t loadedPixels = width * height;
+    uint32_t renderedPixels = tile_w * tile_h;
+    bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
+    bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
+    bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
+    if ((pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if (tile_h > 0 && tile_h < height) {
+    if ((pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -904,13 +919,20 @@ void Interpreter::ImportTextureCi4(int tile, bool importReplacement) {
     uint32_t width = resultLineSizeBytes * 2;
     uint32_t height = resultLineSizeBytes > 0 ? sizeBytes / resultLineSizeBytes : 0;
 
-    // Clamp to tile dimensions from SetTileSize
+    // Clamp to the rendered region only when the loaded buffer is ~1.33x of it (mipmap
+    // pyramid signature). Window-scrolling tiles have loaded ≈ rendered or loaded >> rendered;
+    // skip both. CLAMP wrap mode always opts in.
     uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
     uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
-    if (tile_w > 0 && tile_w < width) {
+    uint32_t loadedPixels = width * height;
+    uint32_t renderedPixels = tile_w * tile_h;
+    bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
+    bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
+    bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
+    if ((pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if (tile_h > 0 && tile_h < height) {
+    if ((pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -989,13 +1011,20 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
     uint32_t width = resultLineSizeBytes;
     uint32_t height = resultLineSizeBytes > 0 ? sizeBytes / resultLineSizeBytes : 0;
 
-    // Clamp to tile dimensions from SetTileSize
+    // Clamp to the rendered region only when the loaded buffer is ~1.33x of it (mipmap
+    // pyramid signature). Window-scrolling tiles have loaded ≈ rendered or loaded >> rendered;
+    // skip both. CLAMP wrap mode always opts in.
     uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
     uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
-    if (tile_w > 0 && tile_w < width) {
+    uint32_t loadedPixels = width * height;
+    uint32_t renderedPixels = tile_w * tile_h;
+    bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
+    bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
+    bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
+    if ((pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if (tile_h > 0 && tile_h < height) {
+    if ((pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -1863,11 +1892,15 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             tex_width2[i] = (uint32_t)(int32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
             tex_height2[i] = (uint32_t)(int32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
 
-            // Clamp to tile bounds (mipmap loads include all levels).
-            if (tex_width2[i] > 0 && tex_width2[i] < tex_width[i]) {
+            // Same pyramid-like ratio gate as ImportTexture: only clamp when loaded pixels
+            // are close to rendered pixels (mipmap), not when much bigger (window scroll).
+            uint32_t loadedPx = tex_width[i] * tex_height[i];
+            uint32_t renderedPx = tex_width2[i] * tex_height2[i];
+            bool pyrLike = renderedPx > 0 && loadedPx > renderedPx && loadedPx * 8 < renderedPx * 13;
+            if ((pyrLike || (cms & G_TX_CLAMP)) && tex_width2[i] > 0 && tex_width2[i] < tex_width[i]) {
                 tex_width[i] = tex_width2[i];
             }
-            if (tex_height2[i] > 0 && tex_height2[i] < tex_height[i]) {
+            if ((pyrLike || (cmt & G_TX_CLAMP)) && tex_height2[i] > 0 && tex_height2[i] < tex_height[i]) {
                 tex_height[i] = tex_height2[i];
             }
 


### PR DESCRIPTION
PR #1043 added two unconditional clamps that overwrote texture dimensions with the rendered window from `SetTileSize `whenever the latter was smaller:

- `ImportTextureXxx `(Rgba16, Rgba32, Ci4, Ci8): clamps the GPU upload size
- `GfxSpTri1`: clamps tex_width/tex_height used for UV [0,1] normalization.

The intent was to handle mipmap pyramid loads, where LoadBlock deposits a base mip plus smaller mips into a single TMEM region. Without clamping, the inflated loaded_size / line_size overshoots tex_height, and UVs sample past the base mip into the smaller-mip bytes.

But the clamps fire for any draw where (lrs - uls + 4) / 4 < tex_width, including:

- Scrolling tiles that use gDPSetTileSize to offset UV sampling into a tiling texture
- Window-clamped sub-regions rendered with gDPSetTileSizeInterp's float values
- Animated water/cloud effects that change uls/ult per frame
- 
In all those cases the clamp shrinks tex_width (and the ImportTexture upload size) to the visible window, so WRAP mode tiles the wrong amount of texture and the visual changes per frame as the scroll values animate.

This change replaces the unconditional clamps with a discriminator. The mipmap-pyramid signature is loaded_pixels slightly larger than rendered_pixels (≈1.33× because mips sum to 4/3 of the base). Window-scrolling tiles have loaded_pixels ≈ rendered_pixels or loaded_pixels >> rendered_pixels. We clamp when:

- 1.0 < loaded_pixels / rendered_pixels < ~1.625 (pyramid-like ratio), **or**
- The tile's wrap mode has G_TX_CLAMP set (the unambiguous "render only this sub-region" signal)