### PR TITLE
Fixed building on GCC 16

### DIFF
--- a/include/ship/window/MouseStateManager.h
+++ b/include/ship/window/MouseStateManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdint.h>
 #include <memory>
 
 namespace Ship {


### PR DESCRIPTION
GCC released recently and made dependencies stricter, causing compiler errors due to uint_32 not being in scope. Adding this include fixes the issue