### PR TITLE
Replace mod() with clamp() in shader WRAP macro

### DIFF
--- a/src/fast/shaders/opengl/default.shader.glsl
+++ b/src/fast/shaders/opengl/default.shader.glsl
@@ -130,7 +130,7 @@
     uniform int texture_filtering[2];
 
     #define TEX_OFFSET(off) @{texture}(tex, texCoord - off / texSize)
-    #define WRAP(x, low, high) mod((x)-(low), (high)-(low)) + (low)
+    #define WRAP(x, low, high) clamp((x), (low), (high))
 
     float random(in vec3 value) {
         float random = dot(sin(value), vec3(12.9898, 78.233, 37.719));


### PR DESCRIPTION
Ship of Harkinian renders textures as missing on devices using PowerVR Rogue GPUs, others untested. Geometry is visible but many textured surfaces are transparent. Same binary works fine on Mali, Adreno, and desktop drivers.

I tracked it down to the fragment shader's WRAP macro:
`#define WRAP(x, low, high) mod((x)-(low), (high)-(low)) + (low)`

On Rogue, `mod()` here returns values outside `[low, high]`. The downstream `clamp(texel, 0.0, 1.0)` then snaps those to `0`. With `texel.a == 0` and `glBlendFunc(GL_SRC_ALPHA, ...)`, pixels contribute nothing to the framebuffer.

The Khronos GLSL spec [explicitly warns](https://registry.khronos.org/OpenGL-Refpages/gl4/html/mod.xhtml) that implementations may compute `mod()` imprecisely: "the error can be large due to the discontinuity in floor... can also cause the result to have a different sign than the infinitely precise result." Similar `mod()` bugs are documented on [Raspberry Pi VideoCore](https://forums.raspberrypi.com/viewtopic.php?t=189455), [Mesa swrast](https://bugs.freedesktop.org/show_bug.cgi?id=27286), and [Metal via Naga](https://github.com/gfx-rs/naga/issues/802).

Replace mod with clamp. It's strictly different math, but functionally equivalent for Harkinian's combiner output range (which as far as I can tell never goes far enough out to need wrap-around) and a subsequent clamp(0, 1) erases any remaining difference at output.

Original wrap:

<img width="2107" height="2163" alt="image" src="https://github.com/user-attachments/assets/007f5d69-b359-4857-9db5-d4709350de46" /></br>

<img width="1134" height="785" alt="image" src="https://github.com/user-attachments/assets/1c588508-0c52-4e2e-aa26-9baba0becb90" /></br>

After change:

<img width="3458" height="2160" alt="image" src="https://github.com/user-attachments/assets/41ddbfcf-1478-434e-aa26-098b9d77a3d7" /></br>

If there is a regression due to this change, it will most likely be visible in terrain decals, fog, or particle effects. I would greatly appreciate spot-check tests before merging, and the shader file doesn't require recompiling anything so anyone can test by replacing the shader file in the port o2r.