### PR TITLE
Untangle various parts from the Context destructor

### DIFF
--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -42,6 +42,7 @@ typedef struct {
             uint32_t Height; ///< Framebuffer height in pixels.
         } Gx2;
     };
+    int32_t Backend;
 } GuiWindowInitData;
 
 /**
@@ -152,8 +153,8 @@ class Fast3dGui : public Ship::Gui {
      */
     ImTextureID GetTextureById(int32_t id);
 
-    std::weak_ptr<Interpreter> mInterpreter; ///< Weak reference to the Fast3D scripting interpreter.
     GuiWindowInitData mImpl;                 ///< Backend-specific window/context handles passed to Init().
+    std::weak_ptr<Interpreter> mInterpreter; ///< Weak reference to the Fast3D scripting interpreter.
 
   private:
     /** @brief Applies any pending resolution or MSAA changes to the render target. */
@@ -163,8 +164,7 @@ class Fast3dGui : public Ship::Gui {
      * @brief Returns the integer scaling factor applied to the game viewport.
      * @return Scaling multiplier (1 = native, 2 = 2×, etc.).
      */
-    int16_t GetIntegerScaleFactor();
-
     std::unordered_map<std::string, Ship::GuiTextureMetadata> mGuiTextures; ///< Cached GPU texture registry.
+    int16_t GetIntegerScaleFactor();
 };
 } // namespace Fast

--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <SDL2/SDL.h>
+
+#include "Fast3dWindow.h"
 #include "ship/window/gui/Gui.h"
 #include "fast/WindowEvent.h"
 #include "fast/resource/type/Texture.h"
@@ -42,7 +44,7 @@ typedef struct {
             uint32_t Height; ///< Framebuffer height in pixels.
         } Gx2;
     };
-    int32_t Backend;
+    WindowBackend Backend;
 } GuiWindowInitData;
 
 /**
@@ -153,8 +155,8 @@ class Fast3dGui : public Ship::Gui {
      */
     ImTextureID GetTextureById(int32_t id);
 
-    GuiWindowInitData mImpl;                 ///< Backend-specific window/context handles passed to Init().
     std::weak_ptr<Interpreter> mInterpreter; ///< Weak reference to the Fast3D scripting interpreter.
+    GuiWindowInitData mImpl;                 ///< Backend-specific window/context handles passed to Init().
 
   private:
     /** @brief Applies any pending resolution or MSAA changes to the render target. */
@@ -164,7 +166,8 @@ class Fast3dGui : public Ship::Gui {
      * @brief Returns the integer scaling factor applied to the game viewport.
      * @return Scaling multiplier (1 = native, 2 = 2×, etc.).
      */
-    std::unordered_map<std::string, Ship::GuiTextureMetadata> mGuiTextures; ///< Cached GPU texture registry.
     int16_t GetIntegerScaleFactor();
+
+    std::unordered_map<std::string, Ship::GuiTextureMetadata> mGuiTextures; ///< Cached GPU texture registry.
 };
 } // namespace Fast

--- a/include/libultraship/bridge/resourcebridge.h
+++ b/include/libultraship/bridge/resourcebridge.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "stdint.h"
+#include "stddef.h"
 #include "ship/Api.h"
 
 #ifdef __cplusplus
-#include "fast/resource/type/Texture.h"
 #include "ship/resource/Resource.h"
 #include <memory>
 

--- a/include/ship/Context.h
+++ b/include/ship/Context.h
@@ -40,15 +40,18 @@ class Keystore;
  * auto ctx = Ship::Context::CreateInstance("MyApp", "app", "config.json", archivePaths);
  * // ... use ctx->GetResourceManager(), ctx->GetWindow(), etc.
  * @endcode
+ * @note Pointers to @code Context@endcode should not be stored as members. You should always access
+ * @code Context@endcode via GetRawInstance
  */
 class Context {
   public:
     /**
      * @brief Returns the currently active global Context instance.
-     * @return Shared pointer to the Context, or an empty pointer if none exists.
+     * @return Raw pointer to the Context. This should not be considered shared and should be considered invalid
+     * once the scope ends.
      */
-    static std::shared_ptr<Context> GetInstance();
-
+    static Context* GetRawInstance();
+    static void DestroyInstance();
     /**
      * @brief Creates, initializes, and stores the global Context instance.
      *
@@ -63,15 +66,15 @@ class Context {
      * @param audioSettings     Initial audio backend and channel configuration.
      * @param window            Optional pre-constructed Window to use; if nullptr a default is created.
      * @param controlDeck       Optional pre-constructed ControlDeck; if nullptr a default is created.
-     * @return Shared pointer to the fully initialized Context.
+     * @return Raw pointer to the fully initialized Context.
+     * @note The pointer returned by this function is only for convenience directly after creating an instance.
      */
-    static std::shared_ptr<Context> CreateInstance(const std::string& name, const std::string& shortName,
-                                                   const std::string& configFilePath,
-                                                   const std::vector<std::string>& archivePaths = {},
-                                                   const std::unordered_set<uint32_t>& validHashes = {},
-                                                   uint32_t reservedThreadCount = 1, AudioSettings audioSettings = {},
-                                                   std::shared_ptr<Window> window = nullptr,
-                                                   std::shared_ptr<ControlDeck> controlDeck = nullptr);
+    static Context* CreateInstance(const std::string& name, const std::string& shortName,
+                                   const std::string& configFilePath, const std::vector<std::string>& archivePaths = {},
+                                   const std::unordered_set<uint32_t>& validHashes = {},
+                                   uint32_t reservedThreadCount = 1, AudioSettings audioSettings = {},
+                                   std::shared_ptr<Window> window = nullptr,
+                                   std::shared_ptr<ControlDeck> controlDeck = nullptr);
 
     /**
      * @brief Creates a Context that has not yet been initialized.
@@ -81,10 +84,11 @@ class Context {
      * @param name           Human-readable application name.
      * @param shortName      Short application identifier.
      * @param configFilePath Path to the JSON configuration file.
-     * @return Shared pointer to the uninitialized Context.
+     * @return Raw pointer to the uninitialized Context.
+     * @note The pointer returned by this function is only for convenience directly after creating an instance.
      */
-    static std::shared_ptr<Context> CreateUninitializedInstance(const std::string& name, const std::string& shortName,
-                                                                const std::string& configFilePath);
+    static Context* CreateUninitializedInstance(const std::string& name, const std::string& shortName,
+                                                const std::string& configFilePath);
 
     /**
      * @brief Returns the platform-specific application bundle directory (e.g. the .app bundle on macOS).
@@ -266,7 +270,7 @@ class Context {
     Context() = default;
 
   private:
-    static std::weak_ptr<Context> mContext;
+    static Context* mContext;
 
     std::shared_ptr<spdlog::logger> mLogger;
     std::shared_ptr<Config> mConfig;

--- a/include/ship/Context.h
+++ b/include/ship/Context.h
@@ -270,9 +270,13 @@ class Context {
     Context() = default;
 
   private:
-    static Context* mContext;
+    static std::unique_ptr<Context> mContext;
 
     std::shared_ptr<spdlog::logger> mLogger;
+    // We only need the spdlog threadpool on release builds because of the async logger.
+#ifndef _DEBUG
+    std::shared_ptr<spdlog::details::thread_pool> mLogThreadPool;
+#endif
     std::shared_ptr<Config> mConfig;
     std::shared_ptr<ConsoleVariable> mConsoleVariables;
     std::shared_ptr<ResourceManager> mResourceManager;

--- a/include/ship/resource/ResourceManager.h
+++ b/include/ship/resource/ResourceManager.h
@@ -84,7 +84,7 @@ struct ResourceIdentifierHash {
  *
  * Typical usage:
  * @code
- * auto rm = Ship::Context::GetInstance()->GetResourceManager();
+ * auto rm = Ship::Context::GetRawInstance()->GetResourceManager();
  * auto tex = rm->LoadResource<Ship::Texture>("textures/foo.tex");
  * @endcode
  */

--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -66,8 +66,7 @@ bool Fast3dGui::SupportsViewports() {
 }
 
 void Fast3dGui::HandleWindowEvents(Fast::WindowEvent event) {
-    auto window = Ship::Context::GetInstance()->GetWindow();
-    switch (window->GetWindowBackend()) {
+    switch (mImpl.Backend) {
         case WindowBackend::FAST3D_SDL_OPENGL:
         case WindowBackend::FAST3D_SDL_METAL:
             ImGui_ImplSDL2_ProcessEvent(static_cast<const SDL_Event*>(event.Sdl.Event));
@@ -87,13 +86,10 @@ void Fast3dGui::HandleWindowEvents(Fast::WindowEvent event) {
 }
 
 void Fast3dGui::ImGuiWMInit() {
-    auto window = Ship::Context::GetInstance()->GetWindow();
-    mInterpreter = std::dynamic_pointer_cast<Fast3dWindow>(window)->GetInterpreterWeak();
-
-    switch (window->GetWindowBackend()) {
+    switch (mImpl.Backend) {
         case WindowBackend::FAST3D_SDL_OPENGL:
             SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "1");
-            if (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_ALLOW_BACKGROUND_INPUTS, 1)) {
+            if (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_ALLOW_BACKGROUND_INPUTS, 1)) {
                 SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
             }
             ImGui_ImplSDL2_InitForOpenGL(static_cast<SDL_Window*>(mImpl.Opengl.Window), mImpl.Opengl.Context);
@@ -101,7 +97,7 @@ void Fast3dGui::ImGuiWMInit() {
 #if __APPLE__
         case WindowBackend::FAST3D_SDL_METAL:
             SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "1");
-            if (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_ALLOW_BACKGROUND_INPUTS, 1)) {
+            if (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_ALLOW_BACKGROUND_INPUTS, 1)) {
                 SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
             }
             ImGui_ImplSDL2_InitForMetal(static_cast<SDL_Window*>(mImpl.Metal.Window));
@@ -118,8 +114,7 @@ void Fast3dGui::ImGuiWMInit() {
 }
 
 void Fast3dGui::ImGuiWMShutdown() {
-    auto window = Ship::Context::GetInstance()->GetWindow();
-    switch (window->GetWindowBackend()) {
+    switch (mImpl.Backend) {
 #ifdef ENABLE_OPENGL
         case WindowBackend::FAST3D_SDL_OPENGL:
             ImGui_ImplSDL2_Shutdown();
@@ -141,8 +136,9 @@ void Fast3dGui::ImGuiWMShutdown() {
 }
 
 void Fast3dGui::ImGuiBackendInit() {
-    auto window = Ship::Context::GetInstance()->GetWindow();
-    switch (window->GetWindowBackend()) {
+    auto window = Ship::Context::GetRawInstance()->GetWindow();
+    mInterpreter = std::dynamic_pointer_cast<Fast3dWindow>(window)->GetInterpreterWeak();
+    switch (mImpl.Backend) {
 #ifdef ENABLE_OPENGL
         case WindowBackend::FAST3D_SDL_OPENGL:
 #ifdef __APPLE__
@@ -175,8 +171,7 @@ void Fast3dGui::ImGuiBackendInit() {
 }
 
 void Fast3dGui::ImGuiBackendShutdown() {
-    auto window = Ship::Context::GetInstance()->GetWindow();
-    switch (window->GetWindowBackend()) {
+    switch (mImpl.Backend) {
 #ifdef ENABLE_OPENGL
         case WindowBackend::FAST3D_SDL_OPENGL:
             ImGui_ImplOpenGL3_Shutdown();
@@ -198,8 +193,7 @@ void Fast3dGui::ImGuiBackendShutdown() {
 }
 
 void Fast3dGui::ImGuiBackendNewFrame() {
-    auto window = Ship::Context::GetInstance()->GetWindow();
-    switch (window->GetWindowBackend()) {
+    switch (mImpl.Backend) {
 #ifdef ENABLE_OPENGL
         case WindowBackend::FAST3D_SDL_OPENGL:
             ImGui_ImplOpenGL3_NewFrame();
@@ -225,8 +219,7 @@ void Fast3dGui::ImGuiBackendNewFrame() {
 }
 
 void Fast3dGui::ImGuiWMNewFrame() {
-    auto window = Ship::Context::GetInstance()->GetWindow();
-    switch (window->GetWindowBackend()) {
+    switch (mImpl.Backend) {
         case WindowBackend::FAST3D_SDL_OPENGL:
         case WindowBackend::FAST3D_SDL_METAL:
             ImGui_ImplSDL2_NewFrame();
@@ -242,8 +235,7 @@ void Fast3dGui::ImGuiWMNewFrame() {
 }
 
 void Fast3dGui::ImGuiRenderDrawData(ImDrawData* data) {
-    auto window = Ship::Context::GetInstance()->GetWindow();
-    switch (window->GetWindowBackend()) {
+    switch (mImpl.Backend) {
 #ifdef ENABLE_OPENGL
         case WindowBackend::FAST3D_SDL_OPENGL:
             ImGui_ImplOpenGL3_RenderDrawData(data);
@@ -273,9 +265,8 @@ void Fast3dGui::DrawFloatingWindows() {
         return;
     }
 
-    auto window = Ship::Context::GetInstance()->GetWindow();
     // OpenGL requires extra platform handling for the GL context
-    if (window->GetWindowBackend() == WindowBackend::FAST3D_SDL_OPENGL && mImpl.Opengl.Context != nullptr) {
+    if (mImpl.Backend == WindowBackend::FAST3D_SDL_OPENGL && mImpl.Opengl.Context != nullptr) {
         // Backup window and context before calling RenderPlatformWindowsDefault
         SDL_Window* backupCurrentWindow = SDL_GL_GetCurrentWindow();
         SDL_GLContext backupCurrentContext = SDL_GL_GetCurrentContext();
@@ -288,7 +279,7 @@ void Fast3dGui::DrawFloatingWindows() {
     } else {
 #ifdef __APPLE__
         // Metal requires additional frame setup to get ImGui ready for drawing floating windows
-        if (window->GetWindowBackend() == WindowBackend::FAST3D_SDL_METAL) {
+        if (mImpl.Backend == WindowBackend::FAST3D_SDL_METAL) {
             GfxRenderingAPIMetal* api = (GfxRenderingAPIMetal*)mInterpreter.lock()->GetCurrentRenderingAPI();
             api->SetupFloatingFrame();
         }
@@ -315,22 +306,23 @@ void Fast3dGui::CalculateGameViewport() {
     mainPos.x -= mTemporaryWindowPos.x;
     mainPos.y -= mTemporaryWindowPos.y;
     ImVec2 size = ImGui::GetContentRegionAvail();
-    mInterpreter.lock()->mCurDimensions.width = (uint32_t)(size.x * mInterpreter.lock()->mCurDimensions.internal_mul);
-    mInterpreter.lock()->mCurDimensions.height = (uint32_t)(size.y * mInterpreter.lock()->mCurDimensions.internal_mul);
-    mInterpreter.lock()->mGameWindowViewport.x = (int16_t)mainPos.x;
-    mInterpreter.lock()->mGameWindowViewport.y = (int16_t)mainPos.y;
-    mInterpreter.lock()->mGameWindowViewport.width = (int16_t)size.x;
-    mInterpreter.lock()->mGameWindowViewport.height = (int16_t)size.y;
+    const auto interpreter = mInterpreter.lock().get();
+    interpreter->mCurDimensions.width = (uint32_t)(size.x * mInterpreter.lock()->mCurDimensions.internal_mul);
+    interpreter->mCurDimensions.height = (uint32_t)(size.y * mInterpreter.lock()->mCurDimensions.internal_mul);
+    interpreter->mGameWindowViewport.x = (int16_t)mainPos.x;
+    interpreter->mGameWindowViewport.y = (int16_t)mainPos.y;
+    interpreter->mGameWindowViewport.width = (int16_t)size.x;
+    interpreter->mGameWindowViewport.height = (int16_t)size.y;
 
-    if (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled",
-                                                                        0)) {
+    if (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled",
+                                                                           0)) {
         ApplyResolutionChanges();
     }
 
-    switch (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_LOW_RES_MODE, 0)) {
+    switch (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_LOW_RES_MODE, 0)) {
         case 1: { // N64 Mode
-            mInterpreter.lock()->mCurDimensions.width = 320;
-            mInterpreter.lock()->mCurDimensions.height = 240;
+            interpreter->mCurDimensions.width = 320;
+            interpreter->mCurDimensions.height = 240;
             /*
             const int sw = size.y * 320 / 240;
             mInterpreter.lock()->mGameWindowViewport.x += ((int)size.x - sw) / 2;
@@ -338,15 +330,15 @@ void Fast3dGui::CalculateGameViewport() {
             break;
         }
         case 2: { // 240p Widescreen
-            const int vertRes = 240;
-            mInterpreter.lock()->mCurDimensions.width = vertRes * size.x / size.y;
-            mInterpreter.lock()->mCurDimensions.height = vertRes;
+            constexpr int vertRes = 240;
+            interpreter->mCurDimensions.width = vertRes * size.x / size.y;
+            interpreter->mCurDimensions.height = vertRes;
             break;
         }
         case 3: { // 480p Widescreen
-            const int vertRes = 480;
-            mInterpreter.lock()->mCurDimensions.width = vertRes * size.x / size.y;
-            mInterpreter.lock()->mCurDimensions.height = vertRes;
+            constexpr int vertRes = 480;
+            interpreter->mCurDimensions.width = vertRes * size.x / size.y;
+            interpreter->mCurDimensions.height = vertRes;
             break;
         }
     }
@@ -371,21 +363,22 @@ void Fast3dGui::DrawGame() {
     ImVec2 mainPos = ImGui::GetWindowPos();
     ImVec2 size = ImGui::GetContentRegionAvail();
     ImVec2 pos = ImVec2(0, 0);
-    if (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_LOW_RES_MODE, 0) ==
+    const auto interpreter = mInterpreter.lock().get();
+
+    if (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_LOW_RES_MODE, 0) ==
         1) { // N64 Mode takes priority
         const float sw = size.y * 320.0f / 240.0f;
         pos = ImVec2(floor(size.x / 2 - sw / 2), 0);
         size = ImVec2(sw, size.y);
-    } else if (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    } else if (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
                    CVAR_PREFIX_ADVANCED_RESOLUTION ".Enabled", 0)) {
-        if (!Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        if (!Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
                 CVAR_PREFIX_ADVANCED_RESOLUTION ".PixelPerfectMode", 0)) {
-            if (!Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+            if (!Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
                     CVAR_PREFIX_ADVANCED_RESOLUTION ".IgnoreAspectCorrection", 0)) {
-                float sWdth =
-                    size.y * mInterpreter.lock()->mCurDimensions.width / mInterpreter.lock()->mCurDimensions.height;
-                float sHght =
-                    size.x * mInterpreter.lock()->mCurDimensions.height / mInterpreter.lock()->mCurDimensions.width;
+                float sWdth = size.y * interpreter->mCurDimensions.width / interpreter->mCurDimensions.height;
+                float sHght = size.x * interpreter->mCurDimensions.height / interpreter->mCurDimensions.width;
+
                 float sPosX = floor(size.x / 2.0f - sWdth / 2.0f);
                 float sPosY = floor(size.y / 2.0f - sHght / 2.0f);
                 if (sPosY < 0.0f) { // pillarbox
@@ -401,14 +394,14 @@ void Fast3dGui::DrawGame() {
             }
         } else { // in pixel perfect mode it's much easier
             const int factor = GetIntegerScaleFactor();
-            float sPosX = floor(size.x / 2.0f - (mInterpreter.lock()->mCurDimensions.width * factor) / 2.0f);
-            float sPosY = floor(size.y / 2.0f - (mInterpreter.lock()->mCurDimensions.height * factor) / 2.0f);
+            float sPosX = floor(size.x / 2.0f - (interpreter->mCurDimensions.width * factor) / 2.0f);
+            float sPosY = floor(size.y / 2.0f - (interpreter->mCurDimensions.height * factor) / 2.0f);
             pos = ImVec2(sPosX, sPosY);
-            size = ImVec2(float(mInterpreter.lock()->mCurDimensions.width) * factor,
-                          float(mInterpreter.lock()->mCurDimensions.height) * factor);
+            size = ImVec2(float(interpreter->mCurDimensions.width) * factor,
+                          float(interpreter->mCurDimensions.height) * factor);
         }
     }
-    uintptr_t fb = Ship::Context::GetInstance()->GetWindow()->GetGfxFrameBuffer();
+    uintptr_t fb = Ship::Context::GetRawInstance()->GetWindow()->GetGfxFrameBuffer();
     if (fb) {
         ImGui::SetCursorPos(pos);
         ImGui::Image(reinterpret_cast<ImTextureID>(fb), size);
@@ -420,24 +413,25 @@ void Fast3dGui::DrawGame() {
 void Fast3dGui::ApplyResolutionChanges() {
     ImVec2 size = ImGui::GetContentRegionAvail();
 
-    const float aspectRatioX = Ship::Context::GetInstance()->GetConsoleVariables()->GetFloat(
+    const float aspectRatioX = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetFloat(
         CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioX", 16.0f);
-    const float aspectRatioY = Ship::Context::GetInstance()->GetConsoleVariables()->GetFloat(
+    const float aspectRatioY = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetFloat(
         CVAR_PREFIX_ADVANCED_RESOLUTION ".AspectRatioY", 9.0f);
-    const uint32_t verticalPixelCount = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    const uint32_t verticalPixelCount = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
         CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalPixelCount", 480);
-    const bool verticalResolutionToggle = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    const bool verticalResolutionToggle = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
         CVAR_PREFIX_ADVANCED_RESOLUTION ".VerticalResolutionToggle", 0);
 
     const bool aspectRatioIsEnabled = (aspectRatioX > 0.0f) && (aspectRatioY > 0.0f);
 
-    const uint32_t minResolutionWidth = 320;
-    const uint32_t minResolutionHeight = 240;
-    const uint32_t maxResolutionWidth = 8096;  // the renderer's actual limit is 16384
-    const uint32_t maxResolutionHeight = 4320; // on either axis. if you have the VRAM for it.
+    constexpr uint32_t minResolutionWidth = 320;
+    constexpr uint32_t minResolutionHeight = 240;
+    constexpr uint32_t maxResolutionWidth = 8096;  // the renderer's actual limit is 16384
+    constexpr uint32_t maxResolutionHeight = 4320; // on either axis. if you have the VRAM for it.
     uint32_t newWidth;
     uint32_t newHeight;
-    mInterpreter.lock()->GetCurDimensions(&newWidth, &newHeight);
+    const auto interpreter = mInterpreter.lock().get();
+    interpreter->GetCurDimensions(&newWidth, &newHeight);
 
     if (verticalResolutionToggle) { // Use fixed vertical resolution
         if (aspectRatioIsEnabled) {
@@ -448,12 +442,12 @@ void Fast3dGui::ApplyResolutionChanges() {
         newHeight = verticalPixelCount;
     } else { // Use the window's resolution
         if (aspectRatioIsEnabled) {
-            if (((float)mInterpreter.lock()->mGameWindowViewport.height /
-                 mInterpreter.lock()->mGameWindowViewport.width) < (aspectRatioY / aspectRatioX)) {
+            if (((float)interpreter->mGameWindowViewport.height / interpreter->mGameWindowViewport.width) <
+                (aspectRatioY / aspectRatioX)) {
                 // when pillarboxed
-                newWidth = uint32_t(float(mInterpreter.lock()->mCurDimensions.height / aspectRatioY) * aspectRatioX);
+                newWidth = uint32_t(float(interpreter->mCurDimensions.height / aspectRatioY) * aspectRatioX);
             } else { // when letterboxed
-                newHeight = uint32_t(float(mInterpreter.lock()->mCurDimensions.width / aspectRatioX) * aspectRatioY);
+                newHeight = uint32_t(float(interpreter->mCurDimensions.width / aspectRatioX) * aspectRatioY);
             }
         } // else, having both options turned off does nothing.
     }
@@ -471,31 +465,28 @@ void Fast3dGui::ApplyResolutionChanges() {
         newHeight = maxResolutionHeight;
     }
     // apply new dimensions
-    mInterpreter.lock()->mCurDimensions.width = newWidth;
-    mInterpreter.lock()->mCurDimensions.height = newHeight;
+    interpreter->mCurDimensions.width = newWidth;
+    interpreter->mCurDimensions.height = newHeight;
     // centring the image is done in Fast3dGui::DrawGame().
 }
 
 int16_t Fast3dGui::GetIntegerScaleFactor() {
-    if (!Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    const auto interpreter = mInterpreter.lock().get();
+    if (!Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.FitAutomatically", 0)) {
-        int16_t factor = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int16_t factor = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.Factor", 1);
 
-        if (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        if (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
                 CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.NeverExceedBounds", 1)) {
-            if (((float)mInterpreter.lock()->mGameWindowViewport.height /
-                 mInterpreter.lock()->mGameWindowViewport.width) <
-                ((float)mInterpreter.lock()->mCurDimensions.height / mInterpreter.lock()->mCurDimensions.width)) {
-                if ((uint32_t)factor >
-                    mInterpreter.lock()->mGameWindowViewport.height / mInterpreter.lock()->mCurDimensions.height) {
-                    factor =
-                        mInterpreter.lock()->mGameWindowViewport.height / mInterpreter.lock()->mCurDimensions.height;
+            if (((float)interpreter->mGameWindowViewport.height / interpreter->mGameWindowViewport.width) <
+                ((float)interpreter->mCurDimensions.height / interpreter->mCurDimensions.width)) {
+                if ((uint32_t)factor > interpreter->mGameWindowViewport.height / interpreter->mCurDimensions.height) {
+                    factor = interpreter->mGameWindowViewport.height / interpreter->mCurDimensions.height;
                 }
             } else {
-                if ((uint32_t)factor >
-                    mInterpreter.lock()->mGameWindowViewport.width / mInterpreter.lock()->mCurDimensions.width) {
-                    factor = mInterpreter.lock()->mGameWindowViewport.width / mInterpreter.lock()->mCurDimensions.width;
+                if ((uint32_t)factor > interpreter->mGameWindowViewport.width / interpreter->mCurDimensions.width) {
+                    factor = interpreter->mGameWindowViewport.width / interpreter->mCurDimensions.width;
                 }
             }
         }
@@ -507,14 +498,14 @@ int16_t Fast3dGui::GetIntegerScaleFactor() {
     } else {
         int16_t factor = 1;
 
-        if (((float)mInterpreter.lock()->mGameWindowViewport.height / mInterpreter.lock()->mGameWindowViewport.width) <
-            ((float)mInterpreter.lock()->mCurDimensions.height / mInterpreter.lock()->mCurDimensions.width)) {
-            factor = mInterpreter.lock()->mGameWindowViewport.height / mInterpreter.lock()->mCurDimensions.height;
+        if (((float)interpreter->mGameWindowViewport.height / interpreter->mGameWindowViewport.width) <
+            ((float)interpreter->mCurDimensions.height / interpreter->mCurDimensions.width)) {
+            factor = interpreter->mGameWindowViewport.height / interpreter->mCurDimensions.height;
         } else {
-            factor = mInterpreter.lock()->mGameWindowViewport.width / mInterpreter.lock()->mCurDimensions.width;
+            factor = interpreter->mGameWindowViewport.width / interpreter->mCurDimensions.width;
         }
 
-        factor += Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        factor += Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             CVAR_PREFIX_ADVANCED_RESOLUTION ".IntegerScale.ExceedBoundsBy", 0);
 
         if (factor < 1) {
@@ -554,7 +545,7 @@ void Fast3dGui::LoadTextureFromRawImage(const std::string& name, const std::stri
     initData->ResourceVersion = 0;
     initData->Path = path;
     auto guiTexture = std::static_pointer_cast<Ship::GuiTexture>(
-        Ship::Context::GetInstance()->GetResourceManager()->LoadResource(path, false, initData));
+        Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(path, false, initData));
 
     LoadTextureFromResource(name, guiTexture);
 }
@@ -706,8 +697,8 @@ void Fast3dGui::LoadGuiTexture(const std::string& name, const Fast::Texture& res
 }
 
 void Fast3dGui::LoadGuiTexture(const std::string& name, const std::string& path, const ImVec4& tint) {
-    const auto res =
-        static_cast<Fast::Texture*>(Ship::Context::GetInstance()->GetResourceManager()->LoadResource(path, true).get());
+    const auto res = static_cast<Fast::Texture*>(
+        Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(path, true).get());
 
     LoadGuiTexture(name, *res, tint);
 }

--- a/src/fast/Fast3dWindow.cpp
+++ b/src/fast/Fast3dWindow.cpp
@@ -82,32 +82,34 @@ void Fast3dWindow::Init() {
     uint32_t width, height;
     int32_t posX, posY;
 
-    isFullscreen = Ship::Context::GetInstance()->GetConfig()->GetBool("Window.Fullscreen.Enabled", false) || gameMode;
-    posX = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.PositionX", 100);
-    posY = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.PositionY", 100);
+    isFullscreen =
+        Ship::Context::GetRawInstance()->GetConfig()->GetBool("Window.Fullscreen.Enabled", false) || gameMode;
+    posX = Ship::Context::GetRawInstance()->GetConfig()->GetInt("Window.PositionX", 100);
+    posY = Ship::Context::GetRawInstance()->GetConfig()->GetInt("Window.PositionY", 100);
 
     if (isFullscreen) {
-        width = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Fullscreen.Width", gameMode ? 1280 : 1920);
-        height = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Fullscreen.Height", gameMode ? 800 : 1080);
+        width = Ship::Context::GetRawInstance()->GetConfig()->GetInt("Window.Fullscreen.Width", gameMode ? 1280 : 1920);
+        height =
+            Ship::Context::GetRawInstance()->GetConfig()->GetInt("Window.Fullscreen.Height", gameMode ? 800 : 1080);
     } else {
-        width = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Width", 640);
-        height = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Height", 480);
+        width = Ship::Context::GetRawInstance()->GetConfig()->GetInt("Window.Width", 640);
+        height = Ship::Context::GetRawInstance()->GetConfig()->GetInt("Window.Height", 480);
     }
-    Ship::Context::GetInstance()->GetWindow()->SetFullscreenScancode(
-        Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.Fullscreen", Ship::KbScancode::LUS_KB_F11));
-    Ship::Context::GetInstance()->GetWindow()->SetMouseCaptureScancode(
-        Ship::Context::GetInstance()->GetConfig()->GetInt("Shortcuts.MouseCapture", Ship::KbScancode::LUS_KB_F2));
+    Ship::Context::GetRawInstance()->GetWindow()->SetFullscreenScancode(
+        Ship::Context::GetRawInstance()->GetConfig()->GetInt("Shortcuts.Fullscreen", Ship::KbScancode::LUS_KB_F11));
+    Ship::Context::GetRawInstance()->GetWindow()->SetMouseCaptureScancode(
+        Ship::Context::GetRawInstance()->GetConfig()->GetInt("Shortcuts.MouseCapture", Ship::KbScancode::LUS_KB_F2));
 
     InitWindowManager();
     mGfxDebugger = std::make_shared<GfxDebugger>();
     mInterpreter->SetGfxDebugger(mGfxDebugger);
-    mInterpreter->Init(mWindowManagerApi, mRenderingApi, Ship::Context::GetInstance()->GetName().c_str(), isFullscreen,
-                       width, height, posX, posY);
+    mInterpreter->Init(mWindowManagerApi, mRenderingApi, Ship::Context::GetRawInstance()->GetName().c_str(),
+                       isFullscreen, width, height, posX, posY);
     mWindowManagerApi->SetFullscreenChangedCallback(OnFullscreenChanged);
     mWindowManagerApi->SetKeyboardCallbacks(KeyDown, KeyUp, AllKeysUp);
     mWindowManagerApi->SetMouseCallbacks(MouseButtonDown, MouseButtonUp);
 
-    SetTextureFilter((FilteringMode)Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    SetTextureFilter((FilteringMode)Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
         CVAR_TEXTURE_FILTER, FILTER_THREE_POINT));
 }
 
@@ -192,7 +194,7 @@ bool Fast3dWindow::IsFrameReady() {
 }
 
 bool Fast3dWindow::DrawAndRunGraphicsCommands(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtxReplacements) {
-    std::shared_ptr<Window> wnd = Ship::Context::GetInstance()->GetWindow();
+    std::shared_ptr<Window> wnd = Ship::Context::GetRawInstance()->GetWindow();
 
     // Skip dropped frames
     if (!wnd->IsFrameReady()) {
@@ -343,48 +345,48 @@ const char* Fast3dWindow::GetKeyName(int32_t scancode) {
 }
 
 bool Fast3dWindow::KeyUp(int32_t scancode) {
-    if (scancode == Ship::Context::GetInstance()->GetWindow()->GetFullscreenScancode()) {
-        Ship::Context::GetInstance()->GetWindow()->ToggleFullscreen();
+    if (scancode == Ship::Context::GetRawInstance()->GetWindow()->GetFullscreenScancode()) {
+        Ship::Context::GetRawInstance()->GetWindow()->ToggleFullscreen();
     }
 
-    if (scancode == Ship::Context::GetInstance()->GetWindow()->GetMouseCaptureScancode()) {
-        Ship::Context::GetInstance()->GetWindow()->GetMouseStateManager()->ToggleMouseCaptureOverride();
+    if (scancode == Ship::Context::GetRawInstance()->GetWindow()->GetMouseCaptureScancode()) {
+        Ship::Context::GetRawInstance()->GetWindow()->GetMouseStateManager()->ToggleMouseCaptureOverride();
     }
 
-    Ship::Context::GetInstance()->GetWindow()->SetLastScancode(-1);
-    return Ship::Context::GetInstance()->GetControlDeck()->ProcessKeyboardEvent(
+    Ship::Context::GetRawInstance()->GetWindow()->SetLastScancode(-1);
+    return Ship::Context::GetRawInstance()->GetControlDeck()->ProcessKeyboardEvent(
         Ship::KbEventType::LUS_KB_EVENT_KEY_UP, static_cast<Ship::KbScancode>(scancode));
 }
 
 bool Fast3dWindow::KeyDown(int32_t scancode) {
-    bool isProcessed = Ship::Context::GetInstance()->GetControlDeck()->ProcessKeyboardEvent(
+    bool isProcessed = Ship::Context::GetRawInstance()->GetControlDeck()->ProcessKeyboardEvent(
         Ship::KbEventType::LUS_KB_EVENT_KEY_DOWN, static_cast<Ship::KbScancode>(scancode));
-    Ship::Context::GetInstance()->GetWindow()->SetLastScancode(scancode);
+    Ship::Context::GetRawInstance()->GetWindow()->SetLastScancode(scancode);
 
     return isProcessed;
 }
 
 void Fast3dWindow::AllKeysUp() {
-    Ship::Context::GetInstance()->GetControlDeck()->ProcessKeyboardEvent(Ship::KbEventType::LUS_KB_EVENT_ALL_KEYS_UP,
-                                                                         Ship::KbScancode::LUS_KB_UNKNOWN);
+    Ship::Context::GetRawInstance()->GetControlDeck()->ProcessKeyboardEvent(Ship::KbEventType::LUS_KB_EVENT_ALL_KEYS_UP,
+                                                                            Ship::KbScancode::LUS_KB_UNKNOWN);
 }
 
 bool Fast3dWindow::MouseButtonUp(int button) {
-    return Ship::Context::GetInstance()->GetControlDeck()->ProcessMouseButtonEvent(false,
-                                                                                   static_cast<Ship::MouseBtn>(button));
+    return Ship::Context::GetRawInstance()->GetControlDeck()->ProcessMouseButtonEvent(
+        false, static_cast<Ship::MouseBtn>(button));
 }
 
 bool Fast3dWindow::MouseButtonDown(int button) {
-    bool isProcessed = Ship::Context::GetInstance()->GetControlDeck()->ProcessMouseButtonEvent(
+    bool isProcessed = Ship::Context::GetRawInstance()->GetControlDeck()->ProcessMouseButtonEvent(
         true, static_cast<Ship::MouseBtn>(button));
     return isProcessed;
 }
 
 void Fast3dWindow::OnFullscreenChanged(bool isNowFullscreen) {
-    std::shared_ptr<Window> wnd = Ship::Context::GetInstance()->GetWindow();
+    std::shared_ptr<Window> wnd = Ship::Context::GetRawInstance()->GetWindow();
 
     // Re-save fullscreen enabled after
-    Ship::Context::GetInstance()->GetConfig()->SetBool("Window.Fullscreen.Enabled", isNowFullscreen);
+    Ship::Context::GetRawInstance()->GetConfig()->SetBool("Window.Fullscreen.Enabled", isNowFullscreen);
 }
 
 std::weak_ptr<Interpreter> Fast3dWindow::GetInterpreterWeak() const {
@@ -419,7 +421,7 @@ void Fast3dWindow::SetCurrentDimensions(bool isFullscreen, uint32_t width, uint3
 
 void Fast3dWindow::SetCurrentDimensions(bool isFullscreen, uint32_t width, uint32_t height, int32_t posX,
                                         int32_t posY) {
-    auto config = Ship::Context::GetInstance()->GetConfig();
+    auto config = Ship::Context::GetRawInstance()->GetConfig();
     if (!isFullscreen) {
         config->SetInt("Window.Width", static_cast<int32_t>(width));
         config->SetInt("Window.Height", static_cast<int32_t>(height));

--- a/src/fast/FastMouseStateManager.cpp
+++ b/src/fast/FastMouseStateManager.cpp
@@ -6,7 +6,7 @@
 
 namespace Fast {
 void FastMouseStateManager::ResetCursorVisibilityTimer() {
-    auto wnd = std::dynamic_pointer_cast<Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
+    auto wnd = std::dynamic_pointer_cast<Fast3dWindow>(Ship::Context::GetRawInstance()->GetWindow());
     SetCursorVisibilityTimeTicks(mCursorVisibleSeconds * wnd->GetTargetFps());
     MouseStateManager::ResetCursorVisibilityTimer();
 }

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -42,6 +42,8 @@
 #include "spdlog/spdlog.h"
 #include "nlohmann/json.hpp"
 
+#include "fast/Fast3dWindow.h"
+
 #define DEBUG_D3D 0
 
 using namespace Microsoft::WRL; // For ComPtr
@@ -357,7 +359,9 @@ void CSMain(uint3 DTid : SV_DispatchThreadID) {
 
     Fast::GuiWindowInitData window_impl;
     window_impl.Dx11 = { mWindowBackend->GetWindowHandle(), mContext.Get(), mDevice.Get() };
-    std::dynamic_pointer_cast<Fast::Fast3dGui>(Ship::Context::GetInstance()->GetWindow()->GetGui())->Init(window_impl);
+    window_impl.Backend = WindowBackend::FAST3D_DXGI_DX11
+        : std::dynamic_pointer_cast<Fast::Fast3dGui>(Ship::Context::GetRawInstance()->GetWindow()->GetGui())
+              ->Init(window_impl);
 }
 
 int GfxRenderingAPIDX11::GetMaxTextureSize() {
@@ -704,7 +708,7 @@ void GfxRenderingAPIDX11::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, siz
         const int noVanishFactor = 100;
         float SSDB = -2;
 
-        switch (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_Z_FIGHTING_MODE, 0)) {
+        switch (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_Z_FIGHTING_MODE, 0)) {
             case 1: // scaled z-fighting (N64 mode like)
                 SSDB = -1.0f * (float)mRenderTargetHeight / n64modeFactor;
                 break;
@@ -1376,7 +1380,7 @@ std::optional<std::string> dx_include_fs(const std::string& path) {
     init->ByteOrder = Ship::Endianness::Native;
     init->Format = RESOURCE_FORMAT_BINARY;
     auto res = static_pointer_cast<Ship::Shader>(
-        Ship::Context::GetInstance()->GetResourceManager()->LoadResource(path, true, init));
+        Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(path, true, init));
     if (res == nullptr) {
         return std::nullopt;
     }
@@ -1443,7 +1447,7 @@ std::string gfx_direct3d_common_build_shader(size_t& numFloats, const CCFeatures
         path = std::string(shaderName) + ".hlsl";
     }
 
-    auto res = static_pointer_cast<Ship::Shader>(Ship::Context::GetInstance()->GetResourceManager()->LoadResource(
+    auto res = static_pointer_cast<Ship::Shader>(Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(
         "shaders/directx/default.shader.hlsl", true, init));
 
     if (res == nullptr) {

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -359,7 +359,7 @@ void CSMain(uint3 DTid : SV_DispatchThreadID) {
 
     Fast::GuiWindowInitData window_impl;
     window_impl.Dx11 = { mWindowBackend->GetWindowHandle(), mContext.Get(), mDevice.Get() };
-    window_impl.Backend = WindowBackend::FAST3D_DXGI_DX11
+    window_impl.Backend = WindowBackend::FAST3D_DXGI_DX11;
         : std::dynamic_pointer_cast<Fast::Fast3dGui>(Ship::Context::GetRawInstance()->GetWindow()->GetGui())
               ->Init(window_impl);
 }

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -361,7 +361,7 @@ void CSMain(uint3 DTid : SV_DispatchThreadID) {
     window_impl.Dx11 = { mWindowBackend->GetWindowHandle(), mContext.Get(), mDevice.Get() };
     window_impl.Backend = WindowBackend::FAST3D_DXGI_DX11;
     std::dynamic_pointer_cast<Fast::Fast3dGui>(Ship::Context::GetRawInstance()->GetWindow()->GetGui())
-              ->Init(window_impl);
+        ->Init(window_impl);
 }
 
 int GfxRenderingAPIDX11::GetMaxTextureSize() {

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -360,7 +360,7 @@ void CSMain(uint3 DTid : SV_DispatchThreadID) {
     Fast::GuiWindowInitData window_impl;
     window_impl.Dx11 = { mWindowBackend->GetWindowHandle(), mContext.Get(), mDevice.Get() };
     window_impl.Backend = WindowBackend::FAST3D_DXGI_DX11;
-        : std::dynamic_pointer_cast<Fast::Fast3dGui>(Ship::Context::GetRawInstance()->GetWindow()->GetGui())
+    std::dynamic_pointer_cast<Fast::Fast3dGui>(Ship::Context::GetRawInstance()->GetWindow()->GetGui())
               ->Init(window_impl);
 }
 

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -164,7 +164,7 @@ void GfxWindowBackendDXGI::ToggleBorderlessWindowFullScreen(bool enable, bool ca
             ShowWindow(h_wnd, SW_MAXIMIZE);
         } else {
             std::tuple<HMONITOR, RECT, BOOL> Monitor;
-            auto conf = Ship::Context::GetInstance()->GetConfig();
+            auto conf = Ship::Context::GetRawInstance()->GetConfig();
             current_width = conf->GetInt("Window.Width", 640);
             current_height = conf->GetInt("Window.Height", 480);
             mPosX = conf->GetInt("Window.PositionX", 100);
@@ -358,7 +358,7 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
     char fileName[256];
     Fast::WindowEvent event_impl;
     event_impl.Win32 = { h_wnd, static_cast<int>(message), static_cast<int>(w_param), static_cast<int>(l_param) };
-    auto ctx = Ship::Context::GetInstance();
+    auto ctx = Ship::Context::GetRawInstance();
     if (ctx && ctx->GetWindow() && ctx->GetWindow()->GetGui()) {
         auto fast3dGui = std::dynamic_pointer_cast<Fast::Fast3dGui>(ctx->GetWindow()->GetGui());
         if (fast3dGui) {
@@ -493,7 +493,7 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
             break;
         case WM_DROPFILES:
             DragQueryFileA((HDROP)w_param, 0, fileName, 256);
-            Ship::Context::GetInstance()->GetFileDropMgr()->SetDroppedFile(fileName);
+            Ship::Context::GetRawInstance()->GetFileDropMgr()->SetDroppedFile(fileName);
             break;
         case WM_DISPLAYCHANGE:
             self->monitor_list = GetMonitorList();
@@ -509,7 +509,7 @@ static LRESULT CALLBACK gfx_dxgi_wnd_proc(HWND h_wnd, UINT message, WPARAM w_par
             }
             break;
         case WM_KILLFOCUS:
-            if (auto ctx = Ship::Context::GetInstance(); ctx && ctx->GetConsoleVariables()) {
+            if (auto ctx = Ship::Context::GetRawInstance(); ctx && ctx->GetConsoleVariables()) {
                 if (!ctx->GetConsoleVariables()->GetInteger(CVAR_ALLOW_BACKGROUND_INPUTS, 1)) {
                     ControllerBlockGameInput(ALLOW_BACKGROUND_INPUTS_BLOCK_ID);
                 }
@@ -918,7 +918,7 @@ void GfxWindowBackendDXGI::SwapBuffersBegin() {
     // mLengthInVsyncFrames (now mVsyncEnabled) was used as present interval. Present interval >1 (aka fractional
     // V-Sync) breaks VRR and introduces even more input lag than capping via normal V-Sync does. Get the present
     // interval the user wants instead (V-Sync toggle).
-    mVsyncEnabled = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1) ? 1 : 0;
+    mVsyncEnabled = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1) ? 1 : 0;
 
     LARGE_INTEGER t;
     QueryPerformanceCounter(&t);

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -38,6 +38,8 @@
 #include "ship/Context.h"
 #include "ship/config/ConsoleVariable.h"
 
+#include "fast/Fast3dWindow.h"
+
 #define ARRAY_COUNT(arr) (int32_t)(sizeof(arr) / sizeof(arr[0]))
 
 // MARK: - Helpers
@@ -480,7 +482,7 @@ void GfxRenderingAPIMetal::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, si
         const int n64modeFactor = 120;
         const int noVanishFactor = 100;
         float SSDB = -2;
-        switch (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_Z_FIGHTING_MODE, 0)) {
+        switch (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_Z_FIGHTING_MODE, 0)) {
             case 1: // scaled z-fighting (N64 mode like)
                 SSDB = -1.0f * (float)mRenderTargetHeight / n64modeFactor;
                 break;
@@ -690,7 +692,7 @@ void GfxRenderingAPIMetal::SetupScreenFramebuffer(uint32_t width, uint32_t heigh
     mCurrentDrawable = nullptr;
     mCurrentDrawable = mLayer->nextDrawable();
 
-    bool msaa_enabled = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger("gMSAAValue", 1) > 1;
+    bool msaa_enabled = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger("gMSAAValue", 1) > 1;
 
     FramebufferMetal& fb = mFramebuffers[0];
     TextureDataMetal& tex = mTextures[fb.mTextureId];
@@ -801,7 +803,7 @@ void GfxRenderingAPIMetal::UpdateFramebufferParameters(int fb_id, uint32_t width
 
             bool fb_msaa_enabled = (msaa_level > 1);
             bool game_msaa_enabled =
-                Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger("gMSAAValue", 1) > 1;
+                Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger("gMSAAValue", 1) > 1;
 
             if (fb_msaa_enabled) {
                 render_pass_descriptor->colorAttachments()->object(0)->setTexture(tex.msaaTexture);

--- a/src/fast/backends/gfx_metal_shader.cpp
+++ b/src/fast/backends/gfx_metal_shader.cpp
@@ -190,7 +190,7 @@ std::optional<std::string> metal_include_fs(const std::string& path) {
     init->ByteOrder = Ship::Endianness::Native;
     init->Format = RESOURCE_FORMAT_BINARY;
     auto res = static_pointer_cast<Ship::Shader>(
-        Ship::Context::GetInstance()->GetResourceManager()->LoadResource(path, true, init));
+        Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(path, true, init));
     if (res == nullptr) {
         return std::nullopt;
     }
@@ -262,7 +262,7 @@ MTL::VertexDescriptor* gfx_metal_build_shader(std::string& result, size_t& numFl
     }
 
     auto res = static_pointer_cast<Ship::Shader>(
-        Ship::Context::GetInstance()->GetResourceManager()->LoadResource(path, true, init));
+        Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(path, true, init));
 
     if (res == nullptr) {
         SPDLOG_ERROR("Failed to load default metal shader, missing f3d.o2r?");

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -228,7 +228,7 @@ std::optional<std::string> opengl_include_fs(const std::string& path) {
     init->ByteOrder = Ship::Endianness::Native;
     init->Format = RESOURCE_FORMAT_BINARY;
     auto res = std::static_pointer_cast<Ship::Shader>(
-        Ship::Context::GetInstance()->GetResourceManager()->LoadResource(path, true, init));
+        Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(path, true, init));
     if (res == nullptr) {
         return std::nullopt;
     }
@@ -316,7 +316,7 @@ std::string GfxRenderingAPIOGL::BuildFsShader(const CCFeatures& cc_features) {
     }
 
     auto res = static_pointer_cast<Ship::Shader>(
-        Ship::Context::GetInstance()->GetResourceManager()->LoadResource(path, true, init));
+        Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(path, true, init));
 
     if (res == nullptr) {
         SPDLOG_ERROR("Failed to load default fragment shader, missing f3d.o2r?");
@@ -382,7 +382,7 @@ static std::string BuildVsShader(const CCFeatures& cc_features) {
     }
 
     auto res = static_pointer_cast<Ship::Shader>(
-        Ship::Context::GetInstance()->GetResourceManager()->LoadResource(path, true, init));
+        Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(path, true, init));
 
     if (res == nullptr) {
         SPDLOG_ERROR("Failed to load default vertex shader, missing f3d.o2r?");
@@ -672,7 +672,7 @@ void GfxRenderingAPIOGL::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, size
             const int n64modeFactor = 120;
             const int noVanishFactor = 100;
             GLfloat SSDB = -2;
-            switch (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_Z_FIGHTING_MODE, 0)) {
+            switch (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_Z_FIGHTING_MODE, 0)) {
                 // scaled z-fighting (N64 mode like)
                 case 1:
                     if (mFrameBuffers.size() >

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -1,6 +1,8 @@
+#if defined(ENABLE_OPENGL) || defined(__APPLE__)
+
 #include <stdio.h>
 
-#if defined(ENABLE_OPENGL) || defined(__APPLE__)
+#include "fast/Fast3dWindow.h"
 
 #ifdef __MINGW32__
 #define FOR_WINDOWS 1
@@ -240,11 +242,11 @@ void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
     }
     mFullScreen = on;
 #else
-    if (SDL_SetWindowFullscreen(
-            mWnd, on ? (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_SDL_WINDOWED_FULLSCREEN, 0)
-                            ? SDL_WINDOW_FULLSCREEN_DESKTOP
-                            : SDL_WINDOW_FULLSCREEN)
-                     : 0) >= 0) {
+    if (SDL_SetWindowFullscreen(mWnd, on ? (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
+                                                CVAR_SDL_WINDOWED_FULLSCREEN, 0)
+                                                ? SDL_WINDOW_FULLSCREEN_DESKTOP
+                                                : SDL_WINDOW_FULLSCREEN)
+                                         : 0) >= 0) {
         mFullScreen = on;
     } else {
         SPDLOG_ERROR("Failed to switch from or to fullscreen mode.");
@@ -253,7 +255,7 @@ void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
 #endif
 
     if (!on) {
-        auto conf = Ship::Context::GetInstance()->GetConfig();
+        auto conf = Ship::Context::GetRawInstance()->GetConfig();
         mWindowWidth = conf->GetInt("Window.Width", 640);
         mWindowHeight = conf->GetInt("Window.Height", 480);
         int32_t posX = conf->GetInt("Window.PositionX", 100);
@@ -415,6 +417,7 @@ void GfxWindowBackendSDL2::Init(const char* gameName, const char* gfxApiName, bo
         SDL_GL_SetSwapInterval(mVsyncEnabled ? 1 : 0);
 
         window_impl.Opengl = { mWnd, mCtx };
+        window_impl.Backend = WindowBackend::FAST3D_SDL_OPENGL;
     } else {
         uint32_t flags = SDL_RENDERER_ACCELERATED;
         if (mVsyncEnabled) {
@@ -432,9 +435,11 @@ void GfxWindowBackendSDL2::Init(const char* gameName, const char* gfxApiName, bo
 
         SDL_GetRendererOutputSize(mRenderer, &mWindowWidth, &mWindowHeight);
         window_impl.Metal = { mWnd, mRenderer };
+        window_impl.Backend = WindowBackend::FAST3D_SDL_METAL;
     }
 
-    std::dynamic_pointer_cast<Fast::Fast3dGui>(Ship::Context::GetInstance()->GetWindow()->GetGui())->Init(window_impl);
+    std::dynamic_pointer_cast<Fast::Fast3dGui>(Ship::Context::GetRawInstance()->GetWindow()->GetGui())
+        ->Init(window_impl);
 
     for (size_t i = 0; i < std::size(lus_to_sdl_table); i++) {
         mSdlToLusTable[lus_to_sdl_table[i]] = i;
@@ -600,7 +605,7 @@ void GfxWindowBackendSDL2::OnMouseButtonUp(int btn) const {
 void GfxWindowBackendSDL2::HandleSingleEvent(SDL_Event& event) {
     Fast::WindowEvent event_impl;
     event_impl.Sdl = { &event };
-    auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
+    auto gui = Ship::Context::GetRawInstance()->GetWindow()->GetGui();
     auto fast3dGui = std::dynamic_pointer_cast<Fast::Fast3dGui>(gui);
     if (fast3dGui) {
         fast3dGui->HandleWindowEvents(event_impl);
@@ -650,7 +655,7 @@ void GfxWindowBackendSDL2::HandleSingleEvent(SDL_Event& event) {
             }
             break;
         case SDL_DROPFILE:
-            Ship::Context::GetInstance()->GetFileDropMgr()->SetDroppedFile(event.drop.file);
+            Ship::Context::GetRawInstance()->GetFileDropMgr()->SetDroppedFile(event.drop.file);
             break;
         case SDL_QUIT:
             Close();
@@ -733,7 +738,7 @@ void GfxWindowBackendSDL2::SyncFramerateWithTime() const {
 }
 
 void GfxWindowBackendSDL2::SwapBuffersBegin() {
-    bool nextVsyncEnabled = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1);
+    bool nextVsyncEnabled = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_VSYNC_ENABLED, 1);
 
     if (mVsyncEnabled != nextVsyncEnabled) {
         mVsyncEnabled = nextVsyncEnabled;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2995,7 +2995,7 @@ void Interpreter::Gfxs2dexBgCopy(F3DuObjBg* bg) {
 
     if ((bool)gfx_check_image_signature((char*)data)) {
         std::shared_ptr<Fast::Texture> tex = std::static_pointer_cast<Fast::Texture>(
-            Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess((char*)data));
+            Ship::Context::GetRawInstance()->GetResourceManager()->LoadResourceProcess((char*)data));
         texFlags = tex->Flags;
         rawTexMetadata.width = tex->Width;
         rawTexMetadata.height = tex->Height;
@@ -3032,7 +3032,7 @@ void Interpreter::Gfxs2dexBg1cyc(F3DuObjBg* bg) {
 
     if ((bool)gfx_check_image_signature((char*)data)) {
         std::shared_ptr<Fast::Texture> tex = std::static_pointer_cast<Fast::Texture>(
-            Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess((char*)data));
+            Ship::Context::GetRawInstance()->GetResourceManager()->LoadResourceProcess((char*)data));
         texFlags = tex->Flags;
         rawTexMetadata.width = tex->Width;
         rawTexMetadata.height = tex->Height;
@@ -3250,7 +3250,7 @@ bool gfx_mtx_otr_filepath_handler_custom_f3dex2(F3DGfx** cmd0) {
     Interpreter* gfx = mInstance.lock().get();
     F3DGfx* cmd = *cmd0;
     const char* fileName = (const char*)cmd->words.w1;
-    const int32_t* mtx = (const int32_t*)Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer(
+    const int32_t* mtx = (const int32_t*)Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer(
         (const char*)fileName);
 
     if (mtx != NULL) {
@@ -3264,7 +3264,7 @@ bool gfx_mtx_otr_filepath_handler_custom_f3d(F3DGfx** cmd0) {
     Interpreter* gfx = mInstance.lock().get();
     F3DGfx* cmd = *cmd0;
     const char* fileName = (const char*)cmd->words.w1;
-    const int32_t* mtx = (const int32_t*)Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer(
+    const int32_t* mtx = (const int32_t*)Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer(
         (const char*)fileName);
 
     if (mtx != NULL) {
@@ -3288,7 +3288,7 @@ bool gfx_mtx_otr_handler_custom_f3dex2(F3DGfx** cmd0) {
 
     const uint64_t hash = ((uint64_t)cmd->words.w0 << 32) + cmd->words.w1;
     const int32_t* mtx =
-        (const int32_t*)Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer(hash);
+        (const int32_t*)Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer(hash);
 
     if (mtx != NULL) {
         Interpreter* gfx = mInstance.lock().get();
@@ -3307,7 +3307,7 @@ bool gfx_mtx_otr_handler_custom_f3d(F3DGfx** cmd0) {
 
     const uint64_t hash = ((uint64_t)cmd->words.w0 << 32) + cmd->words.w1;
     const int32_t* mtx =
-        (const int32_t*)Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer(hash);
+        (const int32_t*)Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer(hash);
     if (mtx != nullptr) {
         cmd--;
         gfx->GfxSpMatrix(C0(16, 8), mtx);
@@ -3374,9 +3374,10 @@ bool gfx_movemem_handler_otr(F3DGfx** cmd0) {
 
     if (ucode_handler_index == ucode_f3dex2) {
         gfx->GfxSpMovememF3dex2(index, offset,
-                                Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer(hash));
+                                Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer(hash));
     } else {
-        auto light = (Fast::LightEntry*)Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer(hash);
+        auto light =
+            (Fast::LightEntry*)Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer(hash);
         uintptr_t data = (uintptr_t)&light->Ambient;
         gfx->GfxSpMovememF3d(index, offset, (void*)(data + (hasOffset == 1 ? 0x8 : 0)));
     }
@@ -3515,7 +3516,7 @@ bool gfx_vtx_hash_handler_custom(F3DGfx** cmd0) {
         gfx->GfxSpVertex(C0(12, 8), C0(1, 7) - C0(12, 8), (F3DVtx*)offset);
         (*cmd0)++;
     } else {
-        F3DVtx* vtx = (F3DVtx*)Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer(hash);
+        F3DVtx* vtx = (F3DVtx*)Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer(hash);
 
         if (vtx != NULL) {
             vtx = (F3DVtx*)((char*)vtx + offset);
@@ -3543,7 +3544,7 @@ bool gfx_vtx_otr_filepath_handler_custom(F3DGfx** cmd0) {
     size_t vtxIdxOff = cmd->words.w1 >> 16;
     size_t vtxDataOff = cmd->words.w1 & 0xFFFF;
     F3DVtx* vtx =
-        (F3DVtx*)Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer((const char*)fileName);
+        (F3DVtx*)Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer((const char*)fileName);
     vtx += vtxDataOff;
 
     gfx->GfxSpVertex(vtxCnt, vtxIdxOff, vtx);
@@ -3554,7 +3555,7 @@ bool gfx_dl_otr_filepath_handler_custom(F3DGfx** cmd0) {
     F3DGfx* cmd = *cmd0;
     char* fileName = (char*)cmd->words.w1;
     F3DGfx* nDL =
-        (F3DGfx*)Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer((const char*)fileName);
+        (F3DGfx*)Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer((const char*)fileName);
 
     if (C0(16, 1) == 0 && nDL != nullptr) {
         g_exec_stack.call(*cmd0, nDL);
@@ -3607,7 +3608,7 @@ bool gfx_dl_otr_hash_handler_custom(F3DGfx** cmd0) {
 
         uint64_t hash = ((uint64_t)(*cmd0)->words.w0 << 32) + (*cmd0)->words.w1;
 
-        F3DGfx* gfx = (F3DGfx*)Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer(hash);
+        F3DGfx* gfx = (F3DGfx*)Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer(hash);
 
         if (gfx != 0) {
             g_exec_stack.call(cmd, gfx);
@@ -3665,7 +3666,7 @@ bool gfx_branch_z_otr_handler_f3dex2(F3DGfx** cmd0) {
         (gfx->mRsp->extra_geometry_mode & G_EX_ALWAYS_EXECUTE_BRANCH) != 0) {
         uint64_t hash = ((uint64_t)(*cmd0)->words.w0 << 32) + (*cmd0)->words.w1;
 
-        F3DGfx* gfx = (F3DGfx*)Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer(hash);
+        F3DGfx* gfx = (F3DGfx*)Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer(hash);
 
         if (gfx != 0) {
             (*cmd0) = gfx;
@@ -3855,7 +3856,7 @@ bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
     if ((i & 1) != 1) {
         if (gfx_check_image_signature(imgData) == 1) {
             std::shared_ptr<Fast::Texture> tex = std::static_pointer_cast<Fast::Texture>(
-                Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(imgData));
+                Ship::Context::GetRawInstance()->GetResourceManager()->LoadResourceProcess(imgData));
 
             if (tex == nullptr) {
                 (*cmd0)++;
@@ -3901,7 +3902,8 @@ bool gfx_set_timg_otr_hash_handler_custom(F3DGfx** cmd0) {
     (*cmd0)++;
     uint64_t hash = ((uint64_t)(*cmd0)->words.w0 << 32) + (uint64_t)(*cmd0)->words.w1;
 
-    const char* fileName = Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->HashToCString(hash);
+    const char* fileName =
+        Ship::Context::GetRawInstance()->GetResourceManager()->GetArchiveManager()->HashToCString(hash);
     uint32_t texFlags = 0;
     RawTexMetadata rawTexMetadata = {};
 
@@ -3910,9 +3912,9 @@ bool gfx_set_timg_otr_hash_handler_custom(F3DGfx** cmd0) {
         return false;
     }
 
-    std::shared_ptr<Fast::Texture> texture =
-        std::static_pointer_cast<Fast::Texture>(Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(
-            Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->HashToCString(hash)));
+    std::shared_ptr<Fast::Texture> texture = std::static_pointer_cast<Fast::Texture>(
+        Ship::Context::GetRawInstance()->GetResourceManager()->LoadResourceProcess(
+            Ship::Context::GetRawInstance()->GetResourceManager()->GetArchiveManager()->HashToCString(hash)));
     if (texture != nullptr) {
         texFlags = texture->Flags;
         rawTexMetadata.width = texture->Width;
@@ -3967,7 +3969,7 @@ bool gfx_set_timg_otr_filepath_handler_custom(F3DGfx** cmd0) {
     RawTexMetadata rawTexMetadata = {};
 
     std::shared_ptr<Fast::Texture> texture = std::static_pointer_cast<Fast::Texture>(
-        Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(fileName));
+        Ship::Context::GetRawInstance()->GetResourceManager()->LoadResourceProcess(fileName));
     if (texture != nullptr) {
         Interpreter* gfx = mInstance.lock().get();
         texFlags = texture->Flags;
@@ -4714,7 +4716,7 @@ static void gfx_step() {
 
 #ifdef USE_GBI_TRACE
     if (cmd->words.trace.valid &&
-        Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger("gEnableGFXTrace", 0)) {
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger("gEnableGFXTrace", 0)) {
 #define TRACE                                  \
     "\n====================================\n" \
     " - CMD: {:02X}\n"                         \
@@ -4809,8 +4811,8 @@ void Interpreter::Init(class GfxWindowBackend* wapi, class GfxRenderingAPI* rapi
     mRapi->Init();
     mRapi->UpdateFramebufferParameters(0, width, height, 1, false, true, true, true);
     mCurDimensions.internal_mul =
-        Ship::Context::GetInstance()->GetConsoleVariables()->GetFloat(CVAR_INTERNAL_RESOLUTION, 1);
-    mMsaaLevel = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_MSAA_VALUE, 1);
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->GetFloat(CVAR_INTERNAL_RESOLUTION, 1);
+    mMsaaLevel = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_MSAA_VALUE, 1);
 
     mCurDimensions.width = width;
     mCurDimensions.height = height;
@@ -5190,7 +5192,7 @@ int32_t gfx_check_image_signature(const char* imgData) {
     }
 #endif
 
-    return Ship::Context::GetInstance()->GetResourceManager()->OtrSignatureCheck(imgData);
+    return Ship::Context::GetRawInstance()->GetResourceManager()->OtrSignatureCheck(imgData);
 }
 
 void Interpreter::RegisterBlendedTexture(const char* name, uint8_t* mask, uint8_t* replacement) {
@@ -5200,7 +5202,7 @@ void Interpreter::RegisterBlendedTexture(const char* name, uint8_t* mask, uint8_
 
     if (gfx_check_image_signature(reinterpret_cast<char*>(replacement))) {
         Fast::Texture* tex = std::static_pointer_cast<Fast::Texture>(
-                                 Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(
+                                 Ship::Context::GetRawInstance()->GetResourceManager()->LoadResourceProcess(
                                      reinterpret_cast<char*>(replacement)))
                                  .get();
 

--- a/src/libultraship/bridge/audiobridge.cpp
+++ b/src/libultraship/bridge/audiobridge.cpp
@@ -5,7 +5,7 @@
 extern "C" {
 
 int32_t AudioPlayerBuffered() {
-    auto audio = Ship::Context::GetInstance()->GetAudio()->GetAudioPlayer();
+    auto audio = Ship::Context::GetRawInstance()->GetAudio()->GetAudioPlayer();
     if (audio == nullptr) {
         return 0;
     }
@@ -18,7 +18,7 @@ int32_t AudioPlayerBuffered() {
 }
 
 int32_t AudioPlayerGetDesiredBuffered() {
-    auto audio = Ship::Context::GetInstance()->GetAudio()->GetAudioPlayer();
+    auto audio = Ship::Context::GetRawInstance()->GetAudio()->GetAudioPlayer();
     if (audio == nullptr) {
         return 0;
     }
@@ -31,7 +31,7 @@ int32_t AudioPlayerGetDesiredBuffered() {
 }
 
 AudioChannelsSetting GetAudioChannels() {
-    auto audio = Ship::Context::GetInstance()->GetAudio()->GetAudioPlayer();
+    auto audio = Ship::Context::GetRawInstance()->GetAudio()->GetAudioPlayer();
 
     if (audio == nullptr) {
         return audioStereo;
@@ -41,7 +41,7 @@ AudioChannelsSetting GetAudioChannels() {
 }
 
 int32_t GetNumAudioChannels() {
-    auto audio = Ship::Context::GetInstance()->GetAudio()->GetAudioPlayer();
+    auto audio = Ship::Context::GetRawInstance()->GetAudio()->GetAudioPlayer();
 
     if (audio == nullptr) {
         return 2;
@@ -51,7 +51,7 @@ int32_t GetNumAudioChannels() {
 }
 
 void AudioPlayerPlayFrame(const uint8_t* buf, size_t len) {
-    auto audio = Ship::Context::GetInstance()->GetAudio()->GetAudioPlayer();
+    auto audio = Ship::Context::GetRawInstance()->GetAudio()->GetAudioPlayer();
     if (audio == nullptr) {
         return;
     }
@@ -64,7 +64,7 @@ void AudioPlayerPlayFrame(const uint8_t* buf, size_t len) {
 }
 
 void SetAudioChannels(AudioChannelsSetting channels) {
-    auto audio = Ship::Context::GetInstance()->GetAudio();
+    auto audio = Ship::Context::GetRawInstance()->GetAudio();
     if (audio == nullptr) {
         return;
     }

--- a/src/libultraship/bridge/consolevariablebridge.cpp
+++ b/src/libultraship/bridge/consolevariablebridge.cpp
@@ -2,87 +2,87 @@
 #include "ship/Context.h"
 
 std::shared_ptr<Ship::CVar> CVarGet(const char* name) {
-    return Ship::Context::GetInstance()->GetConsoleVariables()->Get(name);
+    return Ship::Context::GetRawInstance()->GetConsoleVariables()->Get(name);
 }
 
 extern "C" {
 int32_t CVarGetInteger(const char* name, int32_t defaultValue) {
-    return Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(name, defaultValue);
+    return Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(name, defaultValue);
 }
 
 float CVarGetFloat(const char* name, float defaultValue) {
-    return Ship::Context::GetInstance()->GetConsoleVariables()->GetFloat(name, defaultValue);
+    return Ship::Context::GetRawInstance()->GetConsoleVariables()->GetFloat(name, defaultValue);
 }
 
 const char* CVarGetString(const char* name, const char* defaultValue) {
-    return Ship::Context::GetInstance()->GetConsoleVariables()->GetString(name, defaultValue);
+    return Ship::Context::GetRawInstance()->GetConsoleVariables()->GetString(name, defaultValue);
 }
 
 Color_RGBA8 CVarGetColor(const char* name, Color_RGBA8 defaultValue) {
-    return Ship::Context::GetInstance()->GetConsoleVariables()->GetColor(name, defaultValue);
+    return Ship::Context::GetRawInstance()->GetConsoleVariables()->GetColor(name, defaultValue);
 }
 
 Color_RGB8 CVarGetColor24(const char* name, Color_RGB8 defaultValue) {
-    return Ship::Context::GetInstance()->GetConsoleVariables()->GetColor24(name, defaultValue);
+    return Ship::Context::GetRawInstance()->GetConsoleVariables()->GetColor24(name, defaultValue);
 }
 
 void CVarSetInteger(const char* name, int32_t value) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(name, value);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(name, value);
 }
 
 void CVarSetFloat(const char* name, float value) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetFloat(name, value);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetFloat(name, value);
 }
 
 void CVarSetString(const char* name, const char* value) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(name, value);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(name, value);
 }
 
 void CVarSetColor(const char* name, Color_RGBA8 value) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetColor(name, value);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetColor(name, value);
 }
 
 void CVarSetColor24(const char* name, Color_RGB8 value) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetColor24(name, value);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetColor24(name, value);
 }
 
 void CVarRegisterInteger(const char* name, int32_t defaultValue) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->RegisterInteger(name, defaultValue);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->RegisterInteger(name, defaultValue);
 }
 
 void CVarRegisterFloat(const char* name, float defaultValue) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->RegisterFloat(name, defaultValue);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->RegisterFloat(name, defaultValue);
 }
 
 void CVarRegisterString(const char* name, const char* defaultValue) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->RegisterString(name, defaultValue);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->RegisterString(name, defaultValue);
 }
 
 void CVarRegisterColor(const char* name, Color_RGBA8 defaultValue) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->RegisterColor(name, defaultValue);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->RegisterColor(name, defaultValue);
 }
 
 void CVarRegisterColor24(const char* name, Color_RGB8 defaultValue) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->RegisterColor24(name, defaultValue);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->RegisterColor24(name, defaultValue);
 }
 
 void CVarClear(const char* name) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(name);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(name);
 }
 
 void CVarClearBlock(const char* name) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearBlock(name);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearBlock(name);
 }
 
 void CVarCopy(const char* from, const char* to) {
-    Ship::Context::GetInstance()->GetConsoleVariables()->CopyVariable(from, to);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->CopyVariable(from, to);
 }
 
 void CVarLoad() {
-    Ship::Context::GetInstance()->GetConsoleVariables()->Load();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Load();
 }
 
 void CVarSave() {
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 }

--- a/src/libultraship/bridge/controllerbridge.cpp
+++ b/src/libultraship/bridge/controllerbridge.cpp
@@ -5,10 +5,10 @@
 extern "C" {
 
 void ControllerBlockGameInput(uint16_t inputBlockId) {
-    Ship::Context::GetInstance()->GetControlDeck()->BlockGameInput(static_cast<int32_t>(inputBlockId));
+    Ship::Context::GetRawInstance()->GetControlDeck()->BlockGameInput(static_cast<int32_t>(inputBlockId));
 }
 
 void ControllerUnblockGameInput(uint16_t inputBlockId) {
-    Ship::Context::GetInstance()->GetControlDeck()->UnblockGameInput(static_cast<int32_t>(inputBlockId));
+    Ship::Context::GetRawInstance()->GetControlDeck()->UnblockGameInput(static_cast<int32_t>(inputBlockId));
 }
 }

--- a/src/libultraship/bridge/crashhandlerbridge.cpp
+++ b/src/libultraship/bridge/crashhandlerbridge.cpp
@@ -3,5 +3,5 @@
 #include "ship/debug/CrashHandler.h"
 
 void CrashHandlerRegisterCallback(CrashHandlerCallback callback) {
-    Ship::Context::GetInstance()->GetCrashHandler()->RegisterCallback(callback);
+    Ship::Context::GetRawInstance()->GetCrashHandler()->RegisterCallback(callback);
 }

--- a/src/libultraship/bridge/eventsbridge.cpp
+++ b/src/libultraship/bridge/eventsbridge.cpp
@@ -5,19 +5,19 @@
 extern "C" {
 
 EventID EventSystemRegisterEvent(const char* name) {
-    return Ship::Context::GetInstance()->GetEventSystem()->RegisterEvent(name);
+    return Ship::Context::GetRawInstance()->GetEventSystem()->RegisterEvent(name);
 }
 
 ListenerID EventSystemRegisterListener(EventID id, EventCallback callback, EventPriority priority, const char* file,
                                        int line) {
-    return Ship::Context::GetInstance()->GetEventSystem()->RegisterListener(id, callback, priority, file, line);
+    return Ship::Context::GetRawInstance()->GetEventSystem()->RegisterListener(id, callback, priority, file, line);
 }
 
 void EventSystemUnregisterListener(EventID ev, ListenerID id) {
-    Ship::Context::GetInstance()->GetEventSystem()->UnregisterListener(ev, id);
+    Ship::Context::GetRawInstance()->GetEventSystem()->UnregisterListener(ev, id);
 }
 
 void EventSystemCallEvent(EventID id, void* event, const char* file, int line, const char* key) {
-    Ship::Context::GetInstance()->GetEventSystem()->CallEvent(id, static_cast<IEvent*>(event), file, line, key);
+    Ship::Context::GetRawInstance()->GetEventSystem()->CallEvent(id, static_cast<IEvent*>(event), file, line, key);
 }
 }

--- a/src/libultraship/bridge/gfxbridge.cpp
+++ b/src/libultraship/bridge/gfxbridge.cpp
@@ -7,7 +7,7 @@
 // Set the dimensions for the VI mode that the console would be using
 // (Usually 320x240 for lo-res and 640x480 for hi-res)
 extern "C" void GfxSetNativeDimensions(uint32_t width, uint32_t height) {
-    Fast::Interpreter* gfx = static_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow())
+    Fast::Interpreter* gfx = static_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetRawInstance()->GetWindow())
                                  ->GetInterpreterWeak()
                                  .lock()
                                  .get();
@@ -15,7 +15,7 @@ extern "C" void GfxSetNativeDimensions(uint32_t width, uint32_t height) {
 }
 
 extern "C" void GfxGetPixelDepthPrepare(float x, float y) {
-    auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
+    auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetRawInstance()->GetWindow());
     if (wnd == nullptr) {
         return;
     }
@@ -23,7 +23,7 @@ extern "C" void GfxGetPixelDepthPrepare(float x, float y) {
 }
 
 extern "C" uint16_t GfxGetPixelDepth(float x, float y) {
-    auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
+    auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetRawInstance()->GetWindow());
     if (wnd == nullptr) {
         return 0;
     }

--- a/src/libultraship/bridge/gfxdebuggerbridge.cpp
+++ b/src/libultraship/bridge/gfxdebuggerbridge.cpp
@@ -3,7 +3,7 @@
 #include "fast/Fast3dWindow.h"
 
 static std::shared_ptr<Fast::GfxDebugger> GetGfxDebugger() {
-    auto window = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
+    auto window = std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetRawInstance()->GetWindow());
     return window ? window->GetGfxDebugger() : nullptr;
 }
 

--- a/src/libultraship/bridge/resourcebridge.cpp
+++ b/src/libultraship/bridge/resourcebridge.cpp
@@ -6,11 +6,11 @@
 #include "ship/window/Window.h"
 
 std::shared_ptr<Ship::IResource> ResourceLoad(const char* name) {
-    return Ship::Context::GetInstance()->GetResourceManager()->LoadResource(name);
+    return Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(name);
 }
 
 std::shared_ptr<Ship::IResource> ResourceLoad(uint64_t crc) {
-    return Ship::Context::GetInstance()->GetResourceManager()->LoadResource(crc);
+    return Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(crc);
 }
 
 extern "C" {
@@ -20,31 +20,31 @@ uint64_t ResourceGetCrcByName(const char* name) {
 }
 
 const char* ResourceGetNameByCrc(uint64_t crc) {
-    return Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->HashToCString(crc);
+    return Ship::Context::GetRawInstance()->GetResourceManager()->GetArchiveManager()->HashToCString(crc);
 }
 
 size_t ResourceGetSizeByName(const char* name) {
-    return Ship::Context::GetInstance()->GetResourceManager()->GetResourceSize(name);
+    return Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceSize(name);
 }
 
 size_t ResourceGetSizeByCrc(uint64_t crc) {
-    return Ship::Context::GetInstance()->GetResourceManager()->GetResourceSize(crc);
+    return Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceSize(crc);
 }
 
 uint8_t ResourceGetIsCustomByName(const char* name) {
-    return Ship::Context::GetInstance()->GetResourceManager()->GetResourceIsCustom(name);
+    return Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceIsCustom(name);
 }
 
 uint8_t ResourceGetIsCustomByCrc(uint64_t crc) {
-    return Ship::Context::GetInstance()->GetResourceManager()->GetResourceIsCustom(crc);
+    return Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceIsCustom(crc);
 }
 
 void* ResourceGetDataByName(const char* name) {
-    return Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer(name);
+    return Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer(name);
 }
 
 void* ResourceGetDataByCrc(uint64_t crc) {
-    return Ship::Context::GetInstance()->GetResourceManager()->GetResourceRawPointer(crc);
+    return Ship::Context::GetRawInstance()->GetResourceManager()->GetResourceRawPointer(crc);
 }
 
 uint16_t ResourceGetTexWidthByName(const char* name) {
@@ -114,26 +114,26 @@ size_t ResourceGetTexSizeByCrc(uint64_t crc) {
 }
 
 void ResourceGetGameVersions(uint32_t* versions, size_t versionsSize, size_t* versionsCount) {
-    auto list = Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->GetGameVersions();
+    auto list = Ship::Context::GetRawInstance()->GetResourceManager()->GetArchiveManager()->GetGameVersions();
     memcpy(versions, list.data(), std::min(versionsSize, list.size() * sizeof(uint32_t)));
     *versionsCount = list.size();
 }
 
 void ResourceLoadDirectoryAsync(const char* name) {
-    Ship::Context::GetInstance()->GetResourceManager()->LoadResourcesAsync(name);
+    Ship::Context::GetRawInstance()->GetResourceManager()->LoadResourcesAsync(name);
 }
 
 uint32_t ResourceHasGameVersion(uint32_t hash) {
-    auto list = Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->GetGameVersions();
+    auto list = Ship::Context::GetRawInstance()->GetResourceManager()->GetArchiveManager()->GetGameVersions();
     return std::find(list.begin(), list.end(), hash) != list.end();
 }
 
 void ResourceLoadDirectory(const char* name) {
-    Ship::Context::GetInstance()->GetResourceManager()->LoadResources(name);
+    Ship::Context::GetRawInstance()->GetResourceManager()->LoadResources(name);
 }
 
 void ResourceDirtyDirectory(const char* name) {
-    Ship::Context::GetInstance()->GetResourceManager()->DirtyResources(name);
+    Ship::Context::GetRawInstance()->GetResourceManager()->DirtyResources(name);
 }
 
 void ResourceDirtyByName(const char* name) {
@@ -153,7 +153,7 @@ void ResourceDirtyByCrc(uint64_t crc) {
 }
 
 void ResourceUnloadByName(const char* name) {
-    Ship::Context::GetInstance()->GetResourceManager()->UnloadResource(name);
+    Ship::Context::GetRawInstance()->GetResourceManager()->UnloadResource(name);
 }
 
 void ResourceUnloadByCrc(uint64_t crc) {
@@ -161,10 +161,10 @@ void ResourceUnloadByCrc(uint64_t crc) {
 }
 
 void ResourceUnloadDirectory(const char* name) {
-    Ship::Context::GetInstance()->GetResourceManager()->UnloadResources(name);
+    Ship::Context::GetRawInstance()->GetResourceManager()->UnloadResources(name);
 }
 
 uint32_t IsResourceManagerLoaded() {
-    return Ship::Context::GetInstance()->GetResourceManager()->IsLoaded();
+    return Ship::Context::GetRawInstance()->GetResourceManager()->IsLoaded();
 }
 }

--- a/src/libultraship/bridge/resourcebridge.cpp
+++ b/src/libultraship/bridge/resourcebridge.cpp
@@ -2,6 +2,8 @@
 #include "ship/Context.h"
 #include <string>
 #include <algorithm>
+
+#include "fast/resource/type/Texture.h"
 #include "ship/utils/StrHash64.h"
 #include "ship/window/Window.h"
 

--- a/src/libultraship/bridge/scriptingbridge.cpp
+++ b/src/libultraship/bridge/scriptingbridge.cpp
@@ -6,7 +6,7 @@
 #include "ship/Context.h"
 
 extern "C" void* ScriptGetFunction(const char* module, const char* function) {
-    return Ship::Context::GetInstance()->GetScriptLoader()->GetFunction(module, function);
+    return Ship::Context::GetRawInstance()->GetScriptLoader()->GetFunction(module, function);
 }
 
 #endif // ENABLE_SCRIPTING

--- a/src/libultraship/bridge/windowbridge.cpp
+++ b/src/libultraship/bridge/windowbridge.cpp
@@ -5,30 +5,30 @@
 extern "C" {
 
 uint32_t WindowGetWidth() {
-    return Ship::Context::GetInstance()->GetWindow()->GetWidth();
+    return Ship::Context::GetRawInstance()->GetWindow()->GetWidth();
 }
 
 uint32_t WindowGetHeight() {
-    return Ship::Context::GetInstance()->GetWindow()->GetHeight();
+    return Ship::Context::GetRawInstance()->GetWindow()->GetHeight();
 }
 
 float WindowGetAspectRatio() {
-    return Ship::Context::GetInstance()->GetWindow()->GetCurrentAspectRatio();
+    return Ship::Context::GetRawInstance()->GetWindow()->GetCurrentAspectRatio();
 }
 
 bool WindowIsRunning() {
-    return Ship::Context::GetInstance()->GetWindow()->IsRunning();
+    return Ship::Context::GetRawInstance()->GetWindow()->IsRunning();
 }
 
 int32_t WindowGetPosX() {
-    return Ship::Context::GetInstance()->GetWindow()->GetPosX();
+    return Ship::Context::GetRawInstance()->GetWindow()->GetPosX();
 }
 
 int32_t WindowGetPosY() {
-    return Ship::Context::GetInstance()->GetWindow()->GetPosY();
+    return Ship::Context::GetRawInstance()->GetWindow()->GetPosY();
 }
 
 bool WindowIsFullscreen() {
-    return Ship::Context::GetInstance()->GetWindow()->IsFullscreen();
+    return Ship::Context::GetRawInstance()->GetWindow()->IsFullscreen();
 }
 }

--- a/src/libultraship/controller/controldevice/controller/Controller.cpp
+++ b/src/libultraship/controller/controldevice/controller/Controller.cpp
@@ -42,7 +42,7 @@ void Controller::ReadToOSContPad(OSContPad* pad) {
     if (pad != nullptr) {
         auto& padFromBuffer = mPadBuffer[std::min(
             mPadBuffer.size() - 1,
-            (size_t)Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_SIMULATED_INPUT_LAG, 0))];
+            (size_t)Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_SIMULATED_INPUT_LAG, 0))];
 
         pad->button |= padFromBuffer.button;
 

--- a/src/libultraship/libultra/os.cpp
+++ b/src/libultraship/libultra/os.cpp
@@ -29,7 +29,7 @@ int32_t osContInit(OSMesgQueue* mq, uint8_t* controllerBits, OSContStatus* statu
         exit(EXIT_FAILURE);
     }
 
-    Ship::Context::GetInstance()->GetControlDeck()->Init(controllerBits);
+    Ship::Context::GetRawInstance()->GetControlDeck()->Init(controllerBits);
 
     return 0;
 }
@@ -41,7 +41,7 @@ int32_t osContStartReadData(OSMesgQueue* mesg) {
 void osContGetReadData(OSContPad* pad) {
     memset(pad, 0, sizeof(OSContPad) * __osMaxControllers);
 
-    Ship::Context::GetInstance()->GetControlDeck()->WriteToPad(pad);
+    Ship::Context::GetRawInstance()->GetControlDeck()->WriteToPad(pad);
 }
 
 void osSetTime(OSTime time) {
@@ -86,7 +86,7 @@ int32_t osAiSetNextBuffer(void* buff, size_t len) {
 }
 
 int32_t __osMotorAccess(OSPfs* pfs, uint32_t vibrate) {
-    auto io = Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(pfs->channel)->GetRumble();
+    auto io = Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(pfs->channel)->GetRumble();
     if (vibrate) {
         io->StartRumble();
     } else {

--- a/src/libultraship/window/gui/GfxDebuggerWindow.cpp
+++ b/src/libultraship/window/gui/GfxDebuggerWindow.cpp
@@ -26,8 +26,8 @@ void GfxDebuggerWindow::InitElement() {
 
 void GfxDebuggerWindow::UpdateElement() {
     if (mInterpreter.lock() == nullptr) {
-        mInterpreter =
-            dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow())->GetInterpreterWeak();
+        mInterpreter = dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetRawInstance()->GetWindow())
+                           ->GetInterpreterWeak();
     }
 }
 
@@ -44,7 +44,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                                       float parentPosY = 0) const {
     const F3DGfx* dlStart = cmd;
     auto dbg =
-        std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow())->GetGfxDebugger();
+        std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetRawInstance()->GetWindow())->GetGfxDebugger();
 
     auto nodeWithText = [dbg, dlStart, parentPosY, this, &gfxPath](const F3DGfx* cmd, const std::string& text,
                                                                    const F3DGfx* sub = nullptr) mutable {
@@ -402,7 +402,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                     nodeWithText(cmd0, fmt::format("G_INVALTEXCACHE: clear all entries"));
                 } else {
                     if (((uintptr_t)texAddr & 1) == 0 &&
-                        Ship::Context::GetInstance()->GetResourceManager()->OtrSignatureCheck(texAddr)) {
+                        Ship::Context::GetRawInstance()->GetResourceManager()->OtrSignatureCheck(texAddr)) {
                         nodeWithText(cmd0, fmt::format("G_INVALTEXCACHE: {}", texAddr));
                     } else {
                         nodeWithText(cmd0, fmt::format("G_INVALTEXCACHE: 0x{:x}", (uintptr_t)texAddr));
@@ -523,7 +523,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 uint8_t* mask = (uint8_t*)cmd->words.w0;
                 uint8_t* replacementTex = (uint8_t*)cmd->words.w1;
 
-                if (Ship::Context::GetInstance()->GetResourceManager()->OtrSignatureCheck(timg)) {
+                if (Ship::Context::GetRawInstance()->GetResourceManager()->OtrSignatureCheck(timg)) {
                     timg += 7;
                     nodeWithText(cmd0, fmt::format("G_REGBLENDEDTEX: src {}, mask {}, blended {}", timg, (void*)mask,
                                                    (void*)replacementTex));
@@ -589,7 +589,7 @@ static bool bpEquals(const std::vector<const F3DGfx*>& x, const std::vector<cons
 void GfxDebuggerWindow::DrawDisas() {
 
     auto dbg =
-        std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow())->GetGfxDebugger();
+        std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetRawInstance()->GetWindow())->GetGfxDebugger();
     auto dlist = dbg->GetDisplayList();
     ImGui::Text("dlist: %p", dlist);
     std::string bp = "";
@@ -607,7 +607,7 @@ void GfxDebuggerWindow::DrawDisas() {
     std::string TO_LOAD_TEX = "GfxDebuggerWindowTextureToLoad";
 
     const F3DGfx* cmd = dlist;
-    auto gui = std::dynamic_pointer_cast<Fast::Fast3dGui>(Ship::Context::GetInstance()->GetWindow()->GetGui());
+    auto gui = std::dynamic_pointer_cast<Fast::Fast3dGui>(Ship::Context::GetRawInstance()->GetWindow()->GetGui());
 
     ImGui::BeginChild("###State", ImVec2(0.0f, 200.0f), true);
     {
@@ -711,7 +711,7 @@ void GfxDebuggerWindow::DrawDisas() {
 
 void GfxDebuggerWindow::DrawElement() {
     auto dbg =
-        std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow())->GetGfxDebugger();
+        std::dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetRawInstance()->GetWindow())->GetGfxDebugger();
     // const ImVec2 pos = ImGui::GetWindowPos();
     // const ImVec2 size = ImGui::GetWindowSize();
 

--- a/src/libultraship/window/gui/InputEditorWindow.cpp
+++ b/src/libultraship/window/gui/InputEditorWindow.cpp
@@ -43,7 +43,7 @@ void InputEditorWindow::UpdateElement() {
     }
 
     if (mInputEditorPopupOpen && ImGui::IsPopupOpen("", ImGuiPopupFlags_AnyPopupId)) {
-        Ship::Context::GetInstance()->GetControlDeck()->BlockGameInput(INPUT_EDITOR_WINDOW_GAME_INPUT_BLOCK_ID);
+        Ship::Context::GetRawInstance()->GetControlDeck()->BlockGameInput(INPUT_EDITOR_WINDOW_GAME_INPUT_BLOCK_ID);
 
         // continue to block input for a third of a second after getting the mapping
         mGameInputBlockTimer = ImGui::GetIO().Framerate / 3;
@@ -55,24 +55,24 @@ void InputEditorWindow::UpdateElement() {
             }
         }
 
-        Ship::Context::GetInstance()->GetWindow()->GetGui()->BlockGamepadNavigation();
+        Ship::Context::GetRawInstance()->GetWindow()->GetGui()->BlockGamepadNavigation();
     } else {
         if (mGameInputBlockTimer != INT32_MAX) {
             mGameInputBlockTimer--;
             if (mGameInputBlockTimer <= 0) {
-                Ship::Context::GetInstance()->GetControlDeck()->UnblockGameInput(
+                Ship::Context::GetRawInstance()->GetControlDeck()->UnblockGameInput(
                     INPUT_EDITOR_WINDOW_GAME_INPUT_BLOCK_ID);
                 mGameInputBlockTimer = INT32_MAX;
             }
         }
 
-        if (Ship::Context::GetInstance()->GetWindow()->GetGui()->GamepadNavigationEnabled()) {
+        if (Ship::Context::GetRawInstance()->GetWindow()->GetGui()->GamepadNavigationEnabled()) {
             mMappingInputBlockTimer = ImGui::GetIO().Framerate / 3;
         } else {
             mMappingInputBlockTimer = INT32_MAX;
         }
 
-        Ship::Context::GetInstance()->GetWindow()->GetGui()->UnblockGamepadNavigation();
+        Ship::Context::GetRawInstance()->GetWindow()->GetGui()->UnblockGamepadNavigation();
     }
 }
 
@@ -212,7 +212,7 @@ void InputEditorWindow::DrawButtonLineAddMappingButton(uint8_t port, CONTROLLERB
             ImGui::CloseCurrentPopup();
         }
         // todo: figure out why optional params (using id = "" in the definition) wasn't working
-        if (mMappingInputBlockTimer == INT32_MAX && Ship::Context::GetInstance()
+        if (mMappingInputBlockTimer == INT32_MAX && Ship::Context::GetRawInstance()
                                                         ->GetControlDeck()
                                                         ->GetControllerByPort(port)
                                                         ->GetButton(bitmask)
@@ -225,7 +225,7 @@ void InputEditorWindow::DrawButtonLineAddMappingButton(uint8_t port, CONTROLLERB
 }
 
 void InputEditorWindow::DrawButtonLineEditMappingButton(uint8_t port, CONTROLLERBUTTONS_T bitmask, std::string id) {
-    auto mapping = Ship::Context::GetInstance()
+    auto mapping = Ship::Context::GetRawInstance()
                        ->GetControlDeck()
                        ->GetControllerByPort(port)
                        ->GetButton(bitmask)
@@ -276,7 +276,7 @@ void InputEditorWindow::DrawButtonLineEditMappingButton(uint8_t port, CONTROLLER
             mInputEditorPopupOpen = false;
             ImGui::CloseCurrentPopup();
         }
-        if (mMappingInputBlockTimer == INT32_MAX && Ship::Context::GetInstance()
+        if (mMappingInputBlockTimer == INT32_MAX && Ship::Context::GetRawInstance()
                                                         ->GetControlDeck()
                                                         ->GetControllerByPort(port)
                                                         ->GetButton(bitmask)
@@ -317,7 +317,7 @@ void InputEditorWindow::DrawButtonLineEditMappingButton(uint8_t port, CONTROLLER
             ImGui::Text("Axis Threshold\n\nThe extent to which the joystick\nmust be moved or the trigger\npressed to "
                         "initiate the assigned\nbutton action.\n\n");
 
-            auto globalSettings = Ship::Context::GetInstance()->GetControlDeck()->GetGlobalSDLDeviceSettings();
+            auto globalSettings = Ship::Context::GetRawInstance()->GetControlDeck()->GetGlobalSDLDeviceSettings();
 
             if (sdlAxisDirectionToButtonMapping->AxisIsStick()) {
                 ImGui::Text("Stick axis threshold:");
@@ -412,7 +412,7 @@ void InputEditorWindow::DrawButtonLineEditMappingButton(uint8_t port, CONTROLLER
     ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(1.0f, 0.5f));
     if (ImGui::Button(StringHelper::Sprintf("%s###removeButtonMappingButton%s", ICON_FA_TIMES, id.c_str()).c_str(),
                       ImVec2(ImGui::CalcTextSize(ICON_FA_TIMES).x + SCALE_IMGUI_SIZE(10.0f), 0.0f))) {
-        Ship::Context::GetInstance()
+        Ship::Context::GetRawInstance()
             ->GetControlDeck()
             ->GetControllerByPort(port)
             ->GetButton(bitmask)
@@ -458,7 +458,7 @@ void InputEditorWindow::DrawStickDirectionLineAddMappingButton(uint8_t port, uin
         }
         if (stick == Ship::LEFT) {
             if (mMappingInputBlockTimer == INT32_MAX &&
-                Ship::Context::GetInstance()
+                Ship::Context::GetRawInstance()
                     ->GetControlDeck()
                     ->GetControllerByPort(port)
                     ->GetLeftStick()
@@ -468,7 +468,7 @@ void InputEditorWindow::DrawStickDirectionLineAddMappingButton(uint8_t port, uin
             }
         } else {
             if (mMappingInputBlockTimer == INT32_MAX &&
-                Ship::Context::GetInstance()
+                Ship::Context::GetRawInstance()
                     ->GetControlDeck()
                     ->GetControllerByPort(port)
                     ->GetRightStick()
@@ -484,13 +484,13 @@ void InputEditorWindow::DrawStickDirectionLineEditMappingButton(uint8_t port, ui
                                                                 std::string id) {
     std::shared_ptr<Ship::ControllerAxisDirectionMapping> mapping = nullptr;
     if (stick == Ship::LEFT) {
-        mapping = Ship::Context::GetInstance()
+        mapping = Ship::Context::GetRawInstance()
                       ->GetControlDeck()
                       ->GetControllerByPort(port)
                       ->GetLeftStick()
                       ->GetAxisDirectionMappingById(direction, id);
     } else {
-        mapping = Ship::Context::GetInstance()
+        mapping = Ship::Context::GetRawInstance()
                       ->GetControlDeck()
                       ->GetControllerByPort(port)
                       ->GetRightStick()
@@ -547,7 +547,7 @@ void InputEditorWindow::DrawStickDirectionLineEditMappingButton(uint8_t port, ui
 
         if (stick == Ship::LEFT) {
             if (mMappingInputBlockTimer == INT32_MAX &&
-                Ship::Context::GetInstance()
+                Ship::Context::GetRawInstance()
                     ->GetControlDeck()
                     ->GetControllerByPort(port)
                     ->GetLeftStick()
@@ -557,7 +557,7 @@ void InputEditorWindow::DrawStickDirectionLineEditMappingButton(uint8_t port, ui
             }
         } else {
             if (mMappingInputBlockTimer == INT32_MAX &&
-                Ship::Context::GetInstance()
+                Ship::Context::GetRawInstance()
                     ->GetControlDeck()
                     ->GetControllerByPort(port)
                     ->GetRightStick()
@@ -577,13 +577,13 @@ void InputEditorWindow::DrawStickDirectionLineEditMappingButton(uint8_t port, ui
             StringHelper::Sprintf("%s###removeStickDirectionMappingButton%s", ICON_FA_TIMES, id.c_str()).c_str(),
             ImVec2(ImGui::CalcTextSize(ICON_FA_TIMES).x + SCALE_IMGUI_SIZE(10.0f), 0.0f))) {
         if (stick == Ship::LEFT) {
-            Ship::Context::GetInstance()
+            Ship::Context::GetRawInstance()
                 ->GetControlDeck()
                 ->GetControllerByPort(port)
                 ->GetLeftStick()
                 ->ClearAxisDirectionMapping(direction, id);
         } else {
-            Ship::Context::GetInstance()
+            Ship::Context::GetRawInstance()
                 ->GetControlDeck()
                 ->GetControllerByPort(port)
                 ->GetRightStick()
@@ -616,9 +616,9 @@ void InputEditorWindow::DrawStickSection(uint8_t port, uint8_t stick, int32_t id
     static int8_t sX, sY;
     std::shared_ptr<Ship::ControllerStick> controllerStick = nullptr;
     if (stick == Ship::LEFT) {
-        controllerStick = Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(port)->GetLeftStick();
+        controllerStick = Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(port)->GetLeftStick();
     } else {
-        controllerStick = Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(port)->GetRightStick();
+        controllerStick = Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(port)->GetRightStick();
     }
     controllerStick->Process(sX, sY);
     DrawAnalogPreview(StringHelper::Sprintf("##AnalogPreview%d", id).c_str(), ImVec2(sX, sY));
@@ -756,7 +756,7 @@ void InputEditorWindow::UpdateBitmaskToMappingIds(uint8_t port) {
     // todo: do we need this now that ControllerButton exists?
 
     for (auto [bitmask, button] :
-         Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(port)->GetAllButtons()) {
+         Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(port)->GetAllButtons()) {
         for (auto [id, mapping] : button->GetAllButtonMappings()) {
             // using a vector here instead of a set because i want newly added mappings
             // to go to the end of the list instead of autosorting
@@ -772,10 +772,11 @@ void InputEditorWindow::UpdateStickDirectionToMappingIds(uint8_t port) {
     // todo: do we need this?
     for (auto stick :
          { std::make_pair<uint8_t, std::shared_ptr<Ship::ControllerStick>>(
-               Ship::LEFT, Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(port)->GetLeftStick()),
+               Ship::LEFT,
+               Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(port)->GetLeftStick()),
            std::make_pair<uint8_t, std::shared_ptr<Ship::ControllerStick>>(
                Ship::RIGHT,
-               Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(port)->GetRightStick()) }) {
+               Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(port)->GetRightStick()) }) {
         for (auto direction : { Ship::LEFT, Ship::RIGHT, Ship::UP, Ship::DOWN }) {
             for (auto [id, mapping] : stick.second->GetAllAxisDirectionMappingByDirection(direction)) {
                 // using a vector here instead of a set because i want newly added mappings
@@ -795,7 +796,8 @@ void InputEditorWindow::DrawRemoveRumbleMappingButton(uint8_t port, std::string 
     ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(1.0f, 0.5f));
     if (ImGui::Button(StringHelper::Sprintf("%s###removeRumbleMapping%s", ICON_FA_TIMES, id.c_str()).c_str(),
                       ImVec2(SCALE_IMGUI_SIZE(20.0f), SCALE_IMGUI_SIZE(20.0f)))) {
-        Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(port)->GetRumble()->ClearRumbleMapping(id);
+        Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(port)->GetRumble()->ClearRumbleMapping(
+            id);
     }
     ImGui::PopStyleVar();
 }
@@ -819,7 +821,7 @@ void InputEditorWindow::DrawAddRumbleMappingButton(uint8_t port) {
             ImGui::CloseCurrentPopup();
         }
 
-        if (mMappingInputBlockTimer == INT32_MAX && Ship::Context::GetInstance()
+        if (mMappingInputBlockTimer == INT32_MAX && Ship::Context::GetRawInstance()
                                                         ->GetControlDeck()
                                                         ->GetControllerByPort(port)
                                                         ->GetRumble()
@@ -836,7 +838,7 @@ bool InputEditorWindow::TestingRumble() {
 }
 
 void InputEditorWindow::DrawRumbleSection(uint8_t port) {
-    for (auto [id, mapping] : Ship::Context::GetInstance()
+    for (auto [id, mapping] : Ship::Context::GetRawInstance()
                                   ->GetControlDeck()
                                   ->GetControllerByPort(port)
                                   ->GetRumble()
@@ -979,7 +981,7 @@ void InputEditorWindow::DrawRemoveLEDMappingButton(uint8_t port, std::string id)
     ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(1.0f, 0.5f));
     if (ImGui::Button(StringHelper::Sprintf("%s###removeLEDMapping%s", ICON_FA_TIMES, id.c_str()).c_str(),
                       ImVec2(SCALE_IMGUI_SIZE(20.0f), SCALE_IMGUI_SIZE(20.0f)))) {
-        Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(port)->GetLED()->ClearLEDMapping(id);
+        Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(port)->GetLED()->ClearLEDMapping(id);
     }
     ImGui::PopStyleVar();
 }
@@ -1003,7 +1005,7 @@ void InputEditorWindow::DrawAddLEDMappingButton(uint8_t port) {
             ImGui::CloseCurrentPopup();
         }
 
-        if (mMappingInputBlockTimer == INT32_MAX && Ship::Context::GetInstance()
+        if (mMappingInputBlockTimer == INT32_MAX && Ship::Context::GetRawInstance()
                                                         ->GetControlDeck()
                                                         ->GetControllerByPort(port)
                                                         ->GetLED()
@@ -1017,7 +1019,7 @@ void InputEditorWindow::DrawAddLEDMappingButton(uint8_t port) {
 
 void InputEditorWindow::DrawLEDSection(uint8_t port) {
     for (auto [id, mapping] :
-         Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(port)->GetLED()->GetAllLEDMappings()) {
+         Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(port)->GetLED()->GetAllLEDMappings()) {
         ImGui::AlignTextToFramePadding();
         ImGui::SetNextItemOpen(true, ImGuiCond_Once);
         auto open = ImGui::TreeNode(
@@ -1059,7 +1061,7 @@ void InputEditorWindow::DrawRemoveGyroMappingButton(uint8_t port, std::string id
     ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(1.0f, 0.5f));
     if (ImGui::Button(StringHelper::Sprintf("%s###removeGyroMapping%s", ICON_FA_TIMES, id.c_str()).c_str(),
                       ImVec2(SCALE_IMGUI_SIZE(20.0f), SCALE_IMGUI_SIZE(20.0f)))) {
-        Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(port)->GetGyro()->ClearGyroMapping();
+        Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(port)->GetGyro()->ClearGyroMapping();
     }
     ImGui::PopStyleVar();
 }
@@ -1083,7 +1085,7 @@ void InputEditorWindow::DrawAddGyroMappingButton(uint8_t port) {
             ImGui::CloseCurrentPopup();
         }
 
-        if (mMappingInputBlockTimer == INT32_MAX && Ship::Context::GetInstance()
+        if (mMappingInputBlockTimer == INT32_MAX && Ship::Context::GetRawInstance()
                                                         ->GetControlDeck()
                                                         ->GetControllerByPort(port)
                                                         ->GetGyro()
@@ -1097,7 +1099,7 @@ void InputEditorWindow::DrawAddGyroMappingButton(uint8_t port) {
 
 void InputEditorWindow::DrawGyroSection(uint8_t port) {
     auto mapping =
-        Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(port)->GetGyro()->GetGyroMapping();
+        Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(port)->GetGyro()->GetGyroMapping();
     if (mapping != nullptr) {
         auto id = mapping->GetGyroMappingId();
         ImGui::AlignTextToFramePadding();
@@ -1203,7 +1205,8 @@ void InputEditorWindow::DrawDeviceToggles(uint8_t portIndex) {
 
     ImGui::PopItemFlag();
 
-    auto connectedDeviceManager = Ship::Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager();
+    auto connectedDeviceManager =
+        Ship::Context::GetRawInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager();
     for (const auto& [instanceId, name] : connectedDeviceManager->GetConnectedSDLGamepadNames()) {
         ImGui::PushItemFlag(ImGuiItemFlags_Disabled, true);
         auto buttonColor = ImGui::GetStyleColorVec4(ImGuiCol_Button);
@@ -1239,7 +1242,7 @@ void InputEditorWindow::DrawClearAllButton(uint8_t portIndex) {
             ImGui::CloseCurrentPopup();
         }
         if (ImGui::Button("Clear All")) {
-            Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(portIndex)->ClearAllMappings();
+            Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(portIndex)->ClearAllMappings();
             ImGui::CloseCurrentPopup();
         }
         ImGui::EndPopup();
@@ -1334,11 +1337,11 @@ void InputEditorWindow::DrawSetDefaultsButton(uint8_t portIndex) {
                 ImGui::CloseCurrentPopup();
             }
             if (ImGui::Button("Set defaults")) {
-                Ship::Context::GetInstance()
+                Ship::Context::GetRawInstance()
                     ->GetControlDeck()
                     ->GetControllerByPort(portIndex)
                     ->ClearAllMappingsForDeviceType(Ship::PhysicalDeviceType::Keyboard);
-                Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(portIndex)->AddDefaultMappings(
+                Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(portIndex)->AddDefaultMappings(
                     Ship::PhysicalDeviceType::Keyboard);
                 shouldClose = true;
                 ImGui::CloseCurrentPopup();
@@ -1359,11 +1362,11 @@ void InputEditorWindow::DrawSetDefaultsButton(uint8_t portIndex) {
                 ImGui::CloseCurrentPopup();
             }
             if (ImGui::Button("Set defaults")) {
-                Ship::Context::GetInstance()
+                Ship::Context::GetRawInstance()
                     ->GetControlDeck()
                     ->GetControllerByPort(portIndex)
                     ->ClearAllMappingsForDeviceType(Ship::PhysicalDeviceType::Mouse);
-                Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(portIndex)->AddDefaultMappings(
+                Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(portIndex)->AddDefaultMappings(
                     Ship::PhysicalDeviceType::Mouse);
                 shouldClose = true;
                 ImGui::CloseCurrentPopup();
@@ -1389,11 +1392,11 @@ void InputEditorWindow::DrawSetDefaultsButton(uint8_t portIndex) {
                 ImGui::CloseCurrentPopup();
             }
             if (ImGui::Button("Set defaults")) {
-                Ship::Context::GetInstance()
+                Ship::Context::GetRawInstance()
                     ->GetControlDeck()
                     ->GetControllerByPort(portIndex)
                     ->ClearAllMappingsForDeviceType(Ship::PhysicalDeviceType::SDLGamepad);
-                Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(portIndex)->AddDefaultMappings(
+                Ship::Context::GetRawInstance()->GetControlDeck()->GetControllerByPort(portIndex)->AddDefaultMappings(
                     Ship::PhysicalDeviceType::SDLGamepad);
                 shouldClose = true;
                 ImGui::CloseCurrentPopup();

--- a/src/ship/Context.cpp
+++ b/src/ship/Context.cpp
@@ -29,10 +29,14 @@
 #endif
 
 namespace Ship {
-std::weak_ptr<Context> Context::mContext;
+Context* Context::mContext;
 
-std::shared_ptr<Context> Context::GetInstance() {
-    return mContext.lock();
+Context* Context::GetRawInstance() {
+    return mContext;
+}
+
+void Context::DestroyInstance() {
+    delete mContext;
 }
 
 Context::~Context() {
@@ -58,18 +62,18 @@ Context::~Context() {
     GetConfig()->Save();
     mConfig = nullptr;
     spdlog::shutdown();
+    mContext = nullptr;
 }
 
-std::shared_ptr<Context>
-Context::CreateInstance(const std::string& name, const std::string& shortName, const std::string& configFilePath,
-                        const std::vector<std::string>& archivePaths, const std::unordered_set<uint32_t>& validHashes,
-                        uint32_t reservedThreadCount, AudioSettings audioSettings, std::shared_ptr<Window> window,
-                        std::shared_ptr<ControlDeck> controlDeck) {
-    if (mContext.expired()) {
-        auto shared = std::make_shared<Context>(name, shortName, configFilePath);
-        mContext = shared;
-        if (shared->Init(archivePaths, validHashes, reservedThreadCount, audioSettings, window, controlDeck)) {
-            return shared;
+Context* Context::CreateInstance(const std::string& name, const std::string& shortName,
+                                 const std::string& configFilePath, const std::vector<std::string>& archivePaths,
+                                 const std::unordered_set<uint32_t>& validHashes, uint32_t reservedThreadCount,
+                                 AudioSettings audioSettings, std::shared_ptr<Window> window,
+                                 std::shared_ptr<ControlDeck> controlDeck) {
+    if (mContext == nullptr) {
+        mContext = new Context(name, shortName, configFilePath);
+        if (mContext->Init(archivePaths, validHashes, reservedThreadCount, audioSettings, window, controlDeck)) {
+            return mContext;
         } else {
             SPDLOG_ERROR("Failed to initialize");
             return nullptr;
@@ -78,20 +82,19 @@ Context::CreateInstance(const std::string& name, const std::string& shortName, c
 
     SPDLOG_DEBUG("Trying to create a context when it already exists. Returning existing.");
 
-    return GetInstance();
+    return GetRawInstance();
 }
 
-std::shared_ptr<Context> Context::CreateUninitializedInstance(const std::string& name, const std::string& shortName,
-                                                              const std::string& configFilePath) {
-    if (mContext.expired()) {
-        auto shared = std::make_shared<Context>(name, shortName, configFilePath);
-        mContext = shared;
-        return shared;
+Context* Context::CreateUninitializedInstance(const std::string& name, const std::string& shortName,
+                                              const std::string& configFilePath) {
+    if (mContext == nullptr) {
+        mContext = new Context(name, shortName, configFilePath);
+        return mContext;
     }
 
     SPDLOG_DEBUG("Trying to create an uninitialized context when it already exists. Returning existing.");
 
-    return GetInstance();
+    return GetRawInstance();
 }
 
 Context::Context(std::string name, std::string shortName, std::string configFilePath)

--- a/src/ship/Context.cpp
+++ b/src/ship/Context.cpp
@@ -29,20 +29,19 @@
 #endif
 
 namespace Ship {
-Context* Context::mContext;
+std::unique_ptr<Context> Context::mContext;
 
 Context* Context::GetRawInstance() {
-    return mContext;
+    return mContext.get();
 }
 
 void Context::DestroyInstance() {
-    delete mContext;
+    mContext = nullptr;
 }
 
 Context::~Context() {
     SPDLOG_TRACE("destruct context");
     GetWindow()->SaveWindowToConfig();
-
     // Explicitly destructing everything so that logging is done last.
     mAudio = nullptr;
     mWindow = nullptr;
@@ -61,8 +60,9 @@ Context::~Context() {
 #endif
     GetConfig()->Save();
     mConfig = nullptr;
-    spdlog::shutdown();
-    mContext = nullptr;
+    mLogger->flush();
+    mLogger = nullptr;
+    mLogThreadPool = nullptr;
 }
 
 Context* Context::CreateInstance(const std::string& name, const std::string& shortName,
@@ -71,9 +71,9 @@ Context* Context::CreateInstance(const std::string& name, const std::string& sho
                                  AudioSettings audioSettings, std::shared_ptr<Window> window,
                                  std::shared_ptr<ControlDeck> controlDeck) {
     if (mContext == nullptr) {
-        mContext = new Context(name, shortName, configFilePath);
+        mContext = std::make_unique<Context>(name, shortName, configFilePath);
         if (mContext->Init(archivePaths, validHashes, reservedThreadCount, audioSettings, window, controlDeck)) {
-            return mContext;
+            return mContext.get();
         } else {
             SPDLOG_ERROR("Failed to initialize");
             return nullptr;
@@ -88,8 +88,8 @@ Context* Context::CreateInstance(const std::string& name, const std::string& sho
 Context* Context::CreateUninitializedInstance(const std::string& name, const std::string& shortName,
                                               const std::string& configFilePath) {
     if (mContext == nullptr) {
-        mContext = new Context(name, shortName, configFilePath);
-        return mContext;
+        mContext = std::make_unique<Context>(name, shortName, configFilePath);
+        return mContext.get();
     }
 
     SPDLOG_DEBUG("Trying to create an uninitialized context when it already exists. Returning existing.");
@@ -158,7 +158,7 @@ bool Context::InitLogging(spdlog::level::level_enum debugBuildLogLevel,
         std::wcin.clear();
 #endif
         auto systemConsoleSink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-        // systemConsoleSink->set_level(spdlog::level::trace);
+        systemConsoleSink->set_level(spdlog::level::trace);
         sinks.push_back(systemConsoleSink);
 #endif
 
@@ -170,7 +170,8 @@ bool Context::InitLogging(spdlog::level::level_enum debugBuildLogLevel,
         GetLogger()->set_level(debugBuildLogLevel);
         GetLogger()->flush_on(spdlog::level::trace);
 #else
-        mLogger = std::make_shared<spdlog::async_logger>(GetName(), sinks.begin(), sinks.end(), spdlog::thread_pool(),
+        mLogThreadPool = std::make_shared<spdlog::details::thread_pool>(8192, 1);
+        mLogger = std::make_shared<spdlog::async_logger>(GetName(), sinks.begin(), sinks.end(), mLogThreadPool,
                                                          spdlog::async_overflow_policy::block);
         GetLogger()->set_level(releaseBuildLogLevel);
         GetLogger()->flush_on(spdlog::level::info);
@@ -234,10 +235,10 @@ bool Context::InitResourceManager(const std::vector<std::string>& archivePaths,
         paths.push_back(mMainPath);
         paths.push_back(mPatchesPath);
 
-        mResourceManager = std::make_shared<ResourceManager>();
+        mResourceManager = std::make_unique<ResourceManager>();
         GetResourceManager()->Init(paths, validHashes, reservedThreadCount);
     } else {
-        mResourceManager = std::make_shared<ResourceManager>();
+        mResourceManager = std::make_unique<ResourceManager>();
         GetResourceManager()->Init(archivePaths, validHashes, reservedThreadCount);
     }
 

--- a/src/ship/Context.cpp
+++ b/src/ship/Context.cpp
@@ -62,7 +62,9 @@ Context::~Context() {
     mConfig = nullptr;
     mLogger->flush();
     mLogger = nullptr;
+#ifndef _DEBUG
     mLogThreadPool = nullptr;
+#endif
 }
 
 Context* Context::CreateInstance(const std::string& name, const std::string& shortName,

--- a/src/ship/audio/Audio.cpp
+++ b/src/ship/audio/Audio.cpp
@@ -42,7 +42,7 @@ void Audio::InitAudioPlayer() {
 }
 
 void Audio::Init() {
-    mConfig = Context::GetInstance()->GetConfig();
+    mConfig = Context::GetRawInstance()->GetConfig();
 
     mAvailableAudioBackends = std::make_shared<std::vector<AudioBackend>>();
 #ifdef _WIN32

--- a/src/ship/config/ConsoleVariable.cpp
+++ b/src/ship/config/ConsoleVariable.cpp
@@ -172,7 +172,7 @@ void ConsoleVariable::RegisterColor24(const char* name, Color_RGB8 defaultValue)
 }
 
 void ConsoleVariable::ClearVariable(const char* name) {
-    std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();
+    std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     auto var = Get(name);
     if (var != nullptr) {
         bool color = var->Type == ConsoleVariableType::Color || var->Type == ConsoleVariableType::Color24;
@@ -202,7 +202,7 @@ void ConsoleVariable::ClearVariable(const char* name) {
 }
 
 void ConsoleVariable::ClearBlock(const char* name) {
-    std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();
+    std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     conf->EraseBlock(StringHelper::Sprintf("CVars.%s", name));
     Load();
 }
@@ -241,7 +241,7 @@ void ConsoleVariable::CopyVariable(const char* from, const char* to) {
 }
 
 void ConsoleVariable::Save() {
-    std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();
+    std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
 
     for (const auto& variable : mVariables) {
         const std::string key = StringHelper::Sprintf("CVars.%s", variable.first.c_str());
@@ -277,7 +277,7 @@ void ConsoleVariable::Save() {
 }
 
 void ConsoleVariable::Load() {
-    std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();
+    std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     conf->Reload();
     if (!mVariables.empty()) {
         mVariables.clear();

--- a/src/ship/controller/controldeck/ControlDeck.cpp
+++ b/src/ship/controller/controldeck/ControlDeck.cpp
@@ -73,8 +73,8 @@ bool ControlDeck::AllGameInputBlocked() {
 bool ControlDeck::GamepadGameInputBlocked() {
     // block controller input when using the controller to navigate imgui menus
     return AllGameInputBlocked() ||
-           Context::GetInstance()->GetWindow()->GetGui()->GetMenuOrMenubarVisible() &&
-               Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0);
+           Context::GetRawInstance()->GetWindow()->GetGui()->GetMenuOrMenubarVisible() &&
+               Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0);
 }
 
 bool ControlDeck::KeyboardGameInputBlocked() {
@@ -82,7 +82,7 @@ bool ControlDeck::KeyboardGameInputBlocked() {
     ImGuiWindow* activeIDWindow = ImGui::GetCurrentContext()->ActiveIdWindow;
     return AllGameInputBlocked() ||
            (activeIDWindow != NULL &&
-            activeIDWindow->ID != Context::GetInstance()->GetWindow()->GetGui()->GetMainGameWindowID()) ||
+            activeIDWindow->ID != Context::GetRawInstance()->GetWindow()->GetGui()->GetMainGameWindowID()) ||
            ImGui::GetTopMostPopupModal() != NULL; // ImGui::GetIO().WantCaptureKeyboard, but ActiveId check altered
 }
 
@@ -93,7 +93,7 @@ bool ControlDeck::MouseGameInputBlocked() {
         return true;
     }
     return AllGameInputBlocked() ||
-           (window->ID != Context::GetInstance()->GetWindow()->GetGui()->GetMainGameWindowID());
+           (window->ID != Context::GetRawInstance()->GetWindow()->GetGui()->GetMainGameWindowID());
 }
 
 std::shared_ptr<Controller> ControlDeck::GetControllerByPort(uint8_t port) {

--- a/src/ship/controller/controldevice/controller/Controller.cpp
+++ b/src/ship/controller/controldevice/controller/Controller.cpp
@@ -67,7 +67,7 @@ uint8_t Controller::GetPortIndex() {
 bool Controller::HasConfig() {
     const std::string hasConfigCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.HasConfig", mPortIndex + 1);
-    return Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(hasConfigCvarKey.c_str(), false);
+    return Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(hasConfigCvarKey.c_str(), false);
 }
 
 void Controller::ClearAllMappings() {
@@ -107,8 +107,8 @@ void Controller::AddDefaultMappings(PhysicalDeviceType physicalDeviceType) {
 
     const std::string hasConfigCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.HasConfig", mPortIndex + 1);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(hasConfigCvarKey.c_str(), true);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(hasConfigCvarKey.c_str(), true);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void Controller::ReloadAllMappingsFromConfig() {

--- a/src/ship/controller/controldevice/controller/ControllerButton.cpp
+++ b/src/ship/controller/controldevice/controller/ControllerButton.cpp
@@ -24,7 +24,7 @@ ControllerButton::~ControllerButton() {
 }
 
 std::string ControllerButton::GetConfigNameFromBitmask(CONTROLLERBUTTONS_T bitmask) {
-    return Ship::Context::GetInstance()->GetControlDeck()->GetButtonNameForBitmask(bitmask);
+    return Ship::Context::GetRawInstance()->GetControlDeck()->GetButtonNameForBitmask(bitmask);
 }
 
 std::unordered_map<std::string, std::shared_ptr<ControllerButtonMapping>> ControllerButton::GetAllButtonMappings() {
@@ -80,13 +80,13 @@ void ControllerButton::SaveButtonMappingIdsToConfig() {
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.Buttons.%sButtonMappingIds", mPortIndex + 1,
                               GetConfigNameFromBitmask(mBitmask).c_str());
     if (buttonMappingIdListString == "") {
-        Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(buttonMappingIdsCvarKey.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(buttonMappingIdsCvarKey.c_str());
     } else {
-        Ship::Context::GetInstance()->GetConsoleVariables()->SetString(buttonMappingIdsCvarKey.c_str(),
-                                                                       buttonMappingIdListString.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(buttonMappingIdsCvarKey.c_str(),
+                                                                          buttonMappingIdListString.c_str());
     }
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void ControllerButton::ReloadAllMappingsFromConfig() {
@@ -101,7 +101,7 @@ void ControllerButton::ReloadAllMappingsFromConfig() {
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.Buttons.%sButtonMappingIds", mPortIndex + 1,
                               GetConfigNameFromBitmask(mBitmask).c_str());
     std::stringstream buttonMappingIdsStringStream(
-        Ship::Context::GetInstance()->GetConsoleVariables()->GetString(buttonMappingIdsCvarKey.c_str(), ""));
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->GetString(buttonMappingIdsCvarKey.c_str(), ""));
     std::string buttonMappingIdString;
     while (getline(buttonMappingIdsStringStream, buttonMappingIdString, ',')) {
         LoadButtonMappingFromConfig(buttonMappingIdString);
@@ -154,8 +154,8 @@ bool ControllerButton::AddOrEditButtonMappingFromRawPress(CONTROLLERBUTTONS_T bi
         mapping = std::make_shared<KeyboardKeyToButtonMapping>(mPortIndex, bitmask, mKeyboardScancodeForNewMapping);
     }
 
-    else if (!Context::GetInstance()->GetWindow()->GetGui()->IsMouseOverAnyGuiItem() &&
-             Context::GetInstance()->GetWindow()->GetGui()->IsMouseOverActivePopup()) {
+    else if (!Context::GetRawInstance()->GetWindow()->GetGui()->IsMouseOverAnyGuiItem() &&
+             Context::GetRawInstance()->GetWindow()->GetGui()->IsMouseOverActivePopup()) {
         if (mMouseButtonForNewMapping != LUS_MOUSE_BTN_UNKNOWN) {
             mapping = std::make_shared<MouseButtonToButtonMapping>(mPortIndex, bitmask, mMouseButtonForNewMapping);
         } else {
@@ -184,8 +184,8 @@ bool ControllerButton::AddOrEditButtonMappingFromRawPress(CONTROLLERBUTTONS_T bi
     SaveButtonMappingIdsToConfig();
     const std::string hasConfigCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.HasConfig", mPortIndex + 1);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(hasConfigCvarKey.c_str(), true);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(hasConfigCvarKey.c_str(), true);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
     return true;
 }
 

--- a/src/ship/controller/controldevice/controller/ControllerGyro.cpp
+++ b/src/ship/controller/controldevice/controller/ControllerGyro.cpp
@@ -34,8 +34,8 @@ bool ControllerGyro::SetGyroMappingFromRawPress() {
     SaveGyroMappingIdToConfig();
     const std::string hasConfigCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.HasConfig", mPortIndex + 1);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(hasConfigCvarKey.c_str(), true);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(hasConfigCvarKey.c_str(), true);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
     return true;
 }
 
@@ -52,13 +52,13 @@ void ControllerGyro::SaveGyroMappingIdToConfig() {
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.Gyro.GyroMappingId", mPortIndex + 1);
 
     if (mGyroMapping == nullptr) {
-        Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(gyroMappingIdCvarKey.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(gyroMappingIdCvarKey.c_str());
     } else {
-        Ship::Context::GetInstance()->GetConsoleVariables()->SetString(gyroMappingIdCvarKey.c_str(),
-                                                                       mGyroMapping->GetGyroMappingId().c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(gyroMappingIdCvarKey.c_str(),
+                                                                          mGyroMapping->GetGyroMappingId().c_str());
     }
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void ControllerGyro::ClearGyroMapping() {
@@ -75,7 +75,8 @@ void ControllerGyro::ReloadGyroMappingFromConfig() {
     const std::string gyroMappingIdCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.Gyro.GyroMappingId", mPortIndex + 1);
 
-    std::string id = Ship::Context::GetInstance()->GetConsoleVariables()->GetString(gyroMappingIdCvarKey.c_str(), "");
+    std::string id =
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->GetString(gyroMappingIdCvarKey.c_str(), "");
     if (id == "") {
         mGyroMapping = nullptr;
         return;

--- a/src/ship/controller/controldevice/controller/ControllerLED.cpp
+++ b/src/ship/controller/controldevice/controller/ControllerLED.cpp
@@ -32,13 +32,13 @@ void ControllerLED::SaveLEDMappingIdsToConfig() {
     const std::string ledMappingIdsCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.LEDMappingIds", mPortIndex + 1);
     if (ledMappingIdsCvarKey == "") {
-        Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(ledMappingIdsCvarKey.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(ledMappingIdsCvarKey.c_str());
     } else {
-        Ship::Context::GetInstance()->GetConsoleVariables()->SetString(ledMappingIdsCvarKey.c_str(),
-                                                                       ledMappingIdListString.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(ledMappingIdsCvarKey.c_str(),
+                                                                          ledMappingIdListString.c_str());
     }
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void ControllerLED::AddLEDMapping(std::shared_ptr<ControllerLEDMapping> mapping) {
@@ -103,7 +103,7 @@ void ControllerLED::ReloadAllMappingsFromConfig() {
     const std::string ledMappingIdsCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.LEDMappingIds", mPortIndex + 1);
     std::stringstream ledMappingIdsStringStream(
-        Ship::Context::GetInstance()->GetConsoleVariables()->GetString(ledMappingIdsCvarKey.c_str(), ""));
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->GetString(ledMappingIdsCvarKey.c_str(), ""));
     std::string ledMappingIdString;
     while (getline(ledMappingIdsStringStream, ledMappingIdString, ',')) {
         LoadLEDMappingFromConfig(ledMappingIdString);
@@ -128,8 +128,8 @@ bool ControllerLED::AddLEDMappingFromRawPress() {
     SaveLEDMappingIdsToConfig();
     const std::string hasConfigCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.HasConfig", mPortIndex + 1);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(hasConfigCvarKey.c_str(), true);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(hasConfigCvarKey.c_str(), true);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
     return true;
 }
 

--- a/src/ship/controller/controldevice/controller/ControllerRumble.cpp
+++ b/src/ship/controller/controldevice/controller/ControllerRumble.cpp
@@ -37,13 +37,13 @@ void ControllerRumble::SaveRumbleMappingIdsToConfig() {
     const std::string rumbleMappingIdsCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.RumbleMappingIds", mPortIndex + 1);
     if (rumbleMappingIdListString == "") {
-        Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(rumbleMappingIdsCvarKey.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(rumbleMappingIdsCvarKey.c_str());
     } else {
-        Ship::Context::GetInstance()->GetConsoleVariables()->SetString(rumbleMappingIdsCvarKey.c_str(),
-                                                                       rumbleMappingIdListString.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(rumbleMappingIdsCvarKey.c_str(),
+                                                                          rumbleMappingIdListString.c_str());
     }
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void ControllerRumble::AddRumbleMapping(std::shared_ptr<ControllerRumbleMapping> mapping) {
@@ -119,7 +119,7 @@ void ControllerRumble::ReloadAllMappingsFromConfig() {
     const std::string rumbleMappingIdsCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.RumbleMappingIds", mPortIndex + 1);
     std::stringstream rumbleMappingIdsStringStream(
-        Ship::Context::GetInstance()->GetConsoleVariables()->GetString(rumbleMappingIdsCvarKey.c_str(), ""));
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->GetString(rumbleMappingIdsCvarKey.c_str(), ""));
     std::string rumbleMappingIdString;
     while (getline(rumbleMappingIdsStringStream, rumbleMappingIdString, ',')) {
         LoadRumbleMappingFromConfig(rumbleMappingIdString);
@@ -144,8 +144,8 @@ bool ControllerRumble::AddRumbleMappingFromRawPress() {
     SaveRumbleMappingIdsToConfig();
     const std::string hasConfigCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.HasConfig", mPortIndex + 1);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(hasConfigCvarKey.c_str(), true);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(hasConfigCvarKey.c_str(), true);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
     return true;
 }
 

--- a/src/ship/controller/controldevice/controller/ControllerStick.cpp
+++ b/src/ship/controller/controldevice/controller/ControllerStick.cpp
@@ -95,14 +95,15 @@ void ControllerStick::SaveAxisDirectionMappingIdsToConfig() {
             CVAR_PREFIX_CONTROLLERS ".Port%d.%s.%sAxisDirectionMappingIds", mPortIndex + 1,
             stickIndexToConfigStickIndexName[mStickIndex].c_str(), directionToConfigDirectionName[direction].c_str());
         if (axisDirectionMappingIdListString == "") {
-            Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(axisDirectionMappingIdsCvarKey.c_str());
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
+                axisDirectionMappingIdsCvarKey.c_str());
         } else {
-            Ship::Context::GetInstance()->GetConsoleVariables()->SetString(axisDirectionMappingIdsCvarKey.c_str(),
-                                                                           axisDirectionMappingIdListString.c_str());
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(axisDirectionMappingIdsCvarKey.c_str(),
+                                                                              axisDirectionMappingIdListString.c_str());
         }
     }
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void ControllerStick::ClearAxisDirectionMappingId(Direction direction, std::string id) {
@@ -173,26 +174,27 @@ void ControllerStick::ReloadAllMappingsFromConfig() {
             stickIndexToConfigStickIndexName[mStickIndex].c_str(), directionToConfigDirectionName[direction].c_str());
 
         std::stringstream axisDirectionMappingIdsStringStream(
-            Ship::Context::GetInstance()->GetConsoleVariables()->GetString(axisDirectionMappingIdsCvarKey.c_str(), ""));
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->GetString(axisDirectionMappingIdsCvarKey.c_str(),
+                                                                              ""));
         std::string axisDirectionMappingIdString;
         while (getline(axisDirectionMappingIdsStringStream, axisDirectionMappingIdString, ',')) {
             LoadAxisDirectionMappingFromConfig(axisDirectionMappingIdString);
         }
     }
 
-    SetSensitivity(Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    SetSensitivity(Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.%s.SensitivityPercentage", mPortIndex + 1,
                               stickIndexToConfigStickIndexName[mStickIndex].c_str())
             .c_str(),
         DEFAULT_STICK_SENSITIVITY_PERCENTAGE));
 
-    SetDeadzone(Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    SetDeadzone(Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.%s.DeadzonePercentage", mPortIndex + 1,
                               stickIndexToConfigStickIndexName[mStickIndex].c_str())
             .c_str(),
         DEFAULT_STICK_DEADZONE_PERCENTAGE));
 
-    SetNotchSnapAngle(Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    SetNotchSnapAngle(Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.%s.NotchSnapAngle", mPortIndex + 1,
                               stickIndexToConfigStickIndexName[mStickIndex].c_str())
             .c_str(),
@@ -279,8 +281,8 @@ bool ControllerStick::AddOrEditAxisDirectionMappingFromRawPress(Direction direct
     if (mKeyboardScancodeForNewMapping != LUS_KB_UNKNOWN) {
         mapping = std::make_shared<KeyboardKeyToAxisDirectionMapping>(mPortIndex, mStickIndex, direction,
                                                                       mKeyboardScancodeForNewMapping);
-    } else if (!Context::GetInstance()->GetWindow()->GetGui()->IsMouseOverAnyGuiItem() &&
-               Context::GetInstance()->GetWindow()->GetGui()->IsMouseOverActivePopup()) {
+    } else if (!Context::GetRawInstance()->GetWindow()->GetGui()->IsMouseOverAnyGuiItem() &&
+               Context::GetRawInstance()->GetWindow()->GetGui()->IsMouseOverActivePopup()) {
         if (mMouseButtonForNewMapping != LUS_MOUSE_BTN_UNKNOWN) {
             mapping = std::make_shared<MouseButtonToAxisDirectionMapping>(mPortIndex, mStickIndex, direction,
                                                                           mMouseButtonForNewMapping);
@@ -311,8 +313,8 @@ bool ControllerStick::AddOrEditAxisDirectionMappingFromRawPress(Direction direct
     SaveAxisDirectionMappingIdsToConfig();
     const std::string hasConfigCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.HasConfig", mPortIndex + 1);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(hasConfigCvarKey.c_str(), true);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(hasConfigCvarKey.c_str(), true);
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
     return true;
 }
 
@@ -387,12 +389,12 @@ bool ControllerStick::ProcessMouseButtonEvent(bool isPressed, MouseBtn button) {
 void ControllerStick::SetSensitivity(uint8_t sensitivityPercentage) {
     mSensitivityPercentage = sensitivityPercentage;
     mSensitivity = sensitivityPercentage / 100.0f;
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.%s.SensitivityPercentage", mPortIndex + 1,
                               stickIndexToConfigStickIndexName[mStickIndex].c_str())
             .c_str(),
         mSensitivityPercentage);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void ControllerStick::ResetSensitivityToDefault() {
@@ -410,12 +412,12 @@ bool ControllerStick::SensitivityIsDefault() {
 void ControllerStick::SetDeadzone(uint8_t deadzonePercentage) {
     mDeadzonePercentage = deadzonePercentage;
     mDeadzone = MAX_AXIS_RANGE * (deadzonePercentage / 100.0f);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.%s.DeadzonePercentage", mPortIndex + 1,
                               stickIndexToConfigStickIndexName[mStickIndex].c_str())
             .c_str(),
         mDeadzonePercentage);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void ControllerStick::ResetDeadzoneToDefault() {
@@ -432,12 +434,12 @@ bool ControllerStick::DeadzoneIsDefault() {
 
 void ControllerStick::SetNotchSnapAngle(uint8_t notchSnapAngle) {
     mNotchSnapAngle = notchSnapAngle;
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.%s.NotchSnapAngle", mPortIndex + 1,
                               stickIndexToConfigStickIndexName[mStickIndex].c_str())
             .c_str(),
         mNotchSnapAngle);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void ControllerStick::ResetNotchSnapAngleToDefault() {

--- a/src/ship/controller/controldevice/controller/mapping/factories/AxisDirectionMappingFactory.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/factories/AxisDirectionMappingFactory.cpp
@@ -20,22 +20,22 @@ std::shared_ptr<ControllerAxisDirectionMapping>
 AxisDirectionMappingFactory::CreateAxisDirectionMappingFromConfig(uint8_t portIndex, StickIndex stickIndex,
                                                                   std::string id) {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + id;
-    const std::string mappingClass = Ship::Context::GetInstance()->GetConsoleVariables()->GetString(
+    const std::string mappingClass = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetString(
         StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str(), "");
 
     if (mappingClass == "SDLAxisDirectionToAxisDirectionMapping") {
-        int32_t direction = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t direction = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), -1);
-        int32_t sdlControllerAxis = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t sdlControllerAxis = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.SDLControllerAxis", mappingCvarKey.c_str()).c_str(), -1);
-        int32_t axisDirection = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t axisDirection = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.AxisDirection", mappingCvarKey.c_str()).c_str(), 0);
 
         if ((direction != LEFT && direction != RIGHT && direction != UP && direction != DOWN) ||
             sdlControllerAxis == -1 || (axisDirection != NEGATIVE && axisDirection != POSITIVE)) {
             // something about this mapping is invalid
-            Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
-            Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
             return nullptr;
         }
 
@@ -44,16 +44,16 @@ AxisDirectionMappingFactory::CreateAxisDirectionMappingFromConfig(uint8_t portIn
     }
 
     if (mappingClass == "SDLButtonToAxisDirectionMapping") {
-        int32_t direction = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t direction = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), -1);
-        int32_t sdlControllerButton = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t sdlControllerButton = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.SDLControllerButton", mappingCvarKey.c_str()).c_str(), -1);
 
         if ((direction != LEFT && direction != RIGHT && direction != UP && direction != DOWN) ||
             sdlControllerButton == -1) {
             // something about this mapping is invalid
-            Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
-            Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
             return nullptr;
         }
 
@@ -62,15 +62,15 @@ AxisDirectionMappingFactory::CreateAxisDirectionMappingFromConfig(uint8_t portIn
     }
 
     if (mappingClass == "KeyboardKeyToAxisDirectionMapping") {
-        int32_t direction = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t direction = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), -1);
-        int32_t scancode = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t scancode = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.KeyboardScancode", mappingCvarKey.c_str()).c_str(), 0);
 
         if (direction != LEFT && direction != RIGHT && direction != UP && direction != DOWN) {
             // something about this mapping is invalid
-            Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
-            Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
             return nullptr;
         }
 
@@ -79,15 +79,15 @@ AxisDirectionMappingFactory::CreateAxisDirectionMappingFromConfig(uint8_t portIn
     }
 
     if (mappingClass == "MouseButtonToAxisDirectionMapping") {
-        int32_t direction = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t direction = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), -1);
-        int mouseButton = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int mouseButton = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.MouseButton", mappingCvarKey.c_str()).c_str(), 0);
 
         if (direction != LEFT && direction != RIGHT && direction != UP && direction != DOWN) {
             // something about this mapping is invalid
-            Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
-            Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
             return nullptr;
         }
 
@@ -96,15 +96,15 @@ AxisDirectionMappingFactory::CreateAxisDirectionMappingFromConfig(uint8_t portIn
     }
 
     if (mappingClass == "MouseWheelToAxisDirectionMapping") {
-        int32_t direction = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t direction = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), -1);
-        int wheelDirection = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int wheelDirection = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.WheelDirection", mappingCvarKey.c_str()).c_str(), 0);
 
         if (direction != LEFT && direction != RIGHT && direction != UP && direction != DOWN) {
             // something about this mapping is invalid
-            Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
-            Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
             return nullptr;
         }
 
@@ -119,7 +119,7 @@ std::vector<std::shared_ptr<ControllerAxisDirectionMapping>>
 AxisDirectionMappingFactory::CreateDefaultKeyboardAxisDirectionMappings(uint8_t portIndex, StickIndex stickIndex) {
     std::vector<std::shared_ptr<ControllerAxisDirectionMapping>> mappings;
 
-    auto defaultsForStick = Context::GetInstance()
+    auto defaultsForStick = Context::GetRawInstance()
                                 ->GetControlDeck()
                                 ->GetControllerDefaultMappings()
                                 ->GetDefaultKeyboardKeyToAxisDirectionMappings()[stickIndex];
@@ -136,7 +136,7 @@ std::vector<std::shared_ptr<ControllerAxisDirectionMapping>>
 AxisDirectionMappingFactory::CreateDefaultSDLAxisDirectionMappings(uint8_t portIndex, StickIndex stickIndex) {
     std::vector<std::shared_ptr<ControllerAxisDirectionMapping>> mappings;
 
-    auto defaultButtonsForStick = Context::GetInstance()
+    auto defaultButtonsForStick = Context::GetRawInstance()
                                       ->GetControlDeck()
                                       ->GetControllerDefaultMappings()
                                       ->GetDefaultSDLButtonToAxisDirectionMappings()[stickIndex];
@@ -146,7 +146,7 @@ AxisDirectionMappingFactory::CreateDefaultSDLAxisDirectionMappings(uint8_t portI
             std::make_shared<SDLButtonToAxisDirectionMapping>(portIndex, stickIndex, direction, sdlGamepadButton));
     }
 
-    auto defaultAxisDirectionsForStick = Context::GetInstance()
+    auto defaultAxisDirectionsForStick = Context::GetRawInstance()
                                              ->GetControlDeck()
                                              ->GetControllerDefaultMappings()
                                              ->GetDefaultSDLAxisDirectionToAxisDirectionMappings()[stickIndex];
@@ -165,9 +165,10 @@ AxisDirectionMappingFactory::CreateAxisDirectionMappingFromSDLInput(uint8_t port
                                                                     Direction direction) {
     std::shared_ptr<ControllerAxisDirectionMapping> mapping = nullptr;
 
-    for (auto [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             portIndex)) {
+    for (auto [instanceId, gamepad] : Context::GetRawInstance()
+                                          ->GetControlDeck()
+                                          ->GetConnectedPhysicalDeviceManager()
+                                          ->GetConnectedSDLGamepadsForPort(portIndex)) {
         for (int32_t button = SDL_CONTROLLER_BUTTON_A; button < SDL_CONTROLLER_BUTTON_MAX; button++) {
             if (SDL_GameControllerGetButton(gamepad, static_cast<SDL_GameControllerButton>(button))) {
                 mapping = std::make_shared<SDLButtonToAxisDirectionMapping>(portIndex, stickIndex, direction, button);

--- a/src/ship/controller/controldevice/controller/mapping/factories/ButtonMappingFactory.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/factories/ButtonMappingFactory.cpp
@@ -15,25 +15,25 @@ namespace Ship {
 std::shared_ptr<ControllerButtonMapping> ButtonMappingFactory::CreateButtonMappingFromConfig(uint8_t portIndex,
                                                                                              std::string id) {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".ButtonMappings." + id;
-    const std::string mappingClass = Ship::Context::GetInstance()->GetConsoleVariables()->GetString(
+    const std::string mappingClass = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetString(
         StringHelper::Sprintf("%s.ButtonMappingClass", mappingCvarKey.c_str()).c_str(), "");
-    CONTROLLERBUTTONS_T bitmask = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    CONTROLLERBUTTONS_T bitmask = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
         StringHelper::Sprintf("%s.Bitmask", mappingCvarKey.c_str()).c_str(), 0);
     if (!bitmask) {
         // all button mappings need bitmasks
-        Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
-        Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
         return nullptr;
     }
 
     if (mappingClass == "SDLButtonToButtonMapping") {
-        int32_t sdlControllerButton = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t sdlControllerButton = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.SDLControllerButton", mappingCvarKey.c_str()).c_str(), -1);
 
         if (sdlControllerButton == -1) {
             // something about this mapping is invalid
-            Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
-            Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
             return nullptr;
         }
 
@@ -41,15 +41,15 @@ std::shared_ptr<ControllerButtonMapping> ButtonMappingFactory::CreateButtonMappi
     }
 
     if (mappingClass == "SDLAxisDirectionToButtonMapping") {
-        int32_t sdlControllerAxis = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t sdlControllerAxis = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.SDLControllerAxis", mappingCvarKey.c_str()).c_str(), -1);
-        int32_t axisDirection = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t axisDirection = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.AxisDirection", mappingCvarKey.c_str()).c_str(), 0);
 
         if (sdlControllerAxis == -1 || (axisDirection != -1 && axisDirection != 1)) {
             // something about this mapping is invalid
-            Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
-            Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
+            Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
             return nullptr;
         }
 
@@ -57,21 +57,21 @@ std::shared_ptr<ControllerButtonMapping> ButtonMappingFactory::CreateButtonMappi
     }
 
     if (mappingClass == "KeyboardKeyToButtonMapping") {
-        int32_t scancode = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int32_t scancode = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.KeyboardScancode", mappingCvarKey.c_str()).c_str(), 0);
 
         return std::make_shared<KeyboardKeyToButtonMapping>(portIndex, bitmask, static_cast<KbScancode>(scancode));
     }
 
     if (mappingClass == "MouseButtonToButtonMapping") {
-        int mouseButton = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int mouseButton = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.MouseButton", mappingCvarKey.c_str()).c_str(), 0);
 
         return std::make_shared<MouseButtonToButtonMapping>(portIndex, bitmask, static_cast<MouseBtn>(mouseButton));
     }
 
     if (mappingClass == "MouseWheelToButtonMapping") {
-        int wheelDirection = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+        int wheelDirection = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
             StringHelper::Sprintf("%s.WheelDirection", mappingCvarKey.c_str()).c_str(), 0);
 
         return std::make_shared<MouseWheelToButtonMapping>(portIndex, bitmask,
@@ -85,7 +85,7 @@ std::vector<std::shared_ptr<ControllerButtonMapping>>
 ButtonMappingFactory::CreateDefaultKeyboardButtonMappings(uint8_t portIndex, CONTROLLERBUTTONS_T bitmask) {
     std::vector<std::shared_ptr<ControllerButtonMapping>> mappings;
 
-    auto defaultsForBitmask = Context::GetInstance()
+    auto defaultsForBitmask = Context::GetRawInstance()
                                   ->GetControlDeck()
                                   ->GetControllerDefaultMappings()
                                   ->GetDefaultKeyboardKeyToButtonMappings()[bitmask];
@@ -101,7 +101,7 @@ std::vector<std::shared_ptr<ControllerButtonMapping>>
 ButtonMappingFactory::CreateDefaultSDLButtonMappings(uint8_t portIndex, CONTROLLERBUTTONS_T bitmask) {
     std::vector<std::shared_ptr<ControllerButtonMapping>> mappings;
 
-    auto defaultButtonsForBitmask = Context::GetInstance()
+    auto defaultButtonsForBitmask = Context::GetRawInstance()
                                         ->GetControlDeck()
                                         ->GetControllerDefaultMappings()
                                         ->GetDefaultSDLButtonToButtonMappings()[bitmask];
@@ -110,7 +110,7 @@ ButtonMappingFactory::CreateDefaultSDLButtonMappings(uint8_t portIndex, CONTROLL
         mappings.push_back(std::make_shared<SDLButtonToButtonMapping>(portIndex, bitmask, sdlGamepadButton));
     }
 
-    auto defaultAxisDirectionsForBitmask = Context::GetInstance()
+    auto defaultAxisDirectionsForBitmask = Context::GetRawInstance()
                                                ->GetControlDeck()
                                                ->GetControllerDefaultMappings()
                                                ->GetDefaultSDLAxisDirectionToButtonMappings()[bitmask];
@@ -127,9 +127,10 @@ std::shared_ptr<ControllerButtonMapping>
 ButtonMappingFactory::CreateButtonMappingFromSDLInput(uint8_t portIndex, CONTROLLERBUTTONS_T bitmask) {
     std::shared_ptr<ControllerButtonMapping> mapping = nullptr;
 
-    for (auto [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             portIndex)) {
+    for (auto [instanceId, gamepad] : Context::GetRawInstance()
+                                          ->GetControlDeck()
+                                          ->GetConnectedPhysicalDeviceManager()
+                                          ->GetConnectedSDLGamepadsForPort(portIndex)) {
         for (int32_t button = SDL_CONTROLLER_BUTTON_A; button < SDL_CONTROLLER_BUTTON_MAX; button++) {
             if (SDL_GameControllerGetButton(gamepad, static_cast<SDL_GameControllerButton>(button))) {
                 mapping = std::make_shared<SDLButtonToButtonMapping>(portIndex, bitmask, button);

--- a/src/ship/controller/controldevice/controller/mapping/factories/GyroMappingFactory.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/factories/GyroMappingFactory.cpp
@@ -9,24 +9,24 @@ namespace Ship {
 std::shared_ptr<ControllerGyroMapping> GyroMappingFactory::CreateGyroMappingFromConfig(uint8_t portIndex,
                                                                                        std::string id) {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".GyroMappings." + id;
-    const std::string mappingClass = Ship::Context::GetInstance()->GetConsoleVariables()->GetString(
+    const std::string mappingClass = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetString(
         StringHelper::Sprintf("%s.GyroMappingClass", mappingCvarKey.c_str()).c_str(), "");
 
-    float sensitivity = Ship::Context::GetInstance()->GetConsoleVariables()->GetFloat(
+    float sensitivity = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetFloat(
         StringHelper::Sprintf("%s.Sensitivity", mappingCvarKey.c_str()).c_str(), 2.0f);
     if (sensitivity < 0.0f || sensitivity > 1.0f) {
         // something about this mapping is invalid
-        Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
-        Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
         return nullptr;
     }
 
     if (mappingClass == "SDLGyroMapping") {
-        float neutralPitch = Ship::Context::GetInstance()->GetConsoleVariables()->GetFloat(
+        float neutralPitch = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetFloat(
             StringHelper::Sprintf("%s.NeutralPitch", mappingCvarKey.c_str()).c_str(), 0.0f);
-        float neutralYaw = Ship::Context::GetInstance()->GetConsoleVariables()->GetFloat(
+        float neutralYaw = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetFloat(
             StringHelper::Sprintf("%s.NeutralYaw", mappingCvarKey.c_str()).c_str(), 0.0f);
-        float neutralRoll = Ship::Context::GetInstance()->GetConsoleVariables()->GetFloat(
+        float neutralRoll = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetFloat(
             StringHelper::Sprintf("%s.NeutralRoll", mappingCvarKey.c_str()).c_str(), 0.0f);
 
         return std::make_shared<SDLGyroMapping>(portIndex, sensitivity, neutralPitch, neutralYaw, neutralRoll);
@@ -38,9 +38,10 @@ std::shared_ptr<ControllerGyroMapping> GyroMappingFactory::CreateGyroMappingFrom
 std::shared_ptr<ControllerGyroMapping> GyroMappingFactory::CreateGyroMappingFromSDLInput(uint8_t portIndex) {
     std::shared_ptr<ControllerGyroMapping> mapping = nullptr;
 
-    for (auto [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             portIndex)) {
+    for (auto [instanceId, gamepad] : Context::GetRawInstance()
+                                          ->GetControlDeck()
+                                          ->GetConnectedPhysicalDeviceManager()
+                                          ->GetConnectedSDLGamepadsForPort(portIndex)) {
         if (!SDL_GameControllerHasSensor(gamepad, SDL_SENSOR_GYRO)) {
             continue;
         }

--- a/src/ship/controller/controldevice/controller/mapping/factories/LEDMappingFactory.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/factories/LEDMappingFactory.cpp
@@ -8,19 +8,19 @@
 namespace Ship {
 std::shared_ptr<ControllerLEDMapping> LEDMappingFactory::CreateLEDMappingFromConfig(uint8_t portIndex, std::string id) {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".LEDMappings." + id;
-    const std::string mappingClass = Ship::Context::GetInstance()->GetConsoleVariables()->GetString(
+    const std::string mappingClass = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetString(
         StringHelper::Sprintf("%s.LEDMappingClass", mappingCvarKey.c_str()).c_str(), "");
 
-    int32_t colorSource = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    int32_t colorSource = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
         StringHelper::Sprintf("%s.ColorSource", mappingCvarKey.c_str()).c_str(), -1);
-    Color_RGB8 savedColor = Ship::Context::GetInstance()->GetConsoleVariables()->GetColor24(
+    Color_RGB8 savedColor = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetColor24(
         StringHelper::Sprintf("%s.SavedColor", mappingCvarKey.c_str()).c_str(), { 0, 0, 0 });
 
     if (colorSource != LED_COLOR_SOURCE_OFF && colorSource != LED_COLOR_SOURCE_SET &&
         colorSource != LED_COLOR_SOURCE_GAME) {
         // something about this mapping is invalid
-        Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
-        Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
         return nullptr;
     }
 
@@ -34,9 +34,10 @@ std::shared_ptr<ControllerLEDMapping> LEDMappingFactory::CreateLEDMappingFromCon
 std::shared_ptr<ControllerLEDMapping> LEDMappingFactory::CreateLEDMappingFromSDLInput(uint8_t portIndex) {
     std::shared_ptr<ControllerLEDMapping> mapping = nullptr;
 
-    for (auto [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             portIndex)) {
+    for (auto [instanceId, gamepad] : Context::GetRawInstance()
+                                          ->GetControlDeck()
+                                          ->GetConnectedPhysicalDeviceManager()
+                                          ->GetConnectedSDLGamepadsForPort(portIndex)) {
         if (!SDL_GameControllerHasLED(gamepad)) {
             continue;
         }

--- a/src/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.cpp
@@ -9,19 +9,19 @@ namespace Ship {
 std::shared_ptr<ControllerRumbleMapping> RumbleMappingFactory::CreateRumbleMappingFromConfig(uint8_t portIndex,
                                                                                              std::string id) {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".RumbleMappings." + id;
-    const std::string mappingClass = Ship::Context::GetInstance()->GetConsoleVariables()->GetString(
+    const std::string mappingClass = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetString(
         StringHelper::Sprintf("%s.RumbleMappingClass", mappingCvarKey.c_str()).c_str(), "");
 
-    int32_t lowFrequencyIntensityPercentage = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    int32_t lowFrequencyIntensityPercentage = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
         StringHelper::Sprintf("%s.LowFrequencyIntensity", mappingCvarKey.c_str()).c_str(), -1);
-    int32_t highFrequencyIntensityPercentage = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    int32_t highFrequencyIntensityPercentage = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
         StringHelper::Sprintf("%s.HighFrequencyIntensity", mappingCvarKey.c_str()).c_str(), -1);
 
     if (lowFrequencyIntensityPercentage < 0 || lowFrequencyIntensityPercentage > 100 ||
         highFrequencyIntensityPercentage < 0 || highFrequencyIntensityPercentage > 100) {
         // something about this mapping is invalid
-        Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
-        Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mappingCvarKey.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
         return nullptr;
     }
 
@@ -44,9 +44,10 @@ RumbleMappingFactory::CreateDefaultSDLRumbleMappings(PhysicalDeviceType physical
 std::shared_ptr<ControllerRumbleMapping> RumbleMappingFactory::CreateRumbleMappingFromSDLInput(uint8_t portIndex) {
     std::shared_ptr<ControllerRumbleMapping> mapping = nullptr;
 
-    for (auto [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             portIndex)) {
+    for (auto [instanceId, gamepad] : Context::GetRawInstance()
+                                          ->GetControlDeck()
+                                          ->GetConnectedPhysicalDeviceManager()
+                                          ->GetConnectedSDLGamepadsForPort(portIndex)) {
         if (!SDL_GameControllerHasRumble(gamepad)) {
             continue;
         }

--- a/src/ship/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAnyMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAnyMapping.cpp
@@ -14,7 +14,7 @@ KeyboardKeyToAnyMapping::~KeyboardKeyToAnyMapping() {
 }
 
 std::string KeyboardKeyToAnyMapping::GetPhysicalInputName() {
-    return Context::GetInstance()->GetWindow()->GetKeyName(mKeyboardScancode);
+    return Context::GetRawInstance()->GetWindow()->GetKeyName(mKeyboardScancode);
 }
 
 bool KeyboardKeyToAnyMapping::ProcessKeyboardEvent(KbEventType eventType, KbScancode scancode) {

--- a/src/ship/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAxisDirectionMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToAxisDirectionMapping.cpp
@@ -14,7 +14,7 @@ KeyboardKeyToAxisDirectionMapping::KeyboardKeyToAxisDirectionMapping(uint8_t por
 }
 
 float KeyboardKeyToAxisDirectionMapping::GetNormalizedAxisDirectionValue() {
-    if (Context::GetInstance()->GetControlDeck()->KeyboardGameInputBlocked()) {
+    if (Context::GetRawInstance()->GetControlDeck()->KeyboardGameInputBlocked()) {
         return 0.0f;
     }
 
@@ -27,29 +27,29 @@ std::string KeyboardKeyToAxisDirectionMapping::GetAxisDirectionMappingId() {
 
 void KeyboardKeyToAxisDirectionMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str(),
         "KeyboardKeyToAxisDirectionMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str(), mStickIndex);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), mDirection);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.KeyboardScancode", mappingCvarKey.c_str()).c_str(), mKeyboardScancode);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void KeyboardKeyToAxisDirectionMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.KeyboardScancode", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 int8_t KeyboardKeyToAxisDirectionMapping::GetMappingType() {

--- a/src/ship/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToButtonMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/keyboard/KeyboardKeyToButtonMapping.cpp
@@ -13,7 +13,7 @@ KeyboardKeyToButtonMapping::KeyboardKeyToButtonMapping(uint8_t portIndex, CONTRO
 }
 
 void KeyboardKeyToButtonMapping::UpdatePad(CONTROLLERBUTTONS_T& padButtons) {
-    if (Context::GetInstance()->GetControlDeck()->KeyboardGameInputBlocked()) {
+    if (Context::GetRawInstance()->GetControlDeck()->KeyboardGameInputBlocked()) {
         return;
     }
 
@@ -34,26 +34,26 @@ std::string KeyboardKeyToButtonMapping::GetButtonMappingId() {
 
 void KeyboardKeyToButtonMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".ButtonMappings." + GetButtonMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.ButtonMappingClass", mappingCvarKey.c_str()).c_str(), "KeyboardKeyToButtonMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Bitmask", mappingCvarKey.c_str()).c_str(), mBitmask);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.KeyboardScancode", mappingCvarKey.c_str()).c_str(), mKeyboardScancode);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void KeyboardKeyToButtonMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".ButtonMappings." + GetButtonMappingId();
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.ButtonMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Bitmask", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.KeyboardScancode", mappingCvarKey.c_str()).c_str());
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 std::string KeyboardKeyToButtonMapping::GetPhysicalDeviceName() {

--- a/src/ship/controller/controldevice/controller/mapping/mouse/MouseButtonToAxisDirectionMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/mouse/MouseButtonToAxisDirectionMapping.cpp
@@ -14,7 +14,7 @@ MouseButtonToAxisDirectionMapping::MouseButtonToAxisDirectionMapping(uint8_t por
 }
 
 float MouseButtonToAxisDirectionMapping::GetNormalizedAxisDirectionValue() {
-    if (Context::GetInstance()->GetControlDeck()->MouseGameInputBlocked()) {
+    if (Context::GetRawInstance()->GetControlDeck()->MouseGameInputBlocked()) {
         return 0.0f;
     }
 
@@ -27,29 +27,29 @@ std::string MouseButtonToAxisDirectionMapping::GetAxisDirectionMappingId() {
 
 void MouseButtonToAxisDirectionMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str(),
         "MouseButtonToAxisDirectionMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str(), mStickIndex);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), mDirection);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.MouseButton", mappingCvarKey.c_str()).c_str(), static_cast<int>(mButton));
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void MouseButtonToAxisDirectionMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.MouseButton", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 int8_t MouseButtonToAxisDirectionMapping::GetMappingType() {

--- a/src/ship/controller/controldevice/controller/mapping/mouse/MouseButtonToButtonMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/mouse/MouseButtonToButtonMapping.cpp
@@ -12,7 +12,7 @@ MouseButtonToButtonMapping::MouseButtonToButtonMapping(uint8_t portIndex, CONTRO
 }
 
 void MouseButtonToButtonMapping::UpdatePad(CONTROLLERBUTTONS_T& padButtons) {
-    if (Context::GetInstance()->GetControlDeck()->MouseGameInputBlocked()) {
+    if (Context::GetRawInstance()->GetControlDeck()->MouseGameInputBlocked()) {
         return;
     }
 
@@ -33,26 +33,26 @@ std::string MouseButtonToButtonMapping::GetButtonMappingId() {
 
 void MouseButtonToButtonMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".ButtonMappings." + GetButtonMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.ButtonMappingClass", mappingCvarKey.c_str()).c_str(), "MouseButtonToButtonMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Bitmask", mappingCvarKey.c_str()).c_str(), mBitmask);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.MouseButton", mappingCvarKey.c_str()).c_str(), static_cast<int>(mButton));
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void MouseButtonToButtonMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".ButtonMappings." + GetButtonMappingId();
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.ButtonMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Bitmask", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.MouseButton", mappingCvarKey.c_str()).c_str());
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 std::string MouseButtonToButtonMapping::GetPhysicalDeviceName() {

--- a/src/ship/controller/controldevice/controller/mapping/mouse/MouseWheelToAxisDirectionMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/mouse/MouseWheelToAxisDirectionMapping.cpp
@@ -16,7 +16,7 @@ MouseWheelToAxisDirectionMapping::MouseWheelToAxisDirectionMapping(uint8_t portI
 }
 
 float MouseWheelToAxisDirectionMapping::GetNormalizedAxisDirectionValue() {
-    if (Context::GetInstance()->GetControlDeck()->MouseGameInputBlocked()) {
+    if (Context::GetRawInstance()->GetControlDeck()->MouseGameInputBlocked()) {
         return 0.0f;
     }
 
@@ -33,29 +33,29 @@ std::string MouseWheelToAxisDirectionMapping::GetAxisDirectionMappingId() {
 
 void MouseWheelToAxisDirectionMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str(),
         "MouseWheelToAxisDirectionMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str(), mStickIndex);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), mDirection);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.WheelDirection", mappingCvarKey.c_str()).c_str(), static_cast<int>(mWheelDirection));
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void MouseWheelToAxisDirectionMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.WheelDirection", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 int8_t MouseWheelToAxisDirectionMapping::GetMappingType() {

--- a/src/ship/controller/controldevice/controller/mapping/mouse/MouseWheelToButtonMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/mouse/MouseWheelToButtonMapping.cpp
@@ -14,7 +14,7 @@ MouseWheelToButtonMapping::MouseWheelToButtonMapping(uint8_t portIndex, CONTROLL
 }
 
 void MouseWheelToButtonMapping::UpdatePad(CONTROLLERBUTTONS_T& padButtons) {
-    if (Context::GetInstance()->GetControlDeck()->MouseGameInputBlocked()) {
+    if (Context::GetRawInstance()->GetControlDeck()->MouseGameInputBlocked()) {
         return;
     }
 
@@ -34,26 +34,26 @@ std::string MouseWheelToButtonMapping::GetButtonMappingId() {
 
 void MouseWheelToButtonMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".ButtonMappings." + GetButtonMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.ButtonMappingClass", mappingCvarKey.c_str()).c_str(), "MouseWheelToButtonMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Bitmask", mappingCvarKey.c_str()).c_str(), mBitmask);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.WheelDirection", mappingCvarKey.c_str()).c_str(), static_cast<int>(mWheelDirection));
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void MouseWheelToButtonMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".ButtonMappings." + GetButtonMappingId();
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.ButtonMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Bitmask", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.WheelDirection", mappingCvarKey.c_str()).c_str());
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 std::string MouseWheelToButtonMapping::GetPhysicalDeviceName() {

--- a/src/ship/controller/controldevice/controller/mapping/mouse/WheelHandler.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/mouse/WheelHandler.cpp
@@ -42,7 +42,7 @@ void WheelHandler::UpdateAxisBuffer(float* buf, float input) {
 }
 
 void WheelHandler::Update() {
-    mCoords = Context::GetInstance()->GetWindow()->GetMouseWheel();
+    mCoords = Context::GetRawInstance()->GetWindow()->GetMouseWheel();
 
     UpdateAxisBuffer(&mBufferedCoords.x, mCoords.x);
     UpdateAxisBuffer(&mBufferedCoords.y, mCoords.y);

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAxisDirectionMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAxisDirectionMapping.cpp
@@ -19,15 +19,16 @@ SDLAxisDirectionToAxisDirectionMapping::SDLAxisDirectionToAxisDirectionMapping(u
 }
 
 float SDLAxisDirectionToAxisDirectionMapping::GetNormalizedAxisDirectionValue() {
-    if (Context::GetInstance()->GetControlDeck()->GamepadGameInputBlocked()) {
+    if (Context::GetRawInstance()->GetControlDeck()->GamepadGameInputBlocked()) {
         return 0.0f;
     }
 
     // todo: i don't like making a vector here, not sure what a better solution is
     std::vector<float> normalizedValues = {};
-    for (const auto& [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             mPortIndex)) {
+    for (const auto& [instanceId, gamepad] : Context::GetRawInstance()
+                                                 ->GetControlDeck()
+                                                 ->GetConnectedPhysicalDeviceManager()
+                                                 ->GetConnectedSDLGamepadsForPort(mPortIndex)) {
         const auto axisValue = SDL_GameControllerGetAxis(gamepad, mControllerAxis);
 
         if ((mAxisDirection == POSITIVE && axisValue < 0) || (mAxisDirection == NEGATIVE && axisValue > 0)) {
@@ -54,33 +55,33 @@ std::string SDLAxisDirectionToAxisDirectionMapping::GetAxisDirectionMappingId() 
 
 void SDLAxisDirectionToAxisDirectionMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str(),
         "SDLAxisDirectionToAxisDirectionMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str(), mStickIndex);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), mDirection);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.SDLControllerAxis", mappingCvarKey.c_str()).c_str(), mControllerAxis);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.AxisDirection", mappingCvarKey.c_str()).c_str(), mAxisDirection);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void SDLAxisDirectionToAxisDirectionMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.SDLControllerAxis", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.AxisDirection", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 int8_t SDLAxisDirectionToAxisDirectionMapping::GetMappingType() {

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToButtonMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToButtonMapping.cpp
@@ -15,26 +15,27 @@ SDLAxisDirectionToButtonMapping::SDLAxisDirectionToButtonMapping(uint8_t portInd
 }
 
 void SDLAxisDirectionToButtonMapping::UpdatePad(CONTROLLERBUTTONS_T& padButtons) {
-    if (Context::GetInstance()->GetControlDeck()->GamepadGameInputBlocked()) {
+    if (Context::GetRawInstance()->GetControlDeck()->GamepadGameInputBlocked()) {
         return;
     }
 
     int32_t axisThresholdPercentage = 25;
     if (AxisIsStick()) {
-        axisThresholdPercentage = Ship::Context::GetInstance()
+        axisThresholdPercentage = Ship::Context::GetRawInstance()
                                       ->GetControlDeck()
                                       ->GetGlobalSDLDeviceSettings()
                                       ->GetStickAxisThresholdPercentage();
     } else if (AxisIsTrigger()) {
-        axisThresholdPercentage = Ship::Context::GetInstance()
+        axisThresholdPercentage = Ship::Context::GetRawInstance()
                                       ->GetControlDeck()
                                       ->GetGlobalSDLDeviceSettings()
                                       ->GetTriggerAxisThresholdPercentage();
     }
 
-    for (const auto& [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             mPortIndex)) {
+    for (const auto& [instanceId, gamepad] : Context::GetRawInstance()
+                                                 ->GetControlDeck()
+                                                 ->GetConnectedPhysicalDeviceManager()
+                                                 ->GetConnectedSDLGamepadsForPort(mPortIndex)) {
         const auto axisValue = SDL_GameControllerGetAxis(gamepad, mControllerAxis);
 
         auto axisMinValue = SDL_JOYSTICK_AXIS_MAX * (axisThresholdPercentage / 100.0f);
@@ -56,29 +57,29 @@ std::string SDLAxisDirectionToButtonMapping::GetButtonMappingId() {
 
 void SDLAxisDirectionToButtonMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".ButtonMappings." + GetButtonMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.ButtonMappingClass", mappingCvarKey.c_str()).c_str(),
         "SDLAxisDirectionToButtonMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Bitmask", mappingCvarKey.c_str()).c_str(), mBitmask);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.SDLControllerAxis", mappingCvarKey.c_str()).c_str(), mControllerAxis);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.AxisDirection", mappingCvarKey.c_str()).c_str(), mAxisDirection);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void SDLAxisDirectionToButtonMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".ButtonMappings." + GetButtonMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.ButtonMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Bitmask", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.SDLControllerAxis", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.AxisDirection", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 std::string SDLAxisDirectionToButtonMapping::GetPhysicalDeviceName() {

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLButtonToAxisDirectionMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLButtonToAxisDirectionMapping.cpp
@@ -17,13 +17,14 @@ SDLButtonToAxisDirectionMapping::SDLButtonToAxisDirectionMapping(uint8_t portInd
 }
 
 float SDLButtonToAxisDirectionMapping::GetNormalizedAxisDirectionValue() {
-    if (Context::GetInstance()->GetControlDeck()->GamepadGameInputBlocked()) {
+    if (Context::GetRawInstance()->GetControlDeck()->GamepadGameInputBlocked()) {
         return 0.0f;
     }
 
-    for (const auto& [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             mPortIndex)) {
+    for (const auto& [instanceId, gamepad] : Context::GetRawInstance()
+                                                 ->GetControlDeck()
+                                                 ->GetConnectedPhysicalDeviceManager()
+                                                 ->GetConnectedSDLGamepadsForPort(mPortIndex)) {
         if (SDL_GameControllerGetButton(gamepad, mControllerButton)) {
             return MAX_AXIS_RANGE;
         }
@@ -38,29 +39,29 @@ std::string SDLButtonToAxisDirectionMapping::GetAxisDirectionMappingId() {
 
 void SDLButtonToAxisDirectionMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str(),
         "SDLButtonToAxisDirectionMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str(), mStickIndex);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str(), mDirection);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.SDLControllerButton", mappingCvarKey.c_str()).c_str(), mControllerButton);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void SDLButtonToAxisDirectionMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".AxisDirectionMappings." + GetAxisDirectionMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Stick", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Direction", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.AxisDirectionMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.SDLControllerButton", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 int8_t SDLButtonToAxisDirectionMapping::GetMappingType() {

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLButtonToButtonMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLButtonToButtonMapping.cpp
@@ -14,13 +14,14 @@ SDLButtonToButtonMapping::SDLButtonToButtonMapping(uint8_t portIndex, CONTROLLER
 }
 
 void SDLButtonToButtonMapping::UpdatePad(CONTROLLERBUTTONS_T& padButtons) {
-    if (Context::GetInstance()->GetControlDeck()->GamepadGameInputBlocked()) {
+    if (Context::GetRawInstance()->GetControlDeck()->GamepadGameInputBlocked()) {
         return;
     }
 
-    for (const auto& [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             mPortIndex)) {
+    for (const auto& [instanceId, gamepad] : Context::GetRawInstance()
+                                                 ->GetControlDeck()
+                                                 ->GetConnectedPhysicalDeviceManager()
+                                                 ->GetConnectedSDLGamepadsForPort(mPortIndex)) {
         if (SDL_GameControllerGetButton(gamepad, mControllerButton)) {
             padButtons |= mBitmask;
             return;
@@ -38,25 +39,25 @@ std::string SDLButtonToButtonMapping::GetButtonMappingId() {
 
 void SDLButtonToButtonMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".ButtonMappings." + GetButtonMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.ButtonMappingClass", mappingCvarKey.c_str()).c_str(), "SDLButtonToButtonMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.Bitmask", mappingCvarKey.c_str()).c_str(), mBitmask);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.SDLControllerButton", mappingCvarKey.c_str()).c_str(), mControllerButton);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void SDLButtonToButtonMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".ButtonMappings." + GetButtonMappingId();
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.ButtonMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Bitmask", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.SDLControllerButton", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 std::string SDLButtonToButtonMapping::GetPhysicalDeviceName() {

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLGyroMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLGyroMapping.cpp
@@ -16,9 +16,10 @@ SDLGyroMapping::SDLGyroMapping(uint8_t portIndex, float sensitivity, float neutr
 }
 
 void SDLGyroMapping::Recalibrate() {
-    for (const auto& [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             mPortIndex)) {
+    for (const auto& [instanceId, gamepad] : Context::GetRawInstance()
+                                                 ->GetControlDeck()
+                                                 ->GetConnectedPhysicalDeviceManager()
+                                                 ->GetConnectedSDLGamepadsForPort(mPortIndex)) {
         if (!SDL_GameControllerHasSensor(gamepad, SDL_SENSOR_GYRO)) {
             continue;
         }
@@ -41,15 +42,16 @@ void SDLGyroMapping::Recalibrate() {
 }
 
 void SDLGyroMapping::UpdatePad(float& x, float& y) {
-    if (Context::GetInstance()->GetControlDeck()->GamepadGameInputBlocked()) {
+    if (Context::GetRawInstance()->GetControlDeck()->GamepadGameInputBlocked()) {
         x = 0;
         y = 0;
         return;
     }
 
-    for (const auto& [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             mPortIndex)) {
+    for (const auto& [instanceId, gamepad] : Context::GetRawInstance()
+                                                 ->GetControlDeck()
+                                                 ->GetConnectedPhysicalDeviceManager()
+                                                 ->GetConnectedSDLGamepadsForPort(mPortIndex)) {
         if (!SDL_GameControllerHasSensor(gamepad, SDL_SENSOR_GYRO)) {
             continue;
         }
@@ -76,35 +78,35 @@ std::string SDLGyroMapping::GetGyroMappingId() {
 void SDLGyroMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".GyroMappings." + GetGyroMappingId();
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.GyroMappingClass", mappingCvarKey.c_str()).c_str(), "SDLGyroMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetFloat(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetFloat(
         StringHelper::Sprintf("%s.Sensitivity", mappingCvarKey.c_str()).c_str(), mSensitivity);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetFloat(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetFloat(
         StringHelper::Sprintf("%s.NeutralPitch", mappingCvarKey.c_str()).c_str(), mNeutralPitch);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetFloat(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetFloat(
         StringHelper::Sprintf("%s.NeutralYaw", mappingCvarKey.c_str()).c_str(), mNeutralYaw);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetFloat(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetFloat(
         StringHelper::Sprintf("%s.NeutralRoll", mappingCvarKey.c_str()).c_str(), mNeutralRoll);
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void SDLGyroMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".GyroMappings." + GetGyroMappingId();
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.GyroMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.Sensitivity", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.NeutralPitch", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.NeutralYaw", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.NeutralRoll", mappingCvarKey.c_str()).c_str());
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 std::string SDLGyroMapping::GetPhysicalDeviceName() {

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLLEDMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLLEDMapping.cpp
@@ -19,9 +19,10 @@ void SDLLEDMapping::SetLEDColor(Color_RGB8 color) {
         color = mSavedColor;
     }
 
-    for (const auto& [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             mPortIndex)) {
+    for (const auto& [instanceId, gamepad] : Context::GetRawInstance()
+                                                 ->GetControlDeck()
+                                                 ->GetConnectedPhysicalDeviceManager()
+                                                 ->GetConnectedSDLGamepadsForPort(mPortIndex)) {
         if (!SDL_GameControllerHasLED(gamepad)) {
             continue;
         }
@@ -36,26 +37,26 @@ std::string SDLLEDMapping::GetLEDMappingId() {
 
 void SDLLEDMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".LEDMappings." + GetLEDMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.LEDMappingClass", mappingCvarKey.c_str()).c_str(), "SDLLEDMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.ColorSource", mappingCvarKey.c_str()).c_str(), mColorSource);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetColor24(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetColor24(
         StringHelper::Sprintf("%s.SavedColor", mappingCvarKey.c_str()).c_str(), mSavedColor);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void SDLLEDMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".LEDMappings." + GetLEDMappingId();
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.LEDMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.ColorSource", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.SavedColor", mappingCvarKey.c_str()).c_str());
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 std::string SDLLEDMapping::GetPhysicalDeviceName() {

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLRumbleMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLRumbleMapping.cpp
@@ -15,17 +15,19 @@ SDLRumbleMapping::SDLRumbleMapping(uint8_t portIndex, uint8_t lowFrequencyIntens
 }
 
 void SDLRumbleMapping::StartRumble() {
-    for (const auto& [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             mPortIndex)) {
+    for (const auto& [instanceId, gamepad] : Context::GetRawInstance()
+                                                 ->GetControlDeck()
+                                                 ->GetConnectedPhysicalDeviceManager()
+                                                 ->GetConnectedSDLGamepadsForPort(mPortIndex)) {
         SDL_GameControllerRumble(gamepad, mLowFrequencyIntensity, mHighFrequencyIntensity, 0);
     }
 }
 
 void SDLRumbleMapping::StopRumble() {
-    for (const auto& [instanceId, gamepad] :
-         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(
-             mPortIndex)) {
+    for (const auto& [instanceId, gamepad] : Context::GetRawInstance()
+                                                 ->GetControlDeck()
+                                                 ->GetConnectedPhysicalDeviceManager()
+                                                 ->GetConnectedSDLGamepadsForPort(mPortIndex)) {
         SDL_GameControllerRumble(gamepad, 0, 0, 0);
     }
 }
@@ -46,28 +48,28 @@ std::string SDLRumbleMapping::GetRumbleMappingId() {
 
 void SDLRumbleMapping::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".RumbleMappings." + GetRumbleMappingId();
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(
         StringHelper::Sprintf("%s.RumbleMappingClass", mappingCvarKey.c_str()).c_str(), "SDLRumbleMapping");
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.LowFrequencyIntensity", mappingCvarKey.c_str()).c_str(),
         mLowFrequencyIntensityPercentage);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.HighFrequencyIntensity", mappingCvarKey.c_str()).c_str(),
         mHighFrequencyIntensityPercentage);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void SDLRumbleMapping::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".RumbleMappings." + GetRumbleMappingId();
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.RumbleMappingClass", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.LowFrequencyIntensity", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.HighFrequencyIntensity", mappingCvarKey.c_str()).c_str());
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 std::string SDLRumbleMapping::GetPhysicalDeviceName() {

--- a/src/ship/controller/physicaldevice/GlobalSDLDeviceSettings.cpp
+++ b/src/ship/controller/physicaldevice/GlobalSDLDeviceSettings.cpp
@@ -9,10 +9,10 @@ namespace Ship {
 GlobalSDLDeviceSettings::GlobalSDLDeviceSettings() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".GlobalSDLDeviceSettings";
     const int32_t defaultAxisThresholdPercentage = 25;
-    mStickAxisThresholdPercentage = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    mStickAxisThresholdPercentage = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
         StringHelper::Sprintf("%s.StickAxisThresholdPercentage", mappingCvarKey.c_str()).c_str(),
         defaultAxisThresholdPercentage);
-    mTriggerAxisThresholdPercentage = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    mTriggerAxisThresholdPercentage = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
         StringHelper::Sprintf("%s.TriggerAxisThresholdPercentage", mappingCvarKey.c_str()).c_str(),
         defaultAxisThresholdPercentage);
 }
@@ -38,22 +38,22 @@ void GlobalSDLDeviceSettings::SetTriggerAxisThresholdPercentage(int32_t triggerA
 
 void GlobalSDLDeviceSettings::SaveToConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".GlobalSDLDeviceSettings";
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.StickAxisThresholdPercentage", mappingCvarKey.c_str()).c_str(),
         mStickAxisThresholdPercentage);
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(
         StringHelper::Sprintf("%s.TriggerAxisThresholdPercentage", mappingCvarKey.c_str()).c_str(),
         mTriggerAxisThresholdPercentage);
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 
 void GlobalSDLDeviceSettings::EraseFromConfig() {
     const std::string mappingCvarKey = CVAR_PREFIX_CONTROLLERS ".GlobalSDLDeviceSettings";
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.StickAxisThresholdPercentage", mappingCvarKey.c_str()).c_str());
-    Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(
         StringHelper::Sprintf("%s.TriggerAxisThresholdPercentage", mappingCvarKey.c_str()).c_str());
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 }
 } // namespace Ship

--- a/src/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.cpp
+++ b/src/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.cpp
@@ -20,15 +20,17 @@ void SDLAddRemoveDeviceEventHandler::UpdateElement() {
     while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_CONTROLLERDEVICEADDED, SDL_CONTROLLERDEVICEADDED) > 0) {
         // from https://wiki.libsdl.org/SDL2/SDL_ControllerDeviceEvent: which - the joystick device index for
         // the SDL_CONTROLLERDEVICEADDED event
-        Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->HandlePhysicalDeviceConnect(
+        Context::GetRawInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->HandlePhysicalDeviceConnect(
             event.cdevice.which);
     }
 
     while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_CONTROLLERDEVICEREMOVED, SDL_CONTROLLERDEVICEREMOVED) > 0) {
         // from https://wiki.libsdl.org/SDL2/SDL_ControllerDeviceEvent: which - the [...] instance id for the
         // SDL_CONTROLLERDEVICEREMOVED [...] event
-        Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->HandlePhysicalDeviceDisconnect(
-            event.cdevice.which);
+        Context::GetRawInstance()
+            ->GetControlDeck()
+            ->GetConnectedPhysicalDeviceManager()
+            ->HandlePhysicalDeviceDisconnect(event.cdevice.which);
     }
 }
 } // namespace Ship

--- a/src/ship/debug/Console.cpp
+++ b/src/ship/debug/Console.cpp
@@ -42,7 +42,7 @@ int32_t Console::Run(const std::string& command, std::string* output) {
     }
 
     const CommandEntry& entry = it->second;
-    int32_t commandResult = entry.Handler(Context::GetInstance()->GetConsole(), cmdArgs, output);
+    int32_t commandResult = entry.Handler(Context::GetRawInstance()->GetConsole(), cmdArgs, output);
     if (output) {
         SPDLOG_INFO("Command \"{}\" returned {} with output: {}", command, commandResult, *output);
     } else {

--- a/src/ship/debug/CrashHandler.cpp
+++ b/src/ship/debug/CrashHandler.cpp
@@ -138,7 +138,7 @@ void CrashHandler::PrintRegisters(ucontext_t* ctx) {
 }
 
 static void ErrorHandler(int sig, siginfo_t* sigInfo, void* data) {
-    std::shared_ptr<CrashHandler> crashHandler = Context::GetInstance()->GetCrashHandler();
+    std::shared_ptr<CrashHandler> crashHandler = Context::GetRawInstance()->GetCrashHandler();
     char intToCharBuffer[16];
 
     std::array<void*, 4096> arr;
@@ -189,15 +189,15 @@ static void ErrorHandler(int sig, siginfo_t* sigInfo, void* data) {
         snprintf(intToCharBuffer, sizeof(intToCharBuffer), "%i ", (int)i);
         WRITE_VAR_LINE(crashHandler, intToCharBuffer, functionName.c_str());
     }
-    SDL_ShowSimpleMessageBox(
-        SDL_MESSAGEBOX_ERROR, (Context::GetInstance()->GetName() + " has crashed").c_str(),
-        (Context::GetInstance()->GetName() + " has crashed. Please upload the logs to the support channel in discord.")
-            .c_str(),
-        nullptr);
+    SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, (Context::GetRawInstance()->GetName() + " has crashed").c_str(),
+                             (Context::GetRawInstance()->GetName() +
+                              " has crashed. Please upload the logs to the support channel in discord.")
+                                 .c_str(),
+                             nullptr);
     free(symbols);
     crashHandler->PrintCommon();
 
-    Context::GetInstance()->GetLogger()->flush();
+    Context::GetRawInstance()->GetLogger()->flush();
     spdlog::shutdown();
     exit(1);
 }
@@ -390,24 +390,24 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
         }
     }
     PrintCommon();
-    Context::GetInstance()->GetLogger()->flush();
+    Context::GetRawInstance()->GetLogger()->flush();
     spdlog::shutdown();
 #endif
 }
 
 extern "C" LONG WINAPI seh_filter(PEXCEPTION_POINTERS ex) {
     char exceptionString[20];
-    std::shared_ptr<CrashHandler> crashHandler = Context::GetInstance()->GetCrashHandler();
+    std::shared_ptr<CrashHandler> crashHandler = Context::GetRawInstance()->GetCrashHandler();
 
     snprintf(exceptionString, std::size(exceptionString), "0x%x", ex->ExceptionRecord->ExceptionCode);
 
     WRITE_VAR_LINE(crashHandler, "Exception: ", exceptionString);
     crashHandler->PrintStack(ex->ContextRecord);
-    MessageBoxA(
-        nullptr,
-        (Context::GetInstance()->GetName() + " has crashed. Please upload the logs to the support channel in discord.")
-            .c_str(),
-        "Crash", MB_OK | MB_ICONERROR);
+    MessageBoxA(nullptr,
+                (Context::GetRawInstance()->GetName() +
+                 " has crashed. Please upload the logs to the support channel in discord.")
+                    .c_str(),
+                "Crash", MB_OK | MB_ICONERROR);
 
     return EXCEPTION_EXECUTE_HANDLER;
 }

--- a/src/ship/resource/ResourceLoader.cpp
+++ b/src/ship/resource/ResourceLoader.cpp
@@ -175,7 +175,8 @@ std::shared_ptr<ResourceInitData> ResourceLoader::ReadResourceInitData(const std
         initData->Format = RESOURCE_FORMAT_XML;
     }
 
-    initData->Type = Context::GetInstance()->GetResourceManager()->GetResourceLoader()->GetResourceType(parsed["type"]);
+    initData->Type =
+        Context::GetRawInstance()->GetResourceManager()->GetResourceLoader()->GetResourceType(parsed["type"]);
     initData->ResourceVersion = parsed["version"];
 
     return initData;
@@ -190,11 +191,11 @@ std::shared_ptr<IResource> ResourceLoader::LoadResource(std::string filePath, st
 
     if (initData == nullptr) {
         auto metaFilePath = filePath + ".meta";
-        auto metaFileToLoad = Context::GetInstance()->GetResourceManager()->LoadFileProcess(metaFilePath);
+        auto metaFileToLoad = Context::GetRawInstance()->GetResourceManager()->LoadFileProcess(metaFilePath);
 
         if (metaFileToLoad != nullptr) {
             auto initDataFromMetaFile = ReadResourceInitData(filePath, metaFileToLoad);
-            fileToLoad = Context::GetInstance()->GetResourceManager()->LoadFileProcess(initDataFromMetaFile->Path);
+            fileToLoad = Context::GetRawInstance()->GetResourceManager()->LoadFileProcess(initDataFromMetaFile->Path);
             initData = initDataFromMetaFile;
         } else {
             initData = ReadResourceInitDataLegacy(filePath, fileToLoad);
@@ -286,7 +287,7 @@ ResourceLoader::ReadResourceInitDataXml(const std::string& filePath, std::shared
 
     auto root = document->FirstChildElement();
     resourceInitData->Type =
-        Context::GetInstance()->GetResourceManager()->GetResourceLoader()->GetResourceType(root->Name());
+        Context::GetRawInstance()->GetResourceManager()->GetResourceLoader()->GetResourceType(root->Name());
     resourceInitData->ResourceVersion = root->IntAttribute("Version");
 
     return resourceInitData;

--- a/src/ship/resource/archive/Archive.cpp
+++ b/src/ship/resource/archive/Archive.cpp
@@ -48,7 +48,7 @@ void Archive::Load() {
         reader->SetEndianness(endianness);
         SetGameVersion(reader->ReadUInt32());
         isGameVersionValid =
-            Context::GetInstance()->GetResourceManager()->GetArchiveManager()->IsGameVersionValid(GetGameVersion());
+            Context::GetRawInstance()->GetResourceManager()->GetArchiveManager()->IsGameVersionValid(GetGameVersion());
 
         if (!isGameVersionValid) {
             SPDLOG_WARN("Attempting to load Archive \"{}\" with invalid version {}", GetPath(), GetGameVersion());
@@ -79,7 +79,7 @@ void Archive::Load() {
                 mHasGameVersion = true;
                 SetGameVersion(mManifest.GameVersion);
                 isGameVersionValid =
-                    Context::GetInstance()->GetResourceManager()->GetArchiveManager()->IsGameVersionValid(
+                    Context::GetRawInstance()->GetResourceManager()->GetArchiveManager()->IsGameVersionValid(
                         GetGameVersion());
 
                 if (!isGameVersionValid) {
@@ -108,7 +108,7 @@ void Archive::Unload() {
 
 std::shared_ptr<File> Archive::LoadFile(uint64_t hash) {
     const std::string& filePath =
-        *Context::GetInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
+        *Context::GetRawInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
     return LoadFile(filePath);
 }
 
@@ -187,8 +187,8 @@ void Archive::Validate() {
         return;
     }
 
-    auto keystore = Context::GetInstance()->GetKeystore();
-    auto manager = Context::GetInstance()->GetResourceManager()->GetArchiveManager();
+    auto keystore = Context::GetRawInstance()->GetKeystore();
+    auto manager = Context::GetRawInstance()->GetResourceManager()->GetArchiveManager();
     std::vector<uint8_t> manifestKey = StringHelper::HexToBytes(mManifest.PublicKey);
 
     if (!keystore->HasKey(manifestKey)) {

--- a/src/ship/resource/archive/FolderArchive.cpp
+++ b/src/ship/resource/archive/FolderArchive.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<File> Ship::FolderArchive::LoadFile(const std::string& filePath)
 
 std::shared_ptr<File> Ship::FolderArchive::LoadFile(uint64_t hash) {
     const std::string& filePath =
-        *Context::GetInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
+        *Context::GetRawInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
 
     return LoadFileRaw(filePath);
 }
@@ -68,7 +68,7 @@ std::shared_ptr<File> FolderArchive::LoadFileRaw(const std::string& filePath) {
 
 std::shared_ptr<File> FolderArchive::LoadFileRaw(uint64_t hash) {
     const std::string& filePath =
-        *Context::GetInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
+        *Context::GetRawInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
 
     return LoadFileRaw(filePath);
 }

--- a/src/ship/resource/archive/O2rArchive.cpp
+++ b/src/ship/resource/archive/O2rArchive.cpp
@@ -36,7 +36,7 @@ void O2rArchive::ReleaseZipHandle(zip_t* handle) {
 
 std::shared_ptr<File> O2rArchive::LoadFile(uint64_t hash) {
     const std::string& filePath =
-        *Context::GetInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
+        *Context::GetRawInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
     return LoadFile(filePath);
 }
 

--- a/src/ship/resource/archive/OtrArchive.cpp
+++ b/src/ship/resource/archive/OtrArchive.cpp
@@ -63,7 +63,7 @@ std::shared_ptr<File> OtrArchive::LoadFile(const std::string& filePath) {
 
 std::shared_ptr<File> OtrArchive::LoadFile(uint64_t hash) {
     const std::string& filePath =
-        *Context::GetInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
+        *Context::GetRawInstance()->GetResourceManager()->GetArchiveManager()->HashToString(hash);
     return LoadFile(filePath);
 }
 

--- a/src/ship/scripting/ScriptLoader.cpp
+++ b/src/ship/scripting/ScriptLoader.cpp
@@ -240,7 +240,7 @@ void ScriptLoader::Compile(const std::shared_ptr<Archive>& archive) {
 
 void ScriptLoader::CompileAll(const std::optional<std::function<void(const std::shared_ptr<Archive>&)>>& preCallback,
                               const std::optional<std::function<void()>>& postCallback) {
-    auto archive = Context::GetInstance()->GetResourceManager()->GetArchiveManager();
+    auto archive = Context::GetRawInstance()->GetResourceManager()->GetArchiveManager();
     auto list = archive->GetArchives();
 
     for (const auto& entry : *list) {

--- a/src/ship/security/Keystore.cpp
+++ b/src/ship/security/Keystore.cpp
@@ -57,7 +57,7 @@ std::vector<KeystoreEntry> Keystore::GetAllKeys() const {
 }
 
 void Keystore::Load() {
-    std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();
+    std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     conf->Reload();
 
     nlohmann::json rootJson = conf->GetNestedJson();
@@ -78,7 +78,7 @@ void Keystore::Load() {
 }
 
 void Keystore::Save() {
-    std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();
+    std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     for (const auto& [keyName, entry] : mKeys) {
         std::string hexString = StringHelper::BytesToHex(entry.Data);
         conf->SetString(StringHelper::Sprintf("Keystore.%s", keyName.c_str()), hexString);

--- a/src/ship/window/FileDropMgr.cpp
+++ b/src/ship/window/FileDropMgr.cpp
@@ -111,7 +111,7 @@ void FileDropMgr::CallHandlers() {
         }
     }
     SPDLOG_WARN("Dropped file {} not handled by any registered.", mPath);
-    auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
+    auto gui = Ship::Context::GetRawInstance()->GetWindow()->GetGui();
     gui->GetGameOverlay()->TextDrawNotification(30.0f, true, "Unsupported file dropped, ignoring");
 }
 

--- a/src/ship/window/MouseStateManager.cpp
+++ b/src/ship/window/MouseStateManager.cpp
@@ -17,7 +17,7 @@ void MouseStateManager::StartFrame() {
 void MouseStateManager::CursorVisibilityTimeoutTick() {
     static Coords sPrevMousePos;
 
-    std::shared_ptr<Window> wnd = Context::GetInstance()->GetWindow();
+    std::shared_ptr<Window> wnd = Context::GetRawInstance()->GetWindow();
     if (ShouldForceCursorVisibility() || wnd->IsMouseCaptured()) {
         return;
     }
@@ -60,12 +60,12 @@ void MouseStateManager::SetForceCursorVisibility(bool visible) {
 }
 
 void MouseStateManager::ToggleMouseCaptureOverride() {
-    const std::shared_ptr<Window> window = Context::GetInstance()->GetWindow();
+    const std::shared_ptr<Window> window = Context::GetRawInstance()->GetWindow();
     window->SetMouseCapture(!window->IsMouseCaptured());
 }
 
 void MouseStateManager::UpdateMouseCapture() {
-    const std::shared_ptr<Window> window = Context::GetInstance()->GetWindow();
+    const std::shared_ptr<Window> window = Context::GetRawInstance()->GetWindow();
     if (!window->GetGui()->GetMenuOrMenubarVisible()) {
         window->SetMouseCapture(ShouldAutoCaptureMouse());
     } else {

--- a/src/ship/window/Window.cpp
+++ b/src/ship/window/Window.cpp
@@ -16,7 +16,7 @@ Window::Window(std::shared_ptr<Gui> gui, std::shared_ptr<MouseStateManager> mous
     mGui = gui;
     mMouseStateManager = mouseStateManager;
     mAvailableWindowBackends = std::make_shared<std::vector<int32_t>>();
-    mConfig = Context::GetInstance()->GetConfig();
+    mConfig = Context::GetRawInstance()->GetConfig();
 }
 
 Window::Window(std::shared_ptr<Gui> gui) : Window(gui, std::make_shared<MouseStateManager>()) {

--- a/src/ship/window/gui/ConsoleWindow.cpp
+++ b/src/ship/window/gui/ConsoleWindow.cpp
@@ -46,8 +46,8 @@ int32_t ConsoleWindow::HelpCommand(std::shared_ptr<Console> console, const std::
 
 int32_t ConsoleWindow::ClearCommand(std::shared_ptr<Console> console, const std::vector<std::string>& args,
                                     std::string* output) {
-    auto window =
-        std::static_pointer_cast<ConsoleWindow>(Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"));
+    auto window = std::static_pointer_cast<ConsoleWindow>(
+        Context::GetRawInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"));
     if (!window) {
         if (output) {
             *output += "A console window is necessary for Clear";
@@ -64,7 +64,7 @@ int32_t ConsoleWindow::UnbindCommand(std::shared_ptr<Console> console, const std
                                      std::string* output) {
     if (args.size() > 1) {
         auto window = std::static_pointer_cast<ConsoleWindow>(
-            Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"));
+            Context::GetRawInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"));
         if (!window) {
             if (output) {
                 *output += "A console window is necessary for Unbind";
@@ -118,7 +118,7 @@ int32_t ConsoleWindow::BindCommand(std::shared_ptr<Console> console, const std::
                                    std::string* output) {
     if (args.size() > 2) {
         auto window = std::static_pointer_cast<ConsoleWindow>(
-            Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"));
+            Context::GetRawInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"));
         if (!window) {
             if (output) {
                 *output += "A console window is necessary for Bind";
@@ -156,7 +156,7 @@ int32_t ConsoleWindow::BindToggleCommand(std::shared_ptr<Console> console, const
                                          std::string* output) {
     if (args.size() > 2) {
         auto window = std::static_pointer_cast<ConsoleWindow>(
-            Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"));
+            Context::GetRawInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"));
         if (!window) {
             if (output) {
                 *output += "A console window is necessary for BindToggle";
@@ -203,9 +203,9 @@ int32_t ConsoleWindow::SetCommand(std::shared_ptr<Console> console, const std::v
     int vType = CheckVarType(args[2]);
 
     if (vType == VARTYPE_STRING) {
-        Ship::Context::GetInstance()->GetConsoleVariables()->SetString(args[1].c_str(), args[2].c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(args[1].c_str(), args[2].c_str());
     } else if (vType == VARTYPE_FLOAT) {
-        Ship::Context::GetInstance()->GetConsoleVariables()->SetFloat((char*)args[1].c_str(), std::stof(args[2]));
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->SetFloat((char*)args[1].c_str(), std::stof(args[2]));
     } else if (vType == VARTYPE_RGBA) {
         uint32_t val = std::stoul(&args[2].c_str()[1], nullptr, 16);
         Color_RGBA8 clr;
@@ -213,12 +213,12 @@ int32_t ConsoleWindow::SetCommand(std::shared_ptr<Console> console, const std::v
         clr.g = val >> 16;
         clr.b = val >> 8;
         clr.a = val & 0xFF;
-        Ship::Context::GetInstance()->GetConsoleVariables()->SetColor((char*)args[1].c_str(), clr);
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->SetColor((char*)args[1].c_str(), clr);
     } else {
-        Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(args[1].c_str(), std::stoi(args[2]));
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(args[1].c_str(), std::stoi(args[2]));
     }
 
-    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
 
     return 0;
 }
@@ -233,7 +233,7 @@ int32_t ConsoleWindow::GetCommand(std::shared_ptr<Console> console, const std::v
         return 1;
     }
 
-    auto cvar = Ship::Context::GetInstance()->GetConsoleVariables()->Get(args[1].c_str());
+    auto cvar = Ship::Context::GetRawInstance()->GetConsoleVariables()->Get(args[1].c_str());
 
     if (cvar != nullptr) {
         if (cvar->Type == ConsoleVariableType::Integer) {
@@ -301,20 +301,20 @@ void ConsoleWindow::InitElement() {
     mFilterBuffer = new char[gMaxBufferSize];
     strcpy(mFilterBuffer, "");
 
-    Context::GetInstance()->GetConsole()->AddCommand(
+    Context::GetRawInstance()->GetConsole()->AddCommand(
         "set", { SetCommand,
                  "Sets a console variable.",
                  { { "varName", ArgumentType::TEXT }, { "varValue", ArgumentType::TEXT } } });
-    Context::GetInstance()->GetConsole()->AddCommand(
+    Context::GetRawInstance()->GetConsole()->AddCommand(
         "get", { GetCommand, "Gets a console variable", { { "varName", ArgumentType::TEXT } } });
-    Context::GetInstance()->GetConsole()->AddCommand("help", { HelpCommand, "Shows all the commands" });
-    Context::GetInstance()->GetConsole()->AddCommand("clear", { ClearCommand, "Clear the console history" });
-    Context::GetInstance()->GetConsole()->AddCommand(
+    Context::GetRawInstance()->GetConsole()->AddCommand("help", { HelpCommand, "Shows all the commands" });
+    Context::GetRawInstance()->GetConsole()->AddCommand("clear", { ClearCommand, "Clear the console history" });
+    Context::GetRawInstance()->GetConsole()->AddCommand(
         "unbind", { UnbindCommand, "Unbinds a key", { { "key", ArgumentType::TEXT } } });
-    Context::GetInstance()->GetConsole()->AddCommand(
+    Context::GetRawInstance()->GetConsole()->AddCommand(
         "bind",
         { BindCommand, "Binds key to commands", { { "key", ArgumentType::TEXT }, { "cmd", ArgumentType::TEXT } } });
-    Context::GetInstance()->GetConsole()->AddCommand(
+    Context::GetRawInstance()->GetConsole()->AddCommand(
         "bind-toggle", { BindToggleCommand,
                          "Bind key as a bool toggle",
                          { { "key", ArgumentType::TEXT }, { "cmd", ArgumentType::TEXT } } });
@@ -330,7 +330,7 @@ void ConsoleWindow::UpdateElement() {
         if (ImGui::IsKeyPressed(key)) {
             Dispatch("set " + var + " " +
                      std::to_string(!static_cast<bool>(
-                         Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(var.c_str(), 0))));
+                         Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(var.c_str(), 0))));
         }
     }
 }
@@ -342,7 +342,7 @@ void ConsoleWindow::DrawElement() {
 
     // Renders autocomplete window
     if (mOpenAutocomplete) {
-        auto console = Context::GetInstance()->GetConsole();
+        auto console = Context::GetRawInstance()->GetConsole();
 
         ImGui::SetNextWindowSize(ImVec2(350, std::min(static_cast<int>(mAutoComplete.size()), 3) * 20.f),
                                  ImGuiCond_Once);
@@ -392,7 +392,7 @@ void ConsoleWindow::DrawElement() {
         ClearLogs(mCurrentChannel);
     }
 
-    if (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger("gSinkEnabled", 0)) {
+    if (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger("gSinkEnabled", 0)) {
         ImGui::SameLine();
         ImGui::SetNextItemWidth(150);
         if (ImGui::BeginCombo("##channel", mCurrentChannel.c_str())) {
@@ -545,7 +545,7 @@ void ConsoleWindow::Dispatch(const std::string& line) {
     mHistoryIndex = -1;
     mHistory.push_back(line);
     SendInfoMessage("> " + line);
-    auto console = Context::GetInstance()->GetConsole();
+    auto console = Context::GetRawInstance()->GetConsole();
     const std::vector<std::string> cmdArgs = StringHelper::Split(line, " ");
     if (console->HasCommand(cmdArgs[0])) {
         const CommandEntry entry = console->GetCommand(cmdArgs[0]);
@@ -576,7 +576,7 @@ void ConsoleWindow::Dispatch(const std::string& line) {
 int ConsoleWindow::CallbackStub(ImGuiInputTextCallbackData* data) {
     const auto instance = static_cast<ConsoleWindow*>(data->UserData);
     const bool emptyHistory = instance->mHistory.empty();
-    auto console = Context::GetInstance()->GetConsole();
+    auto console = Context::GetRawInstance()->GetConsole();
     std::string history;
 
     switch (data->EventKey) {

--- a/src/ship/window/gui/EventDebuggerWindow.cpp
+++ b/src/ship/window/gui/EventDebuggerWindow.cpp
@@ -80,7 +80,7 @@ void DrawEventListenerInfo(std::string& name, const EventRegistration& registry)
 
 void EventDebuggerWindow::DrawElement() {
     bool collapseLogic = false;
-    auto events = Ship::Context::GetInstance()->GetEventSystem()->GetEventRegistrations();
+    auto events = Ship::Context::GetRawInstance()->GetEventSystem()->GetEventRegistrations();
     bool doingCollapseOrExpand = hookOptExpandAll || hookOptCollapseAll;
 
     if (ImGui::Button("Expand All")) {

--- a/src/ship/window/gui/GameOverlay.cpp
+++ b/src/ship/window/gui/GameOverlay.cpp
@@ -26,7 +26,7 @@ void GameOverlay::LoadFont(const std::string& name, float fontSize, const Resour
     initData->ResourceVersion = 0;
     initData->Path = identifier.Path;
     std::shared_ptr<Font> font = std::static_pointer_cast<Font>(
-        Context::GetInstance()->GetResourceManager()->LoadResource(identifier, false, initData));
+        Context::GetRawInstance()->GetResourceManager()->LoadResource(identifier, false, initData));
 
     if (font == nullptr) {
         SPDLOG_ERROR("Failed to load font: {}", name);
@@ -45,7 +45,7 @@ void GameOverlay::LoadFont(const std::string& name, float fontSize, const std::s
     initData->ResourceVersion = 0;
     initData->Path = path;
     std::shared_ptr<Font> font = std::static_pointer_cast<Font>(
-        Context::GetInstance()->GetResourceManager()->LoadResource(path, false, initData));
+        Context::GetRawInstance()->GetResourceManager()->LoadResource(path, false, initData));
 
     if (font == nullptr) {
         SPDLOG_ERROR("Failed to load font: {}", name);
@@ -157,7 +157,7 @@ ImVec2 GameOverlay::CalculateTextSize(const char* text, const char* textEnd, boo
 }
 
 void GameOverlay::Init() {
-    Context::GetInstance()->GetResourceManager()->GetResourceLoader()->RegisterResourceFactory(
+    Context::GetRawInstance()->GetResourceManager()->GetResourceLoader()->RegisterResourceFactory(
         std::make_shared<ResourceFactoryBinaryFontV0>(), RESOURCE_FORMAT_BINARY, "Font",
         static_cast<uint32_t>(RESOURCE_TYPE_FONT), 0);
 }
@@ -169,8 +169,8 @@ void GameOverlay::SetCurrentFont(const std::string& name) {
     }
 
     mCurrentFont = name;
-    Ship::Context::GetInstance()->GetConsoleVariables()->SetString(CVAR_GAME_OVERLAY_FONT, name.c_str());
-    Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+    Ship::Context::GetRawInstance()->GetConsoleVariables()->SetString(CVAR_GAME_OVERLAY_FONT, name.c_str());
+    Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
 }
 
 void GameOverlay::DrawSettings() {
@@ -204,7 +204,7 @@ void GameOverlay::Draw() {
 
         if (overlay.Type == OverlayType::TEXT) {
             const char* text = overlay.Value.c_str();
-            const auto var = Ship::Context::GetInstance()->GetConsoleVariables()->Get(text);
+            const auto var = Ship::Context::GetRawInstance()->GetConsoleVariables()->Get(text);
             ImVec4 color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
 
             switch (var->Type) {

--- a/src/ship/window/gui/Gui.cpp
+++ b/src/ship/window/gui/Gui.cpp
@@ -82,11 +82,11 @@ void Gui::Init() {
     mImGuiIo->LogFilename = mImGuiLogPath.c_str();
 
     if (SupportsViewports() &&
-        Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_ENABLE_MULTI_VIEWPORTS, 1)) {
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_ENABLE_MULTI_VIEWPORTS, 1)) {
         mImGuiIo->ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
     }
 
-    if (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0) &&
+    if (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0) &&
         GetMenuOrMenubarVisible()) {
         mImGuiIo->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
     } else {
@@ -97,7 +97,7 @@ void Gui::Init() {
     GetGuiWindow("Console")->Init();
     GetGameOverlay()->Init();
 
-    Context::GetInstance()->GetResourceManager()->GetResourceLoader()->RegisterResourceFactory(
+    Context::GetRawInstance()->GetResourceManager()->GetResourceLoader()->RegisterResourceFactory(
         std::make_shared<ResourceFactoryBinaryGuiTextureV0>(), RESOURCE_FORMAT_BINARY, "GuiTexture",
         static_cast<uint32_t>(RESOURCE_TYPE_GUI_TEXTURE), 0);
 
@@ -136,7 +136,7 @@ void Gui::BlockGamepadNavigation() {
 }
 
 void Gui::UnblockGamepadNavigation() {
-    if (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0) &&
+    if (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0) &&
         GetMenuOrMenubarVisible()) {
         mImGuiIo->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
     }
@@ -162,8 +162,8 @@ void Gui::ImGuiWMNewFrame() {
 }
 
 void Gui::DrawMenu() {
-    const std::shared_ptr<Window> wnd = Context::GetInstance()->GetWindow();
-    const std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();
+    const std::shared_ptr<Window> wnd = Context::GetRawInstance()->GetWindow();
+    const std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
 
     ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoBackground |
                                    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoMove |
@@ -202,15 +202,15 @@ void Gui::DrawMenu() {
 
     if (ImGui::IsKeyPressed(TOGGLE_BTN, false) || ImGui::IsKeyPressed(ImGuiKey_Escape, false) ||
         (ImGui::IsKeyPressed(TOGGLE_PAD_BTN, false) &&
-         Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0))) {
+         Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0))) {
         if ((ImGui::IsKeyPressed(ImGuiKey_Escape, false) || ImGui::IsKeyPressed(TOGGLE_PAD_BTN, false)) && GetMenu()) {
             GetMenu()->ToggleVisibility();
         } else if ((ImGui::IsKeyPressed(TOGGLE_BTN, false) || ImGui::IsKeyPressed(TOGGLE_PAD_BTN, false)) &&
                    GetMenuBar()) {
             GetMenuBar()->ToggleVisibility();
         }
-        Ship::Context::GetInstance()->GetWindow()->GetMouseStateManager()->UpdateMouseCapture();
-        if (Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0) &&
+        Ship::Context::GetRawInstance()->GetWindow()->GetMouseStateManager()->UpdateMouseCapture();
+        if (Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0) &&
             GetMenuOrMenubarVisible()) {
             mImGuiIo->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
         } else {
@@ -222,7 +222,7 @@ void Gui::DrawMenu() {
     if ((ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) &&
         ImGui::IsKeyPressed(ImGuiKey_R, false)) {
         std::reinterpret_pointer_cast<ConsoleWindow>(
-            Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
+            Context::GetRawInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
             ->Dispatch("reset");
     }
 
@@ -249,7 +249,7 @@ void Gui::HandleMouseCapture() {
     for (auto windowIter : ImGui::GetCurrentContext()->WindowsById.Data) {
         if (windowIter.key != GetMainGameWindowID() && windowIter.key != GetGameOverlay()->GetID()) {
             ImGuiWindow* window = (ImGuiWindow*)windowIter.val_p;
-            if (Context::GetInstance()->GetWindow()->IsMouseCaptured()) {
+            if (Context::GetRawInstance()->GetWindow()->IsMouseCaptured()) {
                 window->Flags |= flags;
             } else {
                 window->Flags &= ~(flags);
@@ -283,7 +283,7 @@ void Gui::DrawFloatingWindows() {
 
 void Gui::CheckSaveCvars() {
     if (mNeedsConsoleVariableSave) {
-        Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->Save();
         mNeedsConsoleVariableSave = false;
     }
 }

--- a/src/ship/window/gui/GuiMenuBar.cpp
+++ b/src/ship/window/gui/GuiMenuBar.cpp
@@ -8,8 +8,8 @@ namespace Ship {
 GuiMenuBar::GuiMenuBar(const std::string& visibilityConsoleVariable, bool isVisible)
     : GuiElement(isVisible), mVisibilityConsoleVariable(visibilityConsoleVariable) {
     if (!mVisibilityConsoleVariable.empty()) {
-        mIsVisible = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(mVisibilityConsoleVariable.c_str(),
-                                                                                     mIsVisible);
+        mIsVisible = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
+            mVisibilityConsoleVariable.c_str(), mIsVisible);
         SyncVisibilityConsoleVariable();
     }
 }
@@ -32,18 +32,18 @@ void GuiMenuBar::SyncVisibilityConsoleVariable() {
         return;
     }
 
-    bool shouldSave = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    bool shouldSave = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
                           mVisibilityConsoleVariable.c_str(), 0) != IsVisible();
 
     if (IsVisible()) {
-        Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(mVisibilityConsoleVariable.c_str(),
-                                                                        IsVisible());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(mVisibilityConsoleVariable.c_str(),
+                                                                           IsVisible());
     } else {
-        Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mVisibilityConsoleVariable.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mVisibilityConsoleVariable.c_str());
     }
 
     if (shouldSave) {
-        Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+        Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
     }
 }
 

--- a/src/ship/window/gui/GuiWindow.cpp
+++ b/src/ship/window/gui/GuiWindow.cpp
@@ -10,8 +10,8 @@ GuiWindow::GuiWindow(const std::string& consoleVariable, bool isVisible, const s
     : GuiElement(isVisible), mName(name), mVisibilityConsoleVariable(consoleVariable), mOriginalSize(originalSize),
       mWindowFlags(windowFlags) {
     if (!mVisibilityConsoleVariable.empty()) {
-        mIsVisible = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(mVisibilityConsoleVariable.c_str(),
-                                                                                     mIsVisible);
+        mIsVisible = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
+            mVisibilityConsoleVariable.c_str(), mIsVisible);
         SyncVisibilityConsoleVariable();
     }
 }
@@ -47,18 +47,18 @@ void GuiWindow::SyncVisibilityConsoleVariable() {
         return;
     }
 
-    bool shouldSave = Ship::Context::GetInstance()->GetConsoleVariables()->GetInteger(
+    bool shouldSave = Ship::Context::GetRawInstance()->GetConsoleVariables()->GetInteger(
                           mVisibilityConsoleVariable.c_str(), 0) != IsVisible();
 
     if (IsVisible()) {
-        Ship::Context::GetInstance()->GetConsoleVariables()->SetInteger(mVisibilityConsoleVariable.c_str(),
-                                                                        IsVisible());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->SetInteger(mVisibilityConsoleVariable.c_str(),
+                                                                           IsVisible());
     } else {
-        Ship::Context::GetInstance()->GetConsoleVariables()->ClearVariable(mVisibilityConsoleVariable.c_str());
+        Ship::Context::GetRawInstance()->GetConsoleVariables()->ClearVariable(mVisibilityConsoleVariable.c_str());
     }
 
     if (shouldSave) {
-        Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+        Context::GetRawInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
     }
 }
 

--- a/tests/archive_resource_tests.cpp
+++ b/tests/archive_resource_tests.cpp
@@ -58,7 +58,7 @@ class TestRamArchive final : public Ship::Archive {
         return MakeFile(it->second);
     }
 
-    // Resolve hash → path locally so we don't need Context::GetInstance()
+    // Resolve hash → path locally so we don't need Context::GetRawInstance()
     std::shared_ptr<Ship::File> LoadFile(uint64_t hash) override {
         for (const auto& [path, _] : mTestFiles) {
             if (CRC64(path.c_str()) == hash) {


### PR DESCRIPTION
Various components were trying to access other components in `Context` during their destructors. `shared_ptr` would return `nullptr` leading to crashes.
This also fixes a race condition and double free inside `spdlog` related to shutting it down.
Fixes #1102. I've only tested on Linux. Someone will need to test Windows and MacOS