### PR TITLE
Gate keystore behind ENABLE_SCRIPTING

### DIFF
--- a/.github/workflows/tidy-format-validation.yml
+++ b/.github/workflows/tidy-format-validation.yml
@@ -46,7 +46,7 @@ jobs:
         run: python3 -m pip install -r requirements.txt
       - name: Prepare compile_commands.json
         run: |
-          cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_SCRIPTING=ON
           cmake --build build --target GenerateScriptKeys
       - name: Create results directory
         run: |

--- a/include/ship/Context.h
+++ b/include/ship/Context.h
@@ -29,8 +29,8 @@ class FileDropMgr;
 class EventSystem;
 #ifdef ENABLE_SCRIPTING
 class ScriptLoader;
-#endif
 class Keystore;
+#endif
 
 /**
  * @brief Central singleton context for the libultraship engine.
@@ -180,9 +180,9 @@ class Context {
 #ifdef ENABLE_SCRIPTING
     /** @brief Returns the ScriptLoader subsystem. */
     std::shared_ptr<ScriptLoader> GetScriptLoader() const;
-#endif
     /** @brief Returns the Keystore subsystem used for archive signature verification. */
     std::shared_ptr<Keystore> GetKeystore() const;
+#endif
 
     /** @brief Returns the human-readable application name. */
     std::string GetName() const;
@@ -266,10 +266,10 @@ class Context {
     bool InitScriptLoader(std::unordered_map<std::string, std::string> compileDefines = {}, int codeVersion = 1,
                           std::string buildOptions = "-g -Wl", std::vector<std::string> includePaths = {},
                           std::vector<std::string> libraryPaths = {}, std::vector<std::string> libraries = {});
-#endif
 
     /** @brief Initializes the Keystore used for verifying signed archives. @return true on success. */
     bool InitKeystore();
+#endif
 
   protected:
     Context() = default;
@@ -291,8 +291,8 @@ class Context {
     std::shared_ptr<EventSystem> mEventSystem;
 #ifdef ENABLE_SCRIPTING
     std::shared_ptr<ScriptLoader> mScriptLoader;
-#endif
     std::shared_ptr<Keystore> mKeystore;
+#endif
 
     std::string mConfigFilePath;
     std::string mMainPath;

--- a/include/ship/resource/archive/ArchiveManager.h
+++ b/include/ship/resource/archive/ArchiveManager.h
@@ -9,12 +9,15 @@
 #include <stdint.h>
 #include <functional>
 #include "ship/resource/File.h"
+#ifdef ENABLE_SCRIPTING
 #include "ship/security/Keystore.h"
+#endif
 
 namespace Ship {
 struct File;
 class Archive;
 
+#ifdef ENABLE_SCRIPTING
 /**
  * @brief Callback invoked when an archive without a trusted key is added.
  *
@@ -22,6 +25,7 @@ class Archive;
  * the Keystore. Return true to accept the archive anyway, or false to reject it.
  */
 using UntrustedArchiveHandler = std::function<bool(Archive& archive, KeystoreEntry& key)>;
+#endif
 
 /**
  * @brief Manages a prioritised collection of mounted Archive objects.
@@ -188,6 +192,7 @@ class ArchiveManager {
      */
     bool IsGameVersionValid(uint32_t gameVersion);
 
+#ifdef ENABLE_SCRIPTING
     /**
      * @brief Sets the callback invoked when an untrusted (unsigned/unknown-key) archive is added.
      * @param handler Callback; return true to accept, false to reject the archive.
@@ -198,6 +203,7 @@ class ArchiveManager {
      * @brief Returns the current untrusted-archive handler.
      */
     UntrustedArchiveHandler GetUntrustedArchiveHandler() const;
+#endif
 
   protected:
     /**
@@ -220,6 +226,8 @@ class ArchiveManager {
     std::unordered_map<uint64_t, std::string> mHashes;
     std::unordered_set<std::string> mDirectories;
     std::unordered_map<uint64_t, std::shared_ptr<Archive>> mFileToArchive;
+#ifdef ENABLE_SCRIPTING
     UntrustedArchiveHandler mUntrustedArchiveHandler;
+#endif
 };
 } // namespace Ship

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,25 +21,27 @@ endif()
 
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/ship/install_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/ship/install_config.h @ONLY)
 
-file(GLOB SCRIPT_PUB_KEYS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../keys/script/*.pem")
-set(EMBEDDED_KEYS_HEADER ${CMAKE_CURRENT_BINARY_DIR}/ship/DefaultKeys.h)
-set(GENERATE_KEYS_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/../tools/generate_keys_header.py)
-get_filename_component(EMBEDDED_KEYS_DIR ${EMBEDDED_KEYS_HEADER} DIRECTORY)
+if(ENABLE_SCRIPTING)
+    file(GLOB SCRIPT_PUB_KEYS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../keys/script/*.pem")
+    set(EMBEDDED_KEYS_HEADER ${CMAKE_CURRENT_BINARY_DIR}/ship/DefaultKeys.h)
+    set(GENERATE_KEYS_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/../tools/generate_keys_header.py)
+    get_filename_component(EMBEDDED_KEYS_DIR ${EMBEDDED_KEYS_HEADER} DIRECTORY)
 
-add_custom_command(
-    OUTPUT ${EMBEDDED_KEYS_HEADER}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${EMBEDDED_KEYS_DIR}
-    COMMAND Python3::Interpreter ${GENERATE_KEYS_SCRIPT} 
-            ${EMBEDDED_KEYS_HEADER}
-            ${SCRIPT_PUB_KEYS}
-    DEPENDS ${GENERATE_KEYS_SCRIPT} 
-            ${SCRIPT_PUB_KEYS}
-    COMMENT "Generating DefaultKeys.h from all keys in /keys/script/"
-    VERBATIM
-)
+    add_custom_command(
+        OUTPUT ${EMBEDDED_KEYS_HEADER}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${EMBEDDED_KEYS_DIR}
+        COMMAND Python3::Interpreter ${GENERATE_KEYS_SCRIPT}
+                ${EMBEDDED_KEYS_HEADER}
+                ${SCRIPT_PUB_KEYS}
+        DEPENDS ${GENERATE_KEYS_SCRIPT}
+                ${SCRIPT_PUB_KEYS}
+        COMMENT "Generating DefaultKeys.h from all keys in /keys/script/"
+        VERBATIM
+    )
 
-add_custom_target(GenerateScriptKeys DEPENDS ${EMBEDDED_KEYS_HEADER})
-add_dependencies(libultraship GenerateScriptKeys)
+    add_custom_target(GenerateScriptKeys DEPENDS ${EMBEDDED_KEYS_HEADER})
+    add_dependencies(libultraship GenerateScriptKeys)
+endif()
 
 #=================== Fast ===================
 

--- a/src/ship/CMakeLists.txt
+++ b/src/ship/CMakeLists.txt
@@ -86,9 +86,11 @@ endif()
 
 #=================== Security ===================
 
-file(GLOB_RECURSE Source_Files__Security RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "security/*.cpp")
-source_group("security" FILES ${Source_Files__Security})
-target_sources(libultraship PRIVATE ${Source_Files__Security})
+if(ENABLE_SCRIPTING)
+    file(GLOB_RECURSE Source_Files__Security RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "security/*.cpp")
+    source_group("security" FILES ${Source_Files__Security})
+    target_sources(libultraship PRIVATE ${Source_Files__Security})
+endif()
 
 #=================== Port ===================
 

--- a/src/ship/Context.cpp
+++ b/src/ship/Context.cpp
@@ -13,8 +13,8 @@
 #include "ship/events/EventSystem.h"
 #ifdef ENABLE_SCRIPTING
 #include "ship/scripting/ScriptLoader.h"
-#endif
 #include "ship/security/Keystore.h"
+#endif
 
 #ifdef _WIN32
 #include <libloaderapi.h>
@@ -54,8 +54,8 @@ Context::~Context() {
         mScriptLoader->UnloadAll();
     }
     mScriptLoader = nullptr;
-#endif
     mKeystore = nullptr;
+#endif
     GetConfig()->Save();
     mConfig = nullptr;
     spdlog::shutdown();
@@ -221,7 +221,9 @@ bool Context::InitResourceManager(const std::vector<std::string>& archivePaths,
         return true;
     }
 
+#ifdef ENABLE_SCRIPTING
     InitKeystore();
+#endif
 
     mMainPath = GetConfig()->GetString("Game.Main Archive", GetAppDirectoryPath());
     mPatchesPath = GetConfig()->GetString("Game.Patches Archive", GetAppDirectoryPath() + "/mods");
@@ -388,7 +390,6 @@ bool Context::InitScriptLoader(std::unordered_map<std::string, std::string> comp
     }
     return true;
 }
-#endif // ENABLE_SCRIPTING
 
 bool Context::InitKeystore() {
     if (GetKeystore() != nullptr) {
@@ -402,6 +403,7 @@ bool Context::InitKeystore() {
     }
     return true;
 }
+#endif // ENABLE_SCRIPTING
 
 std::shared_ptr<ConsoleVariable> Context::GetConsoleVariables() const {
     return mConsoleVariables;
@@ -455,11 +457,11 @@ std::shared_ptr<EventSystem> Context::GetEventSystem() const {
 std::shared_ptr<ScriptLoader> Context::GetScriptLoader() const {
     return mScriptLoader;
 }
-#endif
 
 std::shared_ptr<Keystore> Context::GetKeystore() const {
     return mKeystore;
 }
+#endif
 
 std::string Context::GetName() const {
     return mName;

--- a/src/ship/resource/archive/Archive.cpp
+++ b/src/ship/resource/archive/Archive.cpp
@@ -11,7 +11,9 @@
 #include "ship/utils/StrHash64.h"
 #include "ship/window/Window.h"
 #include "ship/utils/StringHelper.h"
+#ifdef ENABLE_SCRIPTING
 #include "ship/security/Keystore.h"
+#endif
 
 #include <tinyxml2.h>
 #include <monocypher.h>
@@ -179,6 +181,7 @@ void Archive::IndexFile(const std::string& filePath) {
 }
 
 void Archive::Validate() {
+#ifdef ENABLE_SCRIPTING
     if (mManifest.Checksum.empty()) {
         SPDLOG_WARN("Archive {} does not have a checksum in its metadata, skipping validation", GetPath());
         return;
@@ -284,6 +287,7 @@ void Archive::Validate() {
 
     mIsSigned = true;
     SPDLOG_INFO("Archive {} successfully authenticated.", GetPath());
+#endif // ENABLE_SCRIPTING
 }
 
 } // namespace Ship

--- a/src/ship/resource/archive/ArchiveManager.cpp
+++ b/src/ship/resource/archive/ArchiveManager.cpp
@@ -296,6 +296,7 @@ bool ArchiveManager::IsGameVersionValid(uint32_t gameVersion) {
     return mValidGameVersions.empty() || mValidGameVersions.contains(gameVersion);
 }
 
+#ifdef ENABLE_SCRIPTING
 void ArchiveManager::SetUntrustedArchiveHandler(const UntrustedArchiveHandler& handler) {
     mUntrustedArchiveHandler = handler;
 }
@@ -303,5 +304,6 @@ void ArchiveManager::SetUntrustedArchiveHandler(const UntrustedArchiveHandler& h
 UntrustedArchiveHandler ArchiveManager::GetUntrustedArchiveHandler() const {
     return mUntrustedArchiveHandler;
 }
+#endif
 
 } // namespace Ship

--- a/tests/archive_resource_tests.cpp
+++ b/tests/archive_resource_tests.cpp
@@ -380,6 +380,7 @@ TEST(ArchiveManager, GetGameVersionsEmptyOnStart) {
     EXPECT_TRUE(am.GetGameVersions().empty());
 }
 
+#ifdef ENABLE_SCRIPTING
 // ============================================================
 // ArchiveManager — UntrustedArchiveHandler
 // ============================================================
@@ -396,6 +397,7 @@ TEST(ArchiveManager, SetAndGetUntrustedArchiveHandler) {
 
     EXPECT_NE(am.GetUntrustedArchiveHandler(), nullptr);
 }
+#endif
 
 // ============================================================
 // ArchiveManager — WriteFile


### PR DESCRIPTION
Piggybacks on the opt-in scripting refactor in 860fcbf27ea76e3490652da298f8ad97f4e9a1d5

The `Keystore` subsystem is the trust mechanism for signed scripts and signed archives, so it belongs behind the same `ENABLE_SCRIPTING` gate as TCC. Builds with scripting disabled still required the Python cryptography module to generate `DefaultKeys.h`, which was a hard build break for ports that don't ship scripting at all.

`<functional>` in ArchiveManager.h and the `monocypher` includes in Archive.cpp are dead when scripting is off but left in place to avoid mixing concerns.