### PR TITLE
fix(audio): stop the SDL backend dropping audio when the queue runs ahead

### DIFF
--- a/include/ship/audio/SDLAudioPlayer.h
+++ b/include/ship/audio/SDLAudioPlayer.h
@@ -50,6 +50,6 @@ class SDLAudioPlayer final : public AudioPlayer {
 
   private:
     SDL_AudioDeviceID mDevice = 0; ///< Handle to the opened SDL audio device.
-    int32_t mNumChannels = 2;      ///< Number of output channels (2 for stereo, 6 for 5.1).
+    uint8_t mNumChannels = 2;      ///< Number of output channels (2 for stereo, 6 for 5.1).
 };
 } // namespace Ship

--- a/src/ship/audio/SDLAudioPlayer.cpp
+++ b/src/ship/audio/SDLAudioPlayer.cpp
@@ -47,9 +47,6 @@ int SDLAudioPlayer::Buffered() {
 }
 
 void SDLAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
-    if (Buffered() < 6000) {
-        // Don't fill the audio buffer too much in case this happens
-        SDL_PutAudioStreamData(mStream, buf, static_cast<int>(len));
-    }
+    SDL_PutAudioStreamData(mStream, buf, static_cast<int>(len));
 }
 } // namespace Ship

--- a/src/ship/audio/SDLAudioPlayer.cpp
+++ b/src/ship/audio/SDLAudioPlayer.cpp
@@ -13,7 +13,8 @@ void SDLAudioPlayer::DoClose() {
     if (mDevice != 0) {
         // Pause playback first
         SDL_PauseAudioDevice(mDevice, 1);
-        // Clear any queued audio to prevent glitches when reopening
+
+        // Prevent stale audio when reopening
         SDL_ClearQueuedAudio(mDevice);
         SDL_CloseAudioDevice(mDevice);
         mDevice = 0;
@@ -21,29 +22,38 @@ void SDLAudioPlayer::DoClose() {
 }
 
 bool SDLAudioPlayer::DoInit() {
-    if (SDL_Init(SDL_INIT_AUDIO) != 0) {
+    if (SDL_InitSubSystem(SDL_INIT_AUDIO) != 0) {
         SPDLOG_ERROR("SDL init error: {}", SDL_GetError());
         return false;
     }
 
-    // Always open with the correct number of output channels
-    mNumChannels = this->GetNumOutputChannels();
-
     SDL_AudioSpec want, have;
     SDL_zero(want);
+
     want.freq = this->GetSampleRate();
     want.format = AUDIO_S16SYS;
-    want.channels = mNumChannels;
-    want.samples = this->GetSampleLength();
-    want.callback = NULL;
+    want.channels = this->GetNumOutputChannels();
 
-    mDevice = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
+    // Increase backend/device buffering slightly
+    // to reduce rare underruns/glitches.
+    //
+    // IMPORTANT:
+    // This is NOT part of the emulator buffering logic.
+    // It only affects SDL/backend latency.
+    want.samples = GetSampleLength() * 2;
+
+    want.callback = nullptr;
+
+    mDevice = SDL_OpenAudioDevice(nullptr, 0, &want, &have, 0);
+
     if (mDevice == 0) {
-        SPDLOG_ERROR("SDL_OpenAudio error: {}", SDL_GetError());
+        SPDLOG_ERROR("SDL_OpenAudioDevice error: {}", SDL_GetError());
         return false;
     }
 
-    SPDLOG_INFO("SDL Audio initialized: {} channels, {} Hz", mNumChannels, this->GetSampleRate());
+    mNumChannels = have.channels;
+
+    SPDLOG_INFO("SDL audio initialized: {} Hz, {} channels, {} samples", have.freq, have.channels, have.samples);
 
     SDL_PauseAudioDevice(mDevice, 0);
     return true;
@@ -54,9 +64,6 @@ int SDLAudioPlayer::Buffered() {
 }
 
 void SDLAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
-    if (Buffered() < 6000) {
-        // Don't fill the audio buffer too much in case this happens
-        SDL_QueueAudio(mDevice, buf, len);
-    }
+    SDL_QueueAudio(mDevice, buf, len);
 }
 } // namespace Ship


### PR DESCRIPTION
`DoPlay()` dropped its buffer outright once `Buffered()` reached 6000 frames. A slow frame then became an audible cut instead of extra latency, which is the wrong trade for the situation the threshold was meant to protect against.

The threshold was arbitrary, and the callers already bound how much they hand over - every port checks the buffered amount before calling `AudioPlayer_Play`, as @briaguya0 catalogued in the thread below (soh, 2ship, Starship, SpaghettiKart, Ghostship). SDL's own queue handles backpressure from there.

### Rebased onto the SDL3 migration

This PR predates #1191, and most of what it carried is now moot:

| original change | status |
| --- | --- |
| `SDL_Init` → `SDL_InitSubSystem` | already in main |
| `NULL` → `nullptr`, style, log format | already in main |
| read the channel count back from `have` | not applicable - SDL3 converts from the app-side spec, so the requested count is the right divisor in `Buffered()` |
| double the device buffer (`want.samples * 2`) | dropped - SDL3 has no per-device sample count in `SDL_AudioSpec`. `SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES` is the equivalent knob, and SDL3's own guidance is to let it pick |

What is left is the one substantive fix, three lines. Happy to add the sample-frames hint in a follow-up if the underruns it was papering over turn out to still be there under SDL3 - worth measuring rather than assuming, since the stream model is not the SDL2 push queue this was tuned against.
