### PR TITLE
Fix undefined shifts in the GBI macros and two divisions by zero

### DIFF
--- a/include/fast/lus_gbi.h
+++ b/include/fast/lus_gbi.h
@@ -164,8 +164,9 @@ constexpr int8_t RDP_G_TRI1_WIDE = OPCODE(0x49);
  */
 #define G_MAXFBZ 0x3fff /* 3b exp, 11b mantissa */
 
-#define GPACK_RGBA5551(r, g, b, a) ((((r) << 8) & 0xf800) | (((g) << 3) & 0x7c0) | (((b) >> 2) & 0x3e) | ((a)&0x1))
-#define GPACK_ZDZ(z, dz) ((z) << 2 | (dz))
+#define GPACK_RGBA5551(r, g, b, a) \
+    ((((u32)(r) << 8) & 0xf800) | (((u32)(g) << 3) & 0x7c0) | (((u32)(b) >> 2) & 0x3e) | ((u32)(a)&0x1))
+#define GPACK_ZDZ(z, dz) ((u32)(z) << 2 | (dz))
 
 /*
  * flags for G_SETGEOMETRYMODE
@@ -492,38 +493,38 @@ constexpr int8_t RDP_G_TRI1_WIDE = OPCODE(0x49);
 #define G_ZS_PRIM (1 << G_MDSFT_ZSRCSEL)
 
 /* G_SETOTHERMODE_L gSetRenderMode */
-#define AA_EN 0x8
-#define Z_CMP 0x10
-#define Z_UPD 0x20
-#define IM_RD 0x40
-#define CLR_ON_CVG 0x80
-#define CVG_DST_CLAMP 0
-#define CVG_DST_WRAP 0x100
-#define CVG_DST_FULL 0x200
-#define CVG_DST_SAVE 0x300
-#define ZMODE_OPA 0
-#define ZMODE_INTER 0x400
-#define ZMODE_XLU 0x800
-#define ZMODE_DEC 0xc00
-#define CVG_X_ALPHA 0x1000
-#define ALPHA_CVG_SEL 0x2000
-#define FORCE_BL 0x4000
-#define TEX_EDGE 0x0000 /* used to be 0x8000 */
+#define AA_EN 0x8u
+#define Z_CMP 0x10u
+#define Z_UPD 0x20u
+#define IM_RD 0x40u
+#define CLR_ON_CVG 0x80u
+#define CVG_DST_CLAMP 0u
+#define CVG_DST_WRAP 0x100u
+#define CVG_DST_FULL 0x200u
+#define CVG_DST_SAVE 0x300u
+#define ZMODE_OPA 0u
+#define ZMODE_INTER 0x400u
+#define ZMODE_XLU 0x800u
+#define ZMODE_DEC 0xc00u
+#define CVG_X_ALPHA 0x1000u
+#define ALPHA_CVG_SEL 0x2000u
+#define FORCE_BL 0x4000u
+#define TEX_EDGE 0x0000u /* used to be 0x8000 */
 
-#define G_BL_CLR_IN 0
-#define G_BL_CLR_MEM 1
-#define G_BL_CLR_BL 2
-#define G_BL_CLR_FOG 3
-#define G_BL_1MA 0
-#define G_BL_A_MEM 1
-#define G_BL_A_IN 0
-#define G_BL_A_FOG 1
-#define G_BL_A_SHADE 2
-#define G_BL_1 2
-#define G_BL_0 3
+#define G_BL_CLR_IN 0u
+#define G_BL_CLR_MEM 1u
+#define G_BL_CLR_BL 2u
+#define G_BL_CLR_FOG 3u
+#define G_BL_1MA 0u
+#define G_BL_A_MEM 1u
+#define G_BL_A_IN 0u
+#define G_BL_A_FOG 1u
+#define G_BL_A_SHADE 2u
+#define G_BL_1 2u
+#define G_BL_0 3u
 
-#define GBL_c1(m1a, m1b, m2a, m2b) (uint32_t)(m1a) << 30 | (m1b) << 26 | (m2a) << 22 | (m2b) << 18
-#define GBL_c2(m1a, m1b, m2a, m2b) (m1a) << 28 | (m1b) << 24 | (m2a) << 20 | (m2b) << 16
+#define GBL_c1(m1a, m1b, m2a, m2b) (uint32_t)(m1a) << 30u | (m1b) << 26u | (m2a) << 22u | (m2b) << 18u
+#define GBL_c2(m1a, m1b, m2a, m2b) (uint32_t)(m1a) << 28u | (m1b) << 24u | (m2a) << 20u | (m2b) << 16u
 
 #define RM_AA_ZB_OPA_SURF(clk)                                                  \
     AA_EN | Z_CMP | Z_UPD | IM_RD | CVG_DST_CLAMP | ZMODE_OPA | ALPHA_CVG_SEL | \

--- a/include/fast/lus_gbi.h
+++ b/include/fast/lus_gbi.h
@@ -133,8 +133,17 @@ constexpr int8_t RDP_G_TRI1_WIDE = OPCODE(0x49);
 #endif
 
 /* macros for command parsing: */
+#ifdef GDMACMD
+#undef GDMACMD
+#endif
 #define GDMACMD(x) (x)
-#define GIMMCMD(x) = OPCODE(G_IMMFIRST - (x))
+#ifdef GIMMCMD
+#undef GIMMCMD
+#endif
+#define GIMMCMD(x) OPCODE(G_IMMFIRST - (x))
+#ifdef GRDPCMD
+#undef GRDPCMD
+#endif
 #define GRDPCMD(x) (0xff - (x))
 
 #define G_DMACMDSIZ 128
@@ -164,8 +173,12 @@ constexpr int8_t RDP_G_TRI1_WIDE = OPCODE(0x49);
  */
 #define G_MAXFBZ 0x3fff /* 3b exp, 11b mantissa */
 
-#define GPACK_RGBA5551(r, g, b, a) ((((r) << 8) & 0xf800) | (((g) << 3) & 0x7c0) | (((b) >> 2) & 0x3e) | ((a)&0x1))
-#define GPACK_ZDZ(z, dz) ((z) << 2 | (dz))
+#ifdef GPACK_RGBA5551
+#undef GPACK_RGBA5551
+#endif
+#define GPACK_RGBA5551(r, g, b, a) \
+    ((((u32)(r) << 8) & 0xf800) | (((u32)(g) << 3) & 0x7c0) | (((u32)(b) >> 2) & 0x3e) | ((u32)(a) & 0x1))
+#define GPACK_ZDZ(z, dz) ((u32)(z) << 2 | (dz))
 
 /*
  * flags for G_SETGEOMETRYMODE
@@ -492,38 +505,38 @@ constexpr int8_t RDP_G_TRI1_WIDE = OPCODE(0x49);
 #define G_ZS_PRIM (1 << G_MDSFT_ZSRCSEL)
 
 /* G_SETOTHERMODE_L gSetRenderMode */
-#define AA_EN 0x8
-#define Z_CMP 0x10
-#define Z_UPD 0x20
-#define IM_RD 0x40
-#define CLR_ON_CVG 0x80
-#define CVG_DST_CLAMP 0
-#define CVG_DST_WRAP 0x100
-#define CVG_DST_FULL 0x200
-#define CVG_DST_SAVE 0x300
-#define ZMODE_OPA 0
-#define ZMODE_INTER 0x400
-#define ZMODE_XLU 0x800
-#define ZMODE_DEC 0xc00
-#define CVG_X_ALPHA 0x1000
-#define ALPHA_CVG_SEL 0x2000
-#define FORCE_BL 0x4000
-#define TEX_EDGE 0x0000 /* used to be 0x8000 */
+#define AA_EN 0x8u
+#define Z_CMP 0x10u
+#define Z_UPD 0x20u
+#define IM_RD 0x40u
+#define CLR_ON_CVG 0x80u
+#define CVG_DST_CLAMP 0u
+#define CVG_DST_WRAP 0x100u
+#define CVG_DST_FULL 0x200u
+#define CVG_DST_SAVE 0x300u
+#define ZMODE_OPA 0u
+#define ZMODE_INTER 0x400u
+#define ZMODE_XLU 0x800u
+#define ZMODE_DEC 0xc00u
+#define CVG_X_ALPHA 0x1000u
+#define ALPHA_CVG_SEL 0x2000u
+#define FORCE_BL 0x4000u
+#define TEX_EDGE 0x0000u /* used to be 0x8000 */
 
-#define G_BL_CLR_IN 0
-#define G_BL_CLR_MEM 1
-#define G_BL_CLR_BL 2
-#define G_BL_CLR_FOG 3
-#define G_BL_1MA 0
-#define G_BL_A_MEM 1
-#define G_BL_A_IN 0
-#define G_BL_A_FOG 1
-#define G_BL_A_SHADE 2
-#define G_BL_1 2
-#define G_BL_0 3
+#define G_BL_CLR_IN 0u
+#define G_BL_CLR_MEM 1u
+#define G_BL_CLR_BL 2u
+#define G_BL_CLR_FOG 3u
+#define G_BL_1MA 0u
+#define G_BL_A_MEM 1u
+#define G_BL_A_IN 0u
+#define G_BL_A_FOG 1u
+#define G_BL_A_SHADE 2u
+#define G_BL_1 2u
+#define G_BL_0 3u
 
-#define GBL_c1(m1a, m1b, m2a, m2b) (uint32_t)(m1a) << 30 | (m1b) << 26 | (m2a) << 22 | (m2b) << 18
-#define GBL_c2(m1a, m1b, m2a, m2b) (m1a) << 28 | (m1b) << 24 | (m2a) << 20 | (m2b) << 16
+#define GBL_c1(m1a, m1b, m2a, m2b) (uint32_t)(m1a) << 30u | (m1b) << 26u | (m2a) << 22u | (m2b) << 18u
+#define GBL_c2(m1a, m1b, m2a, m2b) (uint32_t)(m1a) << 28u | (m1b) << 24u | (m2a) << 20u | (m2b) << 16u
 
 #define RM_AA_ZB_OPA_SURF(clk)                                                  \
     AA_EN | Z_CMP | Z_UPD | IM_RD | CVG_DST_CLAMP | ZMODE_OPA | ALPHA_CVG_SEL | \
@@ -1344,8 +1357,15 @@ typedef struct {
     unsigned int mask;             /* STATE mask  */
 } F3DuObjTxtrTile_t;               /* 24 bytes */
 
+#ifdef GS_PAL_HEAD
+#undef GS_PAL_HEAD
+#endif
 #define GS_PAL_HEAD(head) ((head) + 256)
-#define GS_PAL_NUM(num) ((num)-1)
+
+#ifdef GS_PAL_NUM
+#undef GS_PAL_NUM
+#endif
+#define GS_PAL_NUM(num) ((num) - 1)
 
 typedef struct {
     unsigned int type;             /* G_OBJLT_TLUT divided into types */

--- a/include/libultraship/libultra/controller.h
+++ b/include/libultraship/libultra/controller.h
@@ -61,28 +61,28 @@
 #endif
 
 /* Buttons */
-#define BTN_CRIGHT 0x00001
-#define BTN_CLEFT 0x00002
-#define BTN_CDOWN 0x00004
-#define BTN_CUP 0x00008
-#define BTN_R 0x00010
-#define BTN_L 0x00020
-#define BTN_DRIGHT 0x00100
-#define BTN_DLEFT 0x00200
-#define BTN_DDOWN 0x00400
-#define BTN_DUP 0x00800
-#define BTN_START 0x01000
-#define BTN_Z 0x02000
-#define BTN_B 0x04000
-#define BTN_A 0x08000
-#define BTN_STICKLEFT 0x10000
-#define BTN_STICKRIGHT 0x20000
-#define BTN_STICKDOWN 0x40000
-#define BTN_STICKUP 0x80000
-#define BTN_VSTICKUP 0x100000
-#define BTN_VSTICKDOWN 0x200000
-#define BTN_VSTICKLEFT 0x400000
-#define BTN_VSTICKRIGHT 0x800000
+#define BTN_CRIGHT 0x00001u
+#define BTN_CLEFT 0x00002u
+#define BTN_CDOWN 0x00004u
+#define BTN_CUP 0x00008u
+#define BTN_R 0x00010u
+#define BTN_L 0x00020u
+#define BTN_DRIGHT 0x00100u
+#define BTN_DLEFT 0x00200u
+#define BTN_DDOWN 0x00400u
+#define BTN_DUP 0x00800u
+#define BTN_START 0x01000u
+#define BTN_Z 0x02000u
+#define BTN_B 0x04000u
+#define BTN_A 0x08000u
+#define BTN_STICKLEFT 0x10000u
+#define BTN_STICKRIGHT 0x20000u
+#define BTN_STICKDOWN 0x40000u
+#define BTN_STICKUP 0x80000u
+#define BTN_VSTICKUP 0x100000u
+#define BTN_VSTICKDOWN 0x200000u
+#define BTN_VSTICKLEFT 0x400000u
+#define BTN_VSTICKRIGHT 0x800000u
 
 typedef struct {
     /* 0x00 */ int32_t ram[15];

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -286,8 +286,9 @@
  */
 #define G_MAXFBZ 0x3fff /* 3b exp, 11b mantissa */
 
-#define GPACK_RGBA5551(r, g, b, a) ((((r) << 8) & 0xf800) | (((g) << 3) & 0x7c0) | (((b) >> 2) & 0x3e) | ((a)&0x1))
-#define GPACK_ZDZ(z, dz) ((z) << 2 | (dz))
+#define GPACK_RGBA5551(r, g, b, a) \
+    ((((u32)(r) << 8) & 0xf800) | (((u32)(g) << 3) & 0x7c0) | (((u32)(b) >> 2) & 0x3e) | ((u32)(a)&0x1))
+#define GPACK_ZDZ(z, dz) ((u32)(z) << 2 | (dz))
 
 /*
  * G_MTX: parameter flags
@@ -654,38 +655,38 @@
 #define G_ZS_PRIM (1 << G_MDSFT_ZSRCSEL)
 
 /* G_SETOTHERMODE_L gSetRenderMode */
-#define AA_EN 0x8
-#define Z_CMP 0x10
-#define Z_UPD 0x20
-#define IM_RD 0x40
-#define CLR_ON_CVG 0x80
-#define CVG_DST_CLAMP 0
-#define CVG_DST_WRAP 0x100
-#define CVG_DST_FULL 0x200
-#define CVG_DST_SAVE 0x300
-#define ZMODE_OPA 0
-#define ZMODE_INTER 0x400
-#define ZMODE_XLU 0x800
-#define ZMODE_DEC 0xc00
-#define CVG_X_ALPHA 0x1000
-#define ALPHA_CVG_SEL 0x2000
-#define FORCE_BL 0x4000
-#define TEX_EDGE 0x0000 /* used to be 0x8000 */
+#define AA_EN 0x8u
+#define Z_CMP 0x10u
+#define Z_UPD 0x20u
+#define IM_RD 0x40u
+#define CLR_ON_CVG 0x80u
+#define CVG_DST_CLAMP 0u
+#define CVG_DST_WRAP 0x100u
+#define CVG_DST_FULL 0x200u
+#define CVG_DST_SAVE 0x300u
+#define ZMODE_OPA 0u
+#define ZMODE_INTER 0x400u
+#define ZMODE_XLU 0x800u
+#define ZMODE_DEC 0xc00u
+#define CVG_X_ALPHA 0x1000u
+#define ALPHA_CVG_SEL 0x2000u
+#define FORCE_BL 0x4000u
+#define TEX_EDGE 0x0000u /* used to be 0x8000 */
 
-#define G_BL_CLR_IN 0
-#define G_BL_CLR_MEM 1
-#define G_BL_CLR_BL 2
-#define G_BL_CLR_FOG 3
-#define G_BL_1MA 0
-#define G_BL_A_MEM 1
-#define G_BL_A_IN 0
-#define G_BL_A_FOG 1
-#define G_BL_A_SHADE 2
-#define G_BL_1 2
-#define G_BL_0 3
+#define G_BL_CLR_IN 0u
+#define G_BL_CLR_MEM 1u
+#define G_BL_CLR_BL 2u
+#define G_BL_CLR_FOG 3u
+#define G_BL_1MA 0u
+#define G_BL_A_MEM 1u
+#define G_BL_A_IN 0u
+#define G_BL_A_FOG 1u
+#define G_BL_A_SHADE 2u
+#define G_BL_1 2u
+#define G_BL_0 3u
 
-#define GBL_c1(m1a, m1b, m2a, m2b) (uint32_t)(m1a) << 30 | (m1b) << 26 | (m2a) << 22 | (m2b) << 18
-#define GBL_c2(m1a, m1b, m2a, m2b) (m1a) << 28 | (m1b) << 24 | (m2a) << 20 | (m2b) << 16
+#define GBL_c1(m1a, m1b, m2a, m2b) (uint32_t)(m1a) << 30u | (m1b) << 26u | (m2a) << 22u | (m2b) << 18u
+#define GBL_c2(m1a, m1b, m2a, m2b) (uint32_t)(m1a) << 28u | (m1b) << 24u | (m2a) << 20u | (m2b) << 16u
 
 #define RM_AA_ZB_OPA_SURF(clk)                                                  \
     AA_EN | Z_CMP | Z_UPD | IM_RD | CVG_DST_CLAMP | ZMODE_OPA | ALPHA_CVG_SEL | \

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -286,8 +286,8 @@
  */
 #define G_MAXFBZ 0x3fff /* 3b exp, 11b mantissa */
 
-#define GPACK_RGBA5551(r, g, b, a) ((((r) << 8) & 0xf800) | (((g) << 3) & 0x7c0) | (((b) >> 2) & 0x3e) | ((a)&0x1))
-#define GPACK_ZDZ(z, dz) ((z) << 2 | (dz))
+#define GPACK_RGBA5551(r, g, b, a) ((((u32)(r) << 8) & 0xf800) | (((u32)(g) << 3) & 0x7c0) | (((u32)(b) >> 2) & 0x3e) | ((u32)(a)&0x1))
+#define GPACK_ZDZ(z, dz) ((u32)(z) << 2 | (dz))
 
 /*
  * G_MTX: parameter flags
@@ -654,38 +654,38 @@
 #define G_ZS_PRIM (1 << G_MDSFT_ZSRCSEL)
 
 /* G_SETOTHERMODE_L gSetRenderMode */
-#define AA_EN 0x8
-#define Z_CMP 0x10
-#define Z_UPD 0x20
-#define IM_RD 0x40
-#define CLR_ON_CVG 0x80
-#define CVG_DST_CLAMP 0
-#define CVG_DST_WRAP 0x100
-#define CVG_DST_FULL 0x200
-#define CVG_DST_SAVE 0x300
-#define ZMODE_OPA 0
-#define ZMODE_INTER 0x400
-#define ZMODE_XLU 0x800
-#define ZMODE_DEC 0xc00
-#define CVG_X_ALPHA 0x1000
-#define ALPHA_CVG_SEL 0x2000
-#define FORCE_BL 0x4000
-#define TEX_EDGE 0x0000 /* used to be 0x8000 */
+#define AA_EN 0x8u
+#define Z_CMP 0x10u
+#define Z_UPD 0x20u
+#define IM_RD 0x40u
+#define CLR_ON_CVG 0x80u
+#define CVG_DST_CLAMP 0u
+#define CVG_DST_WRAP 0x100u
+#define CVG_DST_FULL 0x200u
+#define CVG_DST_SAVE 0x300u
+#define ZMODE_OPA 0u
+#define ZMODE_INTER 0x400u
+#define ZMODE_XLU 0x800u
+#define ZMODE_DEC 0xc00u
+#define CVG_X_ALPHA 0x1000u
+#define ALPHA_CVG_SEL 0x2000u
+#define FORCE_BL 0x4000u
+#define TEX_EDGE 0x0000u /* used to be 0x8000 */
 
-#define G_BL_CLR_IN 0
-#define G_BL_CLR_MEM 1
-#define G_BL_CLR_BL 2
-#define G_BL_CLR_FOG 3
-#define G_BL_1MA 0
-#define G_BL_A_MEM 1
-#define G_BL_A_IN 0
-#define G_BL_A_FOG 1
-#define G_BL_A_SHADE 2
-#define G_BL_1 2
-#define G_BL_0 3
+#define G_BL_CLR_IN 0u
+#define G_BL_CLR_MEM 1u
+#define G_BL_CLR_BL 2u
+#define G_BL_CLR_FOG 3u
+#define G_BL_1MA 0u
+#define G_BL_A_MEM 1u
+#define G_BL_A_IN 0u
+#define G_BL_A_FOG 1u
+#define G_BL_A_SHADE 2u
+#define G_BL_1 2u
+#define G_BL_0 3u
 
-#define GBL_c1(m1a, m1b, m2a, m2b) (uint32_t)(m1a) << 30 | (m1b) << 26 | (m2a) << 22 | (m2b) << 18
-#define GBL_c2(m1a, m1b, m2a, m2b) (m1a) << 28 | (m1b) << 24 | (m2a) << 20 | (m2b) << 16
+#define GBL_c1(m1a, m1b, m2a, m2b) (uint32_t)(m1a) << 30u | (m1b) << 26u | (m2a) << 22u | (m2b) << 18u
+#define GBL_c2(m1a, m1b, m2a, m2b) (uint32_t)(m1a) << 28u | (m1b) << 24u | (m2a) << 20u | (m2b) << 16u
 
 #define RM_AA_ZB_OPA_SURF(clk)                                                  \
     AA_EN | Z_CMP | Z_UPD | IM_RD | CVG_DST_CLAMP | ZMODE_OPA | ALPHA_CVG_SEL | \

--- a/include/libultraship/libultra/mbi.h
+++ b/include/libultraship/libultra/mbi.h
@@ -23,8 +23,8 @@
  * (NOTE: _SHIFTL(v, 0, 32) won't work, just use an assignment)
  *
  */
-#define _SHIFTL(v, s, w) ((u32)(((u32)(v) & ((0x01 << (w)) - 1)) << (s)))
-#define _SHIFTR(v, s, w) ((u32)(((u32)(v) >> (s)) & ((0x01 << (w)) - 1)))
+#define _SHIFTL(v, s, w) ((u32)(((u32)(v) & ((0x01u << (w)) - 1)) << (s)))
+#define _SHIFTR(v, s, w) ((u32)(((u32)(v) >> (s)) & ((0x01u << (w)) - 1u)))
 
 #define G_ON (1)
 #define G_OFF (0)

--- a/include/libultraship/libultra/mbi.h
+++ b/include/libultraship/libultra/mbi.h
@@ -23,8 +23,8 @@
  * (NOTE: _SHIFTL(v, 0, 32) won't work, just use an assignment)
  *
  */
-#define _SHIFTL(v, s, w) ((u32)(((u32)(v) & ((0x01 << (w)) - 1)) << (s)))
-#define _SHIFTR(v, s, w) ((u32)(((u32)(v) >> (s)) & ((0x01 << (w)) - 1)))
+#define _SHIFTL(v, s, w) ((u32)(((u32)(v) & ((0x01u << (w)) - 1u)) << (s)))
+#define _SHIFTR(v, s, w) ((u32)(((u32)(v) >> (s)) & ((0x01u << (w)) - 1u)))
 
 #define G_ON (1)
 #define G_OFF (0)

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1353,10 +1353,25 @@ void Interpreter::ImportTextureMask(int i, int tile) {
 }
 
 void Interpreter::NormalizeVector(float v[3]) {
-    float s = sqrtf(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
-    v[0] /= s;
-    v[1] /= s;
-    v[2] /= s;
+    constexpr float kEpsilon = 1e-8f;
+
+    float s = sqrtf(
+        v[0] * v[0] +
+        v[1] * v[1] +
+        v[2] * v[2]
+    );
+
+    if (s > kEpsilon) {
+        float inv = 1.0f / s;
+
+        v[0] *= inv;
+        v[1] *= inv;
+        v[2] *= inv;
+    } else {
+        v[0] = 0.0f;
+        v[1] = 0.0f;
+        v[2] = 0.0f;
+    }
 }
 
 void Interpreter::TransposedMatrixMul(float res[3], const float a[3], const float b[4][4]) {
@@ -1909,8 +1924,8 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             }
             tex_width[i] = line_size;
 
-            tex_width2[i] = (uint32_t)(int32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
-            tex_height2[i] = (uint32_t)(int32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+            tex_width2[i] = std::lrintf(std::max((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4.f) / 4.f, 1.f));
+            tex_height2[i] = std::lrintf(std::max((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4.f) / 4.f, 1.f));
 
             // Same pyramid-like ratio gate as ImportTexture: only clamp when loaded pixels
             // are close to rendered pixels (mipmap), not when much bigger (window scroll).
@@ -2028,8 +2043,11 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
                 }
             }
 
-            mBufVbo[mBufVboLen++] = u / tex_width[t];
-            mBufVbo[mBufVboLen++] = v / tex_height[t];
+            float invTexWidth = tex_width[t] != 0 ? 1.0f / tex_width[t] : 0.0f;
+            float invTexHeight = tex_height[t] != 0 ? 1.0f / tex_height[t] : 0.0f;
+
+            mBufVbo[mBufVboLen++] = u * invTexWidth;
+            mBufVbo[mBufVboLen++] = v * invTexHeight;
 
             bool clampS = tm & (1 << 2 * t);
             bool clampT = tm & (1 << 2 * t + 1);

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1367,6 +1367,12 @@ void Interpreter::ImportTextureMask(int i, int tile) {
 
 void Interpreter::NormalizeVector(float v[3]) {
     float s = sqrtf(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    if (s == 0.0f) {
+        // A zero-length normal has no direction to preserve, and dividing by it would put NaN into
+        // the lighting maths downstream.
+        v[0] = v[1] = v[2] = 0.0f;
+        return;
+    }
     v[0] /= s;
     v[1] /= s;
     v[2] /= s;
@@ -2041,8 +2047,10 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
                 }
             }
 
-            mBufVbo[mBufVboLen++] = u / tex_width[t];
-            mBufVbo[mBufVboLen++] = v / tex_height[t];
+            // A tile that was never loaded reports a zero size; normalising against it would put
+            // inf or NaN into the vertex buffer.
+            mBufVbo[mBufVboLen++] = tex_width[t] != 0 ? u / tex_width[t] : 0.0f;
+            mBufVbo[mBufVboLen++] = tex_height[t] != 0 ? v / tex_height[t] : 0.0f;
 
             bool clampS = tm & (1 << 2 * t);
             bool clampT = tm & (1 << 2 * t + 1);


### PR DESCRIPTION
Two UB fixes found with UBSan. Rebased onto current `main` and cut down from the original catch-all, which was too broad to review.

**Unsigned bit macros.** `_SHIFTL(1, 0, 31)` evaluates `0x01 << 31` in `int`, overflows, then subtracts 1 from the result - two UBSan reports out of one macro (`left shift of 1 by 31 places cannot be represented in type 'int'`). The render mode flags, the blend macros and the button masks have the same problem at bit 31. Suffixing the constants with `u` puts the arithmetic where the wrap is defined.

Every value these macros expand to is unchanged - checked, not assumed: a program expanding `G_RM_*`, `GBL_c1`/`GBL_c2`, `GPACK_*`, `_SHIFTL`/`_SHIFTR` and `BTN_*` gives byte-identical output built against `main` and against this branch.

**Two divisions by zero.** A zero-length normal made `NormalizeVector` hand NaN to the lighting maths; a tile that was never loaded reports size zero, so the UV normalisation in `GfxSpTri1` put inf or NaN into the vertex buffer. Neither has a direction or scale worth preserving, so both fall back to zero.

Dropped from the original: the `tex_width2`/`tex_height2` rounding change - it clamps to a minimum of 1, which makes the `renderedPx > 0` gate below it fire where it currently skips, so it is a rendering change needing its own testing - plus the `#undef` blocks and the whitespace churn.
