### PR TITLE
Bind imgui's gamepad backend to the controller libultraship is using

### DIFF
--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -133,6 +133,8 @@ class Fast3dGui : public Ship::Gui {
      */
     void LoadTextureFromResource(const std::string& name, std::shared_ptr<Ship::GuiTexture> texture);
 
+    void RefreshImGuiGamepads() override;
+
   protected:
     void ImGuiWMInit() override;
     void ImGuiWMShutdown() override;

--- a/include/ship/window/gui/Gui.h
+++ b/include/ship/window/gui/Gui.h
@@ -153,6 +153,11 @@ class Gui {
     /** @brief Re-enables ImGui gamepad navigation. */
     void UnblockGamepadNavigation();
 
+    /** @brief Re-binds the ImGui platform backend's gamepad list to the currently
+     *  connected controllers. Called once at init and on controller add/remove so it
+     *  is not re-evaluated per frame. The base implementation is a no-op. */
+    virtual void RefreshImGuiGamepads();
+
     /**
      * @brief Shuts down the ImGui context and releases backend resources.
      * @param window Pointer to the Window whose backend context should be torn down.

--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -10,6 +10,8 @@
 #include "ship/window/gui/resource/GuiTextureFactory.h"
 #include "ship/resource/File.h"
 
+#include <vector>
+
 #ifdef __APPLE__
 #include <SDL_hints.h>
 #include <SDL_video.h>
@@ -115,6 +117,9 @@ void Fast3dGui::ImGuiWMInit() {
         default:
             break;
     }
+
+    // Initial gamepad bind once the SDL2 backend exists (no-op for DX/Metal).
+    RefreshImGuiGamepads();
 }
 
 void Fast3dGui::ImGuiWMShutdown() {
@@ -239,6 +244,18 @@ void Fast3dGui::ImGuiWMNewFrame() {
         default:
             break;
     }
+}
+
+// Bind ImGui's SDL2 gamepad backend to the controller(s) the
+// ControlDeck has already opened
+void Fast3dGui::RefreshImGuiGamepads() {
+    auto window = Ship::Context::GetInstance()->GetWindow();
+    auto backend = window->GetWindowBackend();
+    if (backend != WindowBackend::FAST3D_SDL_OPENGL && backend != WindowBackend::FAST3D_SDL_METAL) {
+        return;
+    }
+
+    ImGui_ImplSDL2_SetGamepadMode(ImGui_ImplSDL2_GamepadMode_AutoAll, nullptr, 0);
 }
 
 void Fast3dGui::ImGuiRenderDrawData(ImDrawData* data) {

--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -10,8 +10,6 @@
 #include "ship/window/gui/resource/GuiTextureFactory.h"
 #include "ship/resource/File.h"
 
-#include <vector>
-
 #ifdef __APPLE__
 #include <SDL_hints.h>
 #include <SDL_video.h>

--- a/src/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.cpp
+++ b/src/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.cpp
@@ -2,6 +2,8 @@
 #include <SDL2/SDL.h>
 #include "ship/Context.h"
 #include "ship/controller/controldeck/ControlDeck.h"
+#include "ship/window/Window.h"
+#include "ship/window/gui/Gui.h"
 
 namespace Ship {
 
@@ -17,11 +19,13 @@ void SDLAddRemoveDeviceEventHandler::DrawElement() {
 void SDLAddRemoveDeviceEventHandler::UpdateElement() {
     SDL_PumpEvents();
     SDL_Event event;
+    bool changed = false;
     while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_CONTROLLERDEVICEADDED, SDL_CONTROLLERDEVICEADDED) > 0) {
         // from https://wiki.libsdl.org/SDL2/SDL_ControllerDeviceEvent: which - the joystick device index for
         // the SDL_CONTROLLERDEVICEADDED event
         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->HandlePhysicalDeviceConnect(
             event.cdevice.which);
+        changed = true;
     }
 
     while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_CONTROLLERDEVICEREMOVED, SDL_CONTROLLERDEVICEREMOVED) > 0) {
@@ -29,6 +33,16 @@ void SDLAddRemoveDeviceEventHandler::UpdateElement() {
         // SDL_CONTROLLERDEVICEREMOVED [...] event
         Context::GetInstance()->GetControlDeck()->GetConnectedPhysicalDeviceManager()->HandlePhysicalDeviceDisconnect(
             event.cdevice.which);
+        changed = true;
+    }
+
+    // The connected controller set changed, so re-point the ImGui gamepad
+    // backend at it (keeps menu navigation working across hotplug).
+    if (changed) {
+        auto window = Context::GetInstance()->GetWindow();
+        if (window != nullptr && window->GetGui() != nullptr) {
+            window->GetGui()->RefreshImGuiGamepads();
+        }
     }
 }
 } // namespace Ship

--- a/src/ship/window/gui/Gui.cpp
+++ b/src/ship/window/gui/Gui.cpp
@@ -161,6 +161,9 @@ void Gui::ImGuiBackendNewFrame() {
 void Gui::ImGuiWMNewFrame() {
 }
 
+void Gui::RefreshImGuiGamepads() {
+}
+
 void Gui::DrawMenu() {
     const std::shared_ptr<Window> wnd = Context::GetInstance()->GetWindow();
     const std::shared_ptr<Config> conf = Context::GetInstance()->GetConfig();


### PR DESCRIPTION
If multiple controllers are connected. imgui would use the first one it found. In the event the first controller isn't actually a controller, or isn't the one in use, ControlNav becomes impossible. Instead, use the same gamepad that ControlDeck has already opened.

cc @KiritoDv 