### PR TITLE
Add fixedAspect flag to framebuffers

### DIFF
--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -361,7 +361,7 @@ struct FBInfo {
     uint32_t applied_width, applied_height; // Up-scaled for the viewport
     uint32_t native_width, native_height;   // Max "native" size of the screen, used for up-scaling
     bool resize;                            // Scale to match the viewport
-    bool fixedAspect;                       // Preserve aspect ratio
+    bool forceFixedAspect;                  // Preserve aspect ratio even if resize is true
 };
 
 struct MaskedTextureEntry {
@@ -392,7 +392,7 @@ class Interpreter {
     void SetTargetFps(int fps);
     void SetMaxFrameLatency(int latency);
     int CreateFrameBuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height,
-                          uint8_t resize, bool fixedAspect);
+                          uint8_t resize, bool forceFixedAspect = false);
     void SetFrameBuffer(int fb, float noiseScale);
     void CopyFrameBuffer(int fb_dst_id, int fb_src_id, bool copyOnce, bool* hasCopiedPtr);
     void ResetFrameBuffer();
@@ -561,4 +561,4 @@ const char* GfxGetOpcodeName(int8_t opcode);
 extern "C" void gfx_texture_cache_clear();
 extern "C" void gfx_shader_cache_clear();
 extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height,
-                                      uint8_t resize, bool fixedAspect);
+                                      uint8_t resize, bool forceFixedAspect = false);

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -361,6 +361,7 @@ struct FBInfo {
     uint32_t applied_width, applied_height; // Up-scaled for the viewport
     uint32_t native_width, native_height;   // Max "native" size of the screen, used for up-scaling
     bool resize;                            // Scale to match the viewport
+    bool fixedAspect;                       // Preserve aspect ratio
 };
 
 struct MaskedTextureEntry {
@@ -391,7 +392,7 @@ class Interpreter {
     void SetTargetFps(int fps);
     void SetMaxFrameLatency(int latency);
     int CreateFrameBuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height,
-                          uint8_t resize);
+                          uint8_t resize, bool fixedAspect);
     void SetFrameBuffer(int fb, float noiseScale);
     void CopyFrameBuffer(int fb_dst_id, int fb_src_id, bool copyOnce, bool* hasCopiedPtr);
     void ResetFrameBuffer();
@@ -560,4 +561,4 @@ const char* GfxGetOpcodeName(int8_t opcode);
 extern "C" void gfx_texture_cache_clear();
 extern "C" void gfx_shader_cache_clear();
 extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height,
-                                      uint8_t resize);
+                                      uint8_t resize, bool fixedAspect);

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1457,7 +1457,7 @@ float Interpreter::AdjXForAspectRatio(float x) const {
     // Skip widescreen adjustment for fixed-size off-screen FBs (HUD elements,
     // small capture buffers). But resizable FBs (resize=true) are capturing
     // the main scene and should match the window's aspect ratio.
-    if (mFbActive && mActiveFrameBuffer != mFrameBuffers.end() && !mActiveFrameBuffer->second.resize) {
+    if (mFbActive && mActiveFrameBuffer != mFrameBuffers.end() && !mActiveFrameBuffer->second.fixedAspect) {
         return x;
     } else {
         return x * (4.0f / 3.0f) / ((float)mCurDimensions.width / (float)mCurDimensions.height);
@@ -5064,7 +5064,7 @@ void Interpreter::SetMaxFrameLatency(int latency) {
 }
 
 int Interpreter::CreateFrameBuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height,
-                                   uint8_t resize) {
+                                   uint8_t resize, bool fixedAspect) {
     uint32_t orig_width = width, orig_height = height;
     if (resize) {
         AdjustWidthHeightForScale(width, height, native_width, native_height);
@@ -5074,7 +5074,7 @@ int Interpreter::CreateFrameBuffer(uint32_t width, uint32_t height, uint32_t nat
     mRapi->UpdateFramebufferParameters(fb, width, height, 1, true, true, true, true);
 
     mFrameBuffers[fb] = {
-        orig_width, orig_height, width, height, native_width, native_height, static_cast<bool>(resize)
+        orig_width, orig_height, width, height, native_width, native_height, static_cast<bool>(resize), fixedAspect
     };
     return fb;
 }
@@ -5323,8 +5323,8 @@ void gfx_cc_get_features(uint64_t shader_id0, uint64_t shader_id1, struct CCFeat
 }
 
 extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height,
-                                      uint8_t resize) {
-    return Fast::mInstance.lock().get()->CreateFrameBuffer(width, height, native_width, native_height, resize);
+                                      uint8_t resize, bool fixedAspect) {
+    return Fast::mInstance.lock().get()->CreateFrameBuffer(width, height, native_width, native_height, resize, fixedAspect);
 }
 
 extern "C" void gfx_texture_cache_clear() {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1456,7 +1456,7 @@ void Interpreter::GfxSpPopMatrix(uint32_t count) {
 float Interpreter::AdjXForAspectRatio(float x) const {
     // Skip widescreen adjustment for fixed-size off-screen FBs (HUD elements,
     // small capture buffers), or those which specify a fixed aspect ratio.
-    if (mFbActive && mActiveFrameBuffer != mFrameBuffers.end() && mActiveFrameBuffer->second.fixedAspect) {
+    if (mFbActive && mActiveFrameBuffer != mFrameBuffers.end() && (!mActiveFrameBuffer->second.resize || mActiveFrameBuffer->second.forceFixedAspect)) {
         return x;
     } else {
         return x * (4.0f / 3.0f) / ((float)mCurDimensions.width / (float)mCurDimensions.height);
@@ -5063,7 +5063,7 @@ void Interpreter::SetMaxFrameLatency(int latency) {
 }
 
 int Interpreter::CreateFrameBuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height,
-                                   uint8_t resize, bool fixedAspect) {
+                                   uint8_t resize, bool forceFixedAspect) {
     uint32_t orig_width = width, orig_height = height;
     if (resize) {
         AdjustWidthHeightForScale(width, height, native_width, native_height);
@@ -5073,7 +5073,7 @@ int Interpreter::CreateFrameBuffer(uint32_t width, uint32_t height, uint32_t nat
     mRapi->UpdateFramebufferParameters(fb, width, height, 1, true, true, true, true);
 
     mFrameBuffers[fb] = {
-        orig_width, orig_height, width, height, native_width, native_height, static_cast<bool>(resize), fixedAspect
+        orig_width, orig_height, width, height, native_width, native_height, static_cast<bool>(resize), forceFixedAspect
     };
     return fb;
 }
@@ -5322,9 +5322,9 @@ void gfx_cc_get_features(uint64_t shader_id0, uint64_t shader_id1, struct CCFeat
 }
 
 extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height,
-                                      uint8_t resize, bool fixedAspect) {
+                                      uint8_t resize, bool forceFixedAspect) {
     return Fast::mInstance.lock().get()->CreateFrameBuffer(width, height, native_width, native_height, resize,
-                                                           fixedAspect);
+                                                           forceFixedAspect);
 }
 
 extern "C" void gfx_texture_cache_clear() {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1455,9 +1455,8 @@ void Interpreter::GfxSpPopMatrix(uint32_t count) {
 
 float Interpreter::AdjXForAspectRatio(float x) const {
     // Skip widescreen adjustment for fixed-size off-screen FBs (HUD elements,
-    // small capture buffers). But resizable FBs (resize=true) are capturing
-    // the main scene and should match the window's aspect ratio.
-    if (mFbActive && mActiveFrameBuffer != mFrameBuffers.end() && !mActiveFrameBuffer->second.fixedAspect) {
+    // small capture buffers), or those which specify a fixed aspect ratio.
+    if (mFbActive && mActiveFrameBuffer != mFrameBuffers.end() && mActiveFrameBuffer->second.fixedAspect) {
         return x;
     } else {
         return x * (4.0f / 3.0f) / ((float)mCurDimensions.width / (float)mCurDimensions.height);

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1456,7 +1456,8 @@ void Interpreter::GfxSpPopMatrix(uint32_t count) {
 float Interpreter::AdjXForAspectRatio(float x) const {
     // Skip widescreen adjustment for fixed-size off-screen FBs (HUD elements,
     // small capture buffers), or those which specify a fixed aspect ratio.
-    if (mFbActive && mActiveFrameBuffer != mFrameBuffers.end() && (!mActiveFrameBuffer->second.resize || mActiveFrameBuffer->second.forceFixedAspect)) {
+    if (mFbActive && mActiveFrameBuffer != mFrameBuffers.end() &&
+        (!mActiveFrameBuffer->second.resize || mActiveFrameBuffer->second.forceFixedAspect)) {
         return x;
     } else {
         return x * (4.0f / 3.0f) / ((float)mCurDimensions.width / (float)mCurDimensions.height);

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -5324,7 +5324,8 @@ void gfx_cc_get_features(uint64_t shader_id0, uint64_t shader_id1, struct CCFeat
 
 extern "C" int gfx_create_framebuffer(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height,
                                       uint8_t resize, bool fixedAspect) {
-    return Fast::mInstance.lock().get()->CreateFrameBuffer(width, height, native_width, native_height, resize, fixedAspect);
+    return Fast::mInstance.lock().get()->CreateFrameBuffer(width, height, native_width, native_height, resize,
+                                                           fixedAspect);
 }
 
 extern "C" void gfx_texture_cache_clear() {


### PR DESCRIPTION
Recently AdjXForAspectRatio was change to not get applied if resize was on, assuming that any framebuffer that resizes would want to be adjusted for the current windows aspect ratio, however an edge case in ship1's pause menu wanted both a resized viewport (to be full rendering resolution) and a fixed aspect ratio (as it is portrayed in a fixed size part of the UI), causing incorrect rendering in widescreen. 

This PR address this issue by adding a new flag named fixedAspect which specifically controls AdjXForAspectRatio. When true this causes AdjXForAspectRatio to not run, similar to resize = false before. The existing functionality can be replicated by setting fixedAspect to the inverse of resize in gfx_create_framebuffer.

Ports will need to add the extra argument to each gfx_create_framebuffer call after this merges.