### PR TITLE
fix(crash): replace exit(1) in ShutdownHandler with SDL_QUIT event

### DIFF
--- a/src/ship/debug/CrashHandler.cpp
+++ b/src/ship/debug/CrashHandler.cpp
@@ -217,7 +217,9 @@ static void ErrorHandler(int sig, siginfo_t* sigInfo, void* data) {
 }
 
 static void ShutdownHandler(int sig, siginfo_t* sigInfo, void* data) {
-    exit(1);
+    SDL_Event event;
+    event.type = SDL_QUIT;
+    SDL_PushEvent(&event);
 }
 
 #elif _WIN32


### PR DESCRIPTION
Calling exit() from a signal handler is not async-signal-safe: it triggers C++ destructors and atexit handlers which try to acquire mutexes already held by audio threads, causing a deadlock that the OS aborts as a crash. Push SDL_QUIT instead so the main event loop shuts down cleanly via the existing Close() path.