### PR TITLE
Remove early tlut mode check

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1156,16 +1156,6 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
     uint8_t paletteIndex = mRdp->texture_tile[tile].palette;
     uint32_t origSizeBytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].orig_size_bytes;
 
-    // Check TLUT mode early -- before cache lookup -- so the fmt override
-    // affects both the cache key and the decode path.
-    // Only override to CI for 4-bit and 8-bit texels, which are valid CI sizes.
-    // 16-bit and 32-bit texels are full-color formats that the N64 RDP decodes
-    // natively regardless of TLUT mode.
-    uint32_t tlutMode = mRdp->other_mode_h & (3U << G_MDSFT_TEXTLUT);
-    if (tlutMode != G_TT_NONE && fmt != G_IM_FMT_CI && (siz == G_IM_SIZ_4b || siz == G_IM_SIZ_8b)) {
-        fmt = G_IM_FMT_CI;
-    }
-
     const RawTexMetadata* metadata = &mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata;
     const uint8_t* origAddr =
         importReplacement && (metadata->resource != nullptr)


### PR DESCRIPTION
Reverts the per-draw fmt coercion to G_IM_FMT_CI introduced by #1044.

[gDPSetTextureLUT(mode)](http://n64devkit.square7.ch/n64man/gdp/gDPSetTextureLUT.htm) selects the format of TLUT entries (16-bit RGBA, 16-bit IA, or none) — not a global "decode all subsequent texels through the palette" flag. The active TLUT format is consulted only when a tile's own fmt field (set via [gDPSetTile](https://ultra64.ca/files/documentation/online-manuals/man/n64man/gdp/gDPSetTile.html)) is G_IM_FMT_CI. A tile explicitly set to G_IM_FMT_IA or G_IM_FMT_I decodes as IA/I regardless of whether a TLUT happens to be loaded.

Second reference [n64-fast3d-engine](https://github.com/Emill/n64-fast3d-engine/blob/master/gfx_pc.c) dispatches purely on rdp.texture_tile.fmt — no TLUT-mode override — and that is the hardware-faithful behavior.

The breakage found came from a third-party modeling/DL-generation tool that unconditionally emits `gsDPSetTextureLUT(G_TT_RGBA16)` before every textured draw, regardless of the tile's format. From the N64 RDP's perspective this is harmless. But the LUS override misreads the leftover TLUT mode as a per-draw "decode as CI" signal, and decodes the IA texture through whatever palette was last loaded — producing structured RGB noise that shifts with prior-draw state.

If a real DL exists in any port that relies on TLUT mode as the "treat this as CI" signal (i.e. a tile bound with `fmt=RGBA siz=4b/8b` that's intended to be CI), that DL will need to be identified and the override revisited — ideally with a per-game shim rather than a global behavior change.