### PR TITLE
audio: optional float pipeline end-to-end (opt-in, s16 default)

### DIFF
--- a/include/libultraship/bridge/audiobridge.h
+++ b/include/libultraship/bridge/audiobridge.h
@@ -22,12 +22,29 @@ API_EXPORT AudioChannelsSetting GetAudioChannels();
 API_EXPORT int32_t GetNumAudioChannels();
 
 /**
- * @brief Submits a frame of PCM audio to the audio output device.
+ * @brief Submits a frame of s16 PCM audio to the audio output device (legacy).
+ *
+ * Default entry point preserved for libultraship consumers on the s16
+ * audio path. Forwards to AudioPlayer::Play(uint8_t*, size_t); valid only
+ * when the player is in s16 mode (the default).
  *
  * @param buf Interleaved sample data (stereo: L,R,… or surround: FL,FR,C,LFE,SL,SR,…).
  * @param len Length of @p buf in bytes.
  */
 API_EXPORT void AudioPlayerPlayFrame(const uint8_t* buf, size_t len);
+
+/**
+ * @brief Submits a frame of float PCM audio to the audio output device.
+ *
+ * Float-pipeline entry point. Valid only when the player has been switched
+ * to float mode (see AudioPlayer::SetUseFloatPipeline). The full audio
+ * path — resample / optional mix-source sum / surround decode — runs in
+ * float at the device's output rate.
+ *
+ * @param buf Interleaved stereo float samples (L, R, L, R, …) in nominal [-1, 1] range.
+ * @param frames Number of stereo frames in @p buf.
+ */
+API_EXPORT void AudioPlayerPlayFrameF32(const float* buf, size_t frames);
 
 /**
  * @brief Changes the audio channel configuration at runtime.

--- a/include/ship/audio/Audio.h
+++ b/include/ship/audio/Audio.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+#include <functional>
 #include <string>
 #include <memory>
 #include <vector>
@@ -68,6 +70,33 @@ class Audio {
      */
     AudioChannelsSetting GetAudioChannels() const;
 
+    /** @brief Returns whether the float (HD) audio pipeline is currently active. */
+    bool IsUsingFloatPipeline() const;
+
+    /**
+     * @brief Single authority for the float-pipeline mode.
+     *
+     * Updates the live flag, the settings new players inherit, and the current
+     * player (reopening its device in the matching format). Everything else --
+     * the producer's PlayF32-vs-Play choice and any newly constructed player --
+     * derives from this, so there is exactly one place the mode is owned.
+     *
+     * @return true if applied; false if the current player refused float mode
+     *         (in which case the authority is reverted to the player's actual mode).
+     */
+    bool SetUseFloatPipeline(bool enabled);
+
+    /**
+     * @brief Registers a callback invoked whenever a new AudioPlayer is
+     * initialised (backend switch, fallback to Null, startup).
+     *
+     * The new player already inherits the float-pipeline mode; this hook exists
+     * so the host can re-attach instance-bound state the player cannot carry
+     * across a rebuild (e.g. a FluidSynth mix source). Pass an empty function to
+     * clear it.
+     */
+    void SetOnAudioPlayerInitialized(std::function<void()> callback);
+
   protected:
     /** @brief (Re)initialises the AudioPlayer for the current backend and channel settings. */
     void InitAudioPlayer();
@@ -95,5 +124,11 @@ class Audio {
     AudioSettings mAudioSettings;
     std::shared_ptr<std::vector<AudioBackend>> mAvailableAudioBackends;
     std::shared_ptr<Config> mConfig;
+
+    // Single source of truth for the float-pipeline mode. Lock-free so the audio
+    // producer can read it cheaply; written only by SetUseFloatPipeline, which
+    // also mirrors it into mAudioSettings (the template new players inherit).
+    std::atomic<bool> mUseFloatPipeline{ false };
+    std::function<void()> mOnAudioPlayerInitialized;
 };
 } // namespace Ship

--- a/include/ship/audio/AudioPlayer.h
+++ b/include/ship/audio/AudioPlayer.h
@@ -3,6 +3,7 @@
 #include "stddef.h"
 #include <string>
 #include <memory>
+#include <functional>
 #include "ship/audio/AudioChannelsSetting.h"
 #include "ship/audio/AudioResampler.h"
 #include "ship/audio/SoundMatrixDecoder.h"
@@ -19,6 +20,14 @@ struct AudioSettings {
     int32_t DesiredBuffered = 2480; ///< Target number of frames to keep buffered.
     AudioChannelsSetting ChannelSetting =
         AudioChannelsSetting::audioStereo; ///< Channel mode (stereo / 5.1 matrix / 5.1 raw).
+
+    /// When true, the AudioPlayer pipeline (Play / resampler / matrix decoder
+    /// / backend device format) runs in 32-bit float. Enables the optional
+    /// MixSource hook for sources rendered at the device output rate. When
+    /// false (default), the pipeline is interleaved int16 — same byte layout
+    /// and entry points the AudioPlayer always had, so existing libultraship
+    /// consumers keep working with no code change.
+    bool UseFloatPipeline = false;
 };
 
 /**
@@ -57,18 +66,32 @@ class AudioPlayer {
     virtual int32_t Buffered() = 0;
 
     /**
-     * @brief Submits a frame of PCM audio to the output device.
+     * @brief Submits a frame of PCM audio to the output device — legacy s16 path.
      *
-     * If 5.1 surround output is configured and the channel setting requires matrix
-     * decoding, the stereo @p buf is first decoded to 6-channel surround before
-     * being passed to DoPlay().
+     * Default entry point preserved for libultraship consumers. Samples are
+     * interleaved signed 16-bit; the legacy resampler / matrix-decoder
+     * boundaries do the (lossy) s16↔float conversions internally. Calls
+     * here when @c UseFloatPipeline is true are a configuration mistake
+     * and emit a warning + drop the buffer.
      *
-     * @param buf Interleaved samples:
-     *            - Stereo: (L, R, L, R, …)
-     *            - 5.1:    (FL, FR, C, LFE, SL, SR, …)
+     * @param buf Interleaved s16 samples (Stereo: (L,R,…); 5.1: (FL,FR,C,LFE,SL,SR,…)).
      * @param len Length of @p buf in bytes.
      */
     void Play(const uint8_t* buf, size_t len);
+
+    /**
+     * @brief Submits a frame of PCM audio to the output device — float pipeline.
+     *
+     * Only valid when @c UseFloatPipeline is true. The audio path stays in
+     * 32-bit float through resample, optional MixSource summing + soft-clip,
+     * surround decode, and into the backend. The MixSource (if set) runs at
+     * the device output rate, so any secondary source can render at native
+     * device quality without traversing the resampler.
+     *
+     * @param buf Interleaved stereo float samples in nominal [-1, 1].
+     * @param frames Number of stereo frames in @p buf.
+     */
+    void Play(const float* buf, size_t frames);
 
     /** @brief Returns true if Init() has been called and succeeded. */
     bool IsInitialized();
@@ -129,6 +152,49 @@ class AudioPlayer {
      */
     int32_t GetNumOutputChannels() const;
 
+    /**
+     * @brief Callback signature for a secondary stereo audio source mixed in
+     *        after the resampler.
+     *
+     * The callback fills @p stereoOut with @p frames frames of interleaved
+     * stereo float at the device's output rate (GetSampleRate()), which
+     * lets the source bypass the resampler entirely — the resampler runs
+     * only over the primary input stream. The mix sums the two sources
+     * with a tanh-style soft-clip before surround decoding (if any).
+     */
+    using MixSource = std::function<void(float* stereoOut, int frames)>;
+
+    /**
+     * @brief Installs a secondary audio source whose contribution is mixed
+     *        in at the output rate, post-resampler.
+     *
+     * Only meaningful when @c UseFloatPipeline is true (the s16 legacy path
+     * has no mix step). Pass @c nullptr to remove the source. Thread-safe
+     * with respect to the audio thread only in the sense that
+     * std::function assignment is sequentially consistent on x86; callers
+     * in practice swap this once at synth install/teardown.
+     *
+     * @return true if accepted; false (and ignored) when the player is in
+     *         the s16 legacy mode.
+     */
+    bool SetMixSource(MixSource source);
+
+    /**
+     * @brief Switches the pipeline between legacy s16 and float HD modes
+     *        at runtime.
+     *
+     * Closes the audio device, updates @c UseFloatPipeline, and reopens
+     * the device with the matching format. The Play overload that matches
+     * the new mode is the only one valid until the next switch.
+     *
+     * @return true if the device successfully reinitialised in the new
+     *         mode. On failure the previous mode is restored.
+     */
+    bool SetUseFloatPipeline(bool enabled);
+
+    /** @brief Returns whether the float pipeline mode is active. */
+    bool IsUsingFloatPipeline() const { return mAudioSettings.UseFloatPipeline; }
+
   protected:
     /**
      * @brief Opens and configures the platform audio device.
@@ -157,17 +223,32 @@ class AudioPlayer {
     virtual void DoPlay(const uint8_t* buf, size_t len) = 0;
 
   private:
+    /// Picks the right channel count (stereo for float mode, output channel
+    /// count for legacy s16 mode) and (re)constructs mResampler. No-op when
+    /// the rates already match.
+    void RebuildResampler();
+
     std::unique_ptr<SoundMatrixDecoder>
         mSoundMatrixDecoder; ///< Stereo-to-surround decoder (active in matrix-5.1 mode).
     std::unique_ptr<AudioResampler> mResampler;
 
-    // Fixed-size resample output buffer — no heap allocation on the audio hot path.
-    // Sized for the worst-case ratio and maximum channel count:
-    // ceil(SampleLength * maxOutRate / minInRate) * maxChannels
-    // e.g. 32k→48k, SampleLength=1024, 6ch: ceil(1024 * 3/2) * 6 = 9216
-    // 16384 gives comfortable headroom for other ratios (e.g. 32k→96k * 6ch = 18432 — increase if needed).
+    // Fixed-size scratch buffers — no heap allocation on the audio hot path.
+    // Sized for the worst-case ratio and channel count of the data the buffer
+    // holds at its stage. mResampleBuf holds *stereo* output-rate frames
+    // (resample step), so 2 channels suffice; mMixSourceBuf likewise holds
+    // stereo frames the secondary source writes into. mSurroundBuf is sized
+    // for 6 channels of output-rate frames (matrix-5.1 final output) so the
+    // decoder has somewhere to write before DoPlay. 16384 gives comfortable
+    // headroom for 32k→48k @ SampleLength=1024 (ceil(1024 * 3/2) * 6 = 9216)
+    // and for higher device rates (e.g. 32k→96k).
     static constexpr size_t kResampleBufSamples = 16384;
-    std::array<int16_t, kResampleBufSamples> mResampleBuf{};
+    std::array<float, kResampleBufSamples> mResampleBuf{};
+    std::array<float, kResampleBufSamples> mMixSourceBuf{};
+    // Legacy s16 path uses its own scratch so both code paths can coexist
+    // without retypeing the float buffer. 16384 × 2 B = 32 KB.
+    std::array<int16_t, kResampleBufSamples> mResampleBufS16{};
+
+    MixSource mMixSource;
 
     AudioSettings mAudioSettings;
     bool mInitialized = false;

--- a/include/ship/audio/AudioPlayer.h
+++ b/include/ship/audio/AudioPlayer.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <memory>
 #include "ship/audio/AudioChannelsSetting.h"
+#include "ship/audio/AudioResampler.h"
 #include "ship/audio/SoundMatrixDecoder.h"
 
 namespace Ship {
@@ -12,7 +13,8 @@ namespace Ship {
  * @brief Configuration parameters shared by all AudioPlayer backends.
  */
 struct AudioSettings {
-    int32_t SampleRate = 44100;     ///< Output sample rate in Hz.
+    int32_t SampleRate = 48000;     ///< Output sample rate in Hz.
+    int32_t SourceSampleRate = 0;   ///< Source sample rate in Hz. (0 = same as SampleRate, no resampling)
     int32_t SampleLength = 1024;    ///< Number of samples per audio frame.
     int32_t DesiredBuffered = 2480; ///< Target number of frames to keep buffered.
     AudioChannelsSetting ChannelSetting =
@@ -38,7 +40,7 @@ class AudioPlayer {
      */
     AudioPlayer(AudioSettings settings) : mAudioSettings(settings) {
     }
-    ~AudioPlayer();
+    virtual ~AudioPlayer();
 
     /**
      * @brief Calls DoInit() and sets the initialised flag on success.
@@ -74,6 +76,9 @@ class AudioPlayer {
     /** @brief Returns the configured output sample rate in Hz. */
     int32_t GetSampleRate() const;
 
+    /** @brief Returns the configured source sample rate in Hz. */
+    int32_t GetSourceSampleRate() const;
+
     /** @brief Returns the configured number of samples per audio frame. */
     int32_t GetSampleLength() const;
 
@@ -88,6 +93,12 @@ class AudioPlayer {
      * @param rate New sample rate in Hz.
      */
     void SetSampleRate(int32_t rate);
+
+    /**
+     * @brief Sets the source sample rate.
+     * @param rate New sample rate in Hz.
+     */
+    void SetSourceSampleRate(int32_t rate);
 
     /**
      * @brief Sets the number of samples per audio frame.
@@ -148,6 +159,15 @@ class AudioPlayer {
   private:
     std::unique_ptr<SoundMatrixDecoder>
         mSoundMatrixDecoder; ///< Stereo-to-surround decoder (active in matrix-5.1 mode).
+    std::unique_ptr<AudioResampler> mResampler;
+
+    // Fixed-size resample output buffer — no heap allocation on the audio hot path.
+    // Sized for the worst-case ratio and maximum channel count:
+    // ceil(SampleLength * maxOutRate / minInRate) * maxChannels
+    // e.g. 32k→48k, SampleLength=1024, 6ch: ceil(1024 * 3/2) * 6 = 9216
+    // 16384 gives comfortable headroom for other ratios (e.g. 32k→96k * 6ch = 18432 — increase if needed).
+    static constexpr size_t kResampleBufSamples = 16384;
+    std::array<int16_t, kResampleBufSamples> mResampleBuf{};
 
     AudioSettings mAudioSettings;
     bool mInitialized = false;

--- a/include/ship/audio/AudioResampler.h
+++ b/include/ship/audio/AudioResampler.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace Ship {
+
+/*
+ * AudioResampler — polyphase sinc resampler for integer ratios.
+ *
+ * Designed for the specific case of N64 audio upsampling from 32000 Hz
+ * to 48000 Hz (ratio 3/2 exact). Works for any integer ratio P/Q where
+ * P = outRate / gcd(outRate, inRate) and Q = inRate / gcd(outRate, inRate).
+ *
+ * Architecture:
+ *   - Polyphase decomposition of a windowed-sinc lowpass filter.
+ *   - Filter cutoff at min(inRate, outRate) / 2 to prevent aliasing.
+ *   - Kaiser window (beta=6) for a good stopband attenuation (~60 dB).
+ *   - For 32k→48k: P=3, Q=2, 8 taps per phase → 24 total filter coefficients.
+ *
+ * Usage:
+ *   AudioResampler r(32000, 48000, numChannels);
+ *   r.Process(inS16, inFrames, outS16, outFrames);
+ *
+ * Process() returns the number of output frames actually written.
+ * State (history samples) is preserved between calls for continuous streams.
+ */
+class AudioResampler {
+  public:
+    AudioResampler(int32_t inRate, int32_t outRate, int32_t numChannels);
+
+    /* Resample inFrames input frames into outBuf.
+     * Returns number of output frames written.
+     * outBuf must be large enough for ceil(inFrames * outRate / inRate) frames. */
+    int32_t Process(const int16_t* inBuf, int32_t inFrames, int16_t* outBuf, int32_t maxOutFrames);
+
+    /* Maximum output frames for a given number of input frames. */
+    int32_t MaxOutputFrames(int32_t inFrames) const;
+
+    /* Reset history (e.g. on stream discontinuity). */
+    void Reset();
+
+  private:
+    int32_t mInRate;
+    int32_t mOutRate;
+    int32_t mNumChannels;
+
+    /* Rational ratio P/Q after GCD reduction */
+    int32_t mP; /* upsample factor */
+    int32_t mQ; /* downsample factor */
+
+    /* Polyphase filter — mNumPhases phases × mTapsPerPhase taps */
+    static constexpr int kTapsPerPhase = 8;
+    int32_t mNumPhases;         /* = P */
+    std::vector<float> mCoeffs; /* [phase * kTapsPerPhase + tap] */
+
+    /* Current phase index in [0, P) */
+    int32_t mPhase;
+
+    /* History buffer: kTapsPerPhase-1 frames per channel for convolution state */
+    std::vector<float> mHistory; /* [(kTapsPerPhase-1) * numChannels] */
+
+    void BuildFilter();
+    static float BesselI0(float x);
+    static float KaiserWindow(int n, int N, float beta);
+    static float Sinc(float x);
+
+    static inline int32_t GCD(int32_t a, int32_t b) {
+        while (b) {
+            int32_t t = b;
+            b = a % b;
+            a = t;
+        }
+        return a;
+    }
+};
+
+} // namespace Ship

--- a/include/ship/audio/AudioResampler.h
+++ b/include/ship/audio/AudioResampler.h
@@ -20,10 +20,13 @@ namespace Ship {
  *
  * Usage:
  *   AudioResampler r(32000, 48000, numChannels);
- *   r.Process(inS16, inFrames, outS16, outFrames);
+ *   r.Process(inFloat, inFrames, outFloat, outFrames);
  *
  * Process() returns the number of output frames actually written.
  * State (history samples) is preserved between calls for continuous streams.
+ * Samples are interleaved float in nominal [-1, 1] range; the polyphase
+ * filter is unity-gain so peaks slightly above 1.0 may pass through and
+ * should be soft-clipped by the caller (or before reaching the backend).
  */
 class AudioResampler {
   public:
@@ -31,7 +34,16 @@ class AudioResampler {
 
     /* Resample inFrames input frames into outBuf.
      * Returns number of output frames written.
-     * outBuf must be large enough for ceil(inFrames * outRate / inRate) frames. */
+     * outBuf must be large enough for ceil(inFrames * outRate / inRate) frames.
+     *
+     * Two overloads:
+     *  - float in / float out is the canonical path used by the float audio
+     *    pipeline. Samples are interleaved float in nominal [-1, 1].
+     *  - int16_t in / int16_t out is the legacy entry point preserved for
+     *    libultraship consumers still on the s16 path. It converts at the
+     *    boundaries and clamps the output to the s16 range; the inner DSP
+     *    is identical (the filter coefficients live in float either way). */
+    int32_t Process(const float* inBuf, int32_t inFrames, float* outBuf, int32_t maxOutFrames);
     int32_t Process(const int16_t* inBuf, int32_t inFrames, int16_t* outBuf, int32_t maxOutFrames);
 
     /* Maximum output frames for a given number of input frames. */

--- a/include/ship/audio/CoreAudioAudioPlayer.h
+++ b/include/ship/audio/CoreAudioAudioPlayer.h
@@ -24,7 +24,7 @@ class CoreAudioAudioPlayer : public AudioPlayer {
      * @param settings Sample rate, buffer size, desired buffered frames, and channel mode.
      */
     CoreAudioAudioPlayer(AudioSettings settings);
-    ~CoreAudioAudioPlayer();
+    ~CoreAudioAudioPlayer() override;
 
     /**
      * @brief Returns the number of audio frames currently queued in the ring buffer.

--- a/include/ship/audio/NullAudioPlayer.h
+++ b/include/ship/audio/NullAudioPlayer.h
@@ -20,7 +20,7 @@ class NullAudioPlayer final : public AudioPlayer {
      */
     NullAudioPlayer(AudioSettings settings) : AudioPlayer(settings) {
     }
-    ~NullAudioPlayer();
+    ~NullAudioPlayer() override;
 
     /**
      * @brief Returns the desired buffered frame count so the game always produces audio.

--- a/include/ship/audio/SDLAudioPlayer.h
+++ b/include/ship/audio/SDLAudioPlayer.h
@@ -20,7 +20,7 @@ class SDLAudioPlayer final : public AudioPlayer {
      */
     SDLAudioPlayer(AudioSettings settings) : AudioPlayer(settings) {
     }
-    ~SDLAudioPlayer();
+    ~SDLAudioPlayer() override;
 
     /**
      * @brief Returns the number of audio frames currently queued in the SDL audio device.

--- a/include/ship/audio/SoundMatrixDecoder.h
+++ b/include/ship/audio/SoundMatrixDecoder.h
@@ -35,10 +35,21 @@ class SoundMatrixDecoder {
     void ResetState();
 
     /**
-     * Decode stereo to 5.1 surround
-     * @param stereoInput Interleaved stereo samples [L0, R0, L1, R1, ...]
-     * @param samplePairs Number of stereo sample pairs to process
-     * @return Pointer to internal buffer with interleaved 5.1 samples [FL, FR, C, LFE, SL, SR, ...]
+     * Decode stereo to 5.1 surround — float-pipeline entry point.
+     * @param stereoInput Interleaved stereo float samples [L0, R0, L1, R1, ...]
+     *                    in nominal [-1, 1] range.
+     * @param frames Number of stereo frames (sample pairs) to process.
+     * @return {pointer, frameCount} into the internal 6-channel float buffer
+     *         laid out as [FL, FR, C, LFE, SL, SR, ...].
+     */
+    std::tuple<const float*, int> Process(const float* stereoInput, size_t frames);
+
+    /**
+     * Decode stereo to 5.1 surround — legacy s16 entry point.
+     * Preserved byte-exactly for libultraship consumers on the s16 path.
+     * @param buf Interleaved s16 stereo samples, as bytes.
+     * @param len Length of @p buf in bytes.
+     * @return {pointer, byteLength} into the internal 6-channel s16 buffer.
      */
     std::tuple<const uint8_t*, int> Process(const uint8_t* buf, size_t len);
 
@@ -142,11 +153,17 @@ class SoundMatrixDecoder {
     float ProcessDelay(float sample, CircularDelay& buffer);
 
     /**
-     * @brief Clamps a floating-point sample to the int16_t range.
+     * @brief Soft-saturates a float sample to the nominal [-1, 1] range.
+     *
+     * The matrix mixer can briefly push peaks slightly above 1.0 when both
+     * channels are loud. A hard clip would produce harshness; the pipeline's
+     * soft-clip step handles dramatic over-budget peaks, so this helper just
+     * keeps the surround buffer numerically sane.
+     *
      * @param value Input sample value.
-     * @return Saturated 16-bit integer sample.
+     * @return Clamped float sample.
      */
-    static int16_t Saturate(float value);
+    static float Saturate(float value);
 
     int32_t mDelayLength = 0;
     double mAllPassBaseRate = 1.0; // Precomputed for ProcessAllPass
@@ -176,8 +193,10 @@ class SoundMatrixDecoder {
     CircularDelay mDelaySurrLeft;
     CircularDelay mDelaySurrRight;
 
-    // Output buffer
-    std::vector<int16_t> mSurroundBuffer;
+    // Output buffer — interleaved 6-channel float frames.
+    std::vector<float> mSurroundBuffer;
+    // Quantised mirror used by the legacy s16 Process() overload only.
+    std::vector<int16_t> mSurroundBufferS16;
 };
 
 } // namespace Ship

--- a/src/libultraship/bridge/audiobridge.cpp
+++ b/src/libultraship/bridge/audiobridge.cpp
@@ -63,6 +63,19 @@ void AudioPlayerPlayFrame(const uint8_t* buf, size_t len) {
     audio->Play(buf, len);
 }
 
+void AudioPlayerPlayFrameF32(const float* buf, size_t frames) {
+    auto audio = Ship::Context::GetInstance()->GetAudio()->GetAudioPlayer();
+    if (audio == nullptr) {
+        return;
+    }
+
+    if (!audio->IsInitialized()) {
+        return;
+    }
+
+    audio->Play(buf, frames);
+}
+
 void SetAudioChannels(AudioChannelsSetting channels) {
     auto audio = Ship::Context::GetInstance()->GetAudio();
     if (audio == nullptr) {

--- a/src/ship/audio/Audio.cpp
+++ b/src/ship/audio/Audio.cpp
@@ -36,9 +36,44 @@ void Audio::InitAudioPlayer() {
 
     if (mAudioPlayer && !mAudioPlayer->Init()) {
         // Failed to initialize system audio player.
-        // Fallback to Null if the native system player does not work.
+        // Fallback to Null if the native system player does not work. That path
+        // re-enters InitAudioPlayer (and fires the hook for the Null player), so
+        // return here to avoid also firing it for the failed player.
         SetCurrentAudioBackend(AudioBackend::NUL);
+        return;
     }
+
+    // A fresh AudioPlayer is live. It already inherits the float-pipeline mode
+    // via mAudioSettings; the hook lets the host re-attach instance-bound state
+    // the player cannot carry across a rebuild (e.g. FluidSynth's mix source).
+    if (mOnAudioPlayerInitialized) {
+        mOnAudioPlayerInitialized();
+    }
+}
+
+bool Audio::IsUsingFloatPipeline() const {
+    return mUseFloatPipeline.load(std::memory_order_acquire);
+}
+
+bool Audio::SetUseFloatPipeline(bool enabled) {
+    // Authority first: update the live flag and the template new players inherit,
+    // so anything constructed from here on comes up in the right mode.
+    mAudioSettings.UseFloatPipeline = enabled;
+    mUseFloatPipeline.store(enabled, std::memory_order_release);
+
+    if (mAudioPlayer && !mAudioPlayer->SetUseFloatPipeline(enabled)) {
+        // The player refused the requested mode; reflect what it actually settled
+        // on so producer and consumer stay in agreement.
+        const bool actual = mAudioPlayer->IsUsingFloatPipeline();
+        mAudioSettings.UseFloatPipeline = actual;
+        mUseFloatPipeline.store(actual, std::memory_order_release);
+        return false;
+    }
+    return true;
+}
+
+void Audio::SetOnAudioPlayerInitialized(std::function<void()> callback) {
+    mOnAudioPlayerInitialized = std::move(callback);
 }
 
 void Audio::Init() {
@@ -125,6 +160,10 @@ void Audio::SetCurrentAudioBackend(AudioBackend backend) {
     }
     mConfig->Save();
 
+    // The new player inherits the float-pipeline mode from mAudioSettings (kept
+    // authoritative by SetUseFloatPipeline), so it comes up in the correct mode
+    // by construction. InitAudioPlayer's hook then re-attaches any instance-bound
+    // state (e.g. the FluidSynth mix source).
     InitAudioPlayer();
 }
 

--- a/src/ship/audio/AudioPlayer.cpp
+++ b/src/ship/audio/AudioPlayer.cpp
@@ -9,25 +9,34 @@ AudioPlayer::~AudioPlayer() {
     SPDLOG_TRACE("destruct audio player");
 }
 
+// Resampler channel count differs between modes:
+//   - Float pipeline: resampler processes stereo (input is always stereo;
+//     mix + surround decode both run after the resample step).
+//   - S16 legacy:     resampler processes GetNumOutputChannels() (surround
+//     decode runs *before* the resample step, preserving the historical
+//     order other libultraship consumers rely on).
+void AudioPlayer::RebuildResampler() {
+    const int32_t channels = mAudioSettings.UseFloatPipeline ? 2 : GetNumOutputChannels();
+    if (mAudioSettings.SourceSampleRate != mAudioSettings.SampleRate && mAudioSettings.SourceSampleRate > 0) {
+        SPDLOG_INFO("AudioPlayer: initializing resampler {} Hz → {} Hz, {} ch ({})",
+                    mAudioSettings.SourceSampleRate, mAudioSettings.SampleRate, channels,
+                    mAudioSettings.UseFloatPipeline ? "float HD" : "s16 legacy");
+        mResampler = std::make_unique<AudioResampler>(mAudioSettings.SourceSampleRate, mAudioSettings.SampleRate,
+                                                      channels);
+    } else {
+        SPDLOG_INFO("AudioPlayer: resampler disabled {} Hz → {} Hz, {} ch", mAudioSettings.SourceSampleRate,
+                    mAudioSettings.SampleRate, channels);
+        mResampler = nullptr;
+    }
+}
+
 bool AudioPlayer::Init() {
-    // Initialize sound matrix decoder if matrix surround mode is enabled
     if (mAudioSettings.ChannelSetting == AudioChannelsSetting::audioMatrix51) {
         SPDLOG_INFO("Initializing sound matrix decoder for surround");
         mSoundMatrixDecoder = std::make_unique<SoundMatrixDecoder>(mAudioSettings.SampleRate);
     }
 
-    // Initialize resampler if source and output rates differ
-    if (mAudioSettings.SourceSampleRate != mAudioSettings.SampleRate && mAudioSettings.SourceSampleRate > 0) {
-        SPDLOG_INFO("AudioPlayer: initializing resampler {} Hz → {} Hz, {} ch", mAudioSettings.SourceSampleRate,
-                    mAudioSettings.SampleRate, GetNumOutputChannels());
-        mResampler = std::make_unique<AudioResampler>(mAudioSettings.SourceSampleRate, mAudioSettings.SampleRate,
-                                                      GetNumOutputChannels());
-    } else {
-        SPDLOG_INFO("AudioPlayer: resampler disabled {} Hz → {} Hz, {} ch", mAudioSettings.SourceSampleRate,
-                    mAudioSettings.SampleRate, GetNumOutputChannels());
-        mResampler = nullptr;
-    }
-
+    RebuildResampler();
     mInitialized = DoInit();
     return IsInitialized();
 }
@@ -102,13 +111,45 @@ bool AudioPlayer::SetAudioChannels(AudioChannelsSetting channels) {
         mSoundMatrixDecoder.reset();
     }
 
-    // Rebuild resampler with new channel count
-    if (mAudioSettings.SourceSampleRate != mAudioSettings.SampleRate && mAudioSettings.SourceSampleRate > 0) {
-        mResampler = std::make_unique<AudioResampler>(mAudioSettings.SourceSampleRate, mAudioSettings.SampleRate,
-                                                      GetNumOutputChannels());
-    }
-
+    // Channel-count change can affect the s16 legacy resampler (built at
+    // GetNumOutputChannels()); rebuild to pick that up.
+    RebuildResampler();
     return DoInit();
+}
+
+bool AudioPlayer::SetMixSource(MixSource source) {
+    if (!mAudioSettings.UseFloatPipeline && source) {
+        SPDLOG_WARN("AudioPlayer::SetMixSource ignored — float pipeline is disabled");
+        return false;
+    }
+    mMixSource = std::move(source);
+    return true;
+}
+
+bool AudioPlayer::SetUseFloatPipeline(bool enabled) {
+    if (mAudioSettings.UseFloatPipeline == enabled) {
+        return true;
+    }
+    SPDLOG_INFO("AudioPlayer: switching pipeline mode {} → {}",
+                mAudioSettings.UseFloatPipeline ? "float HD" : "s16 legacy",
+                enabled ? "float HD" : "s16 legacy");
+    DoClose();
+    const bool oldMode = mAudioSettings.UseFloatPipeline;
+    mAudioSettings.UseFloatPipeline = enabled;
+    if (!enabled) {
+        // Dropping the float path also drops any installed mix source — the
+        // s16 mix happens upstream in OTRGlobals.
+        mMixSource = nullptr;
+    }
+    RebuildResampler();
+    mInitialized = DoInit();
+    if (!mInitialized) {
+        SPDLOG_ERROR("AudioPlayer: reinit failed at new mode, reverting");
+        mAudioSettings.UseFloatPipeline = oldMode;
+        RebuildResampler();
+        mInitialized = DoInit();
+    }
+    return mInitialized && mAudioSettings.UseFloatPipeline == enabled;
 }
 
 int32_t AudioPlayer::GetNumOutputChannels() const {
@@ -123,7 +164,17 @@ int32_t AudioPlayer::GetNumOutputChannels() const {
 }
 
 void AudioPlayer::Play(const uint8_t* buf, size_t len) {
-    // Step 1: surround decode if needed (stereo → 5.1)
+    if (mAudioSettings.UseFloatPipeline) {
+        SPDLOG_WARN("AudioPlayer::Play(uint8_t*) called in float mode — dropping buffer");
+        return;
+    }
+
+    // Legacy stages (unchanged from the pre-float-pipeline behaviour so
+    // existing libultraship consumers keep their byte-exact contract):
+    //   1. Surround decode if matrix-5.1 (stereo s16 → 6-channel s16).
+    //   2. Resample at the current channel count.
+    //   3. DoPlay.
+
     const uint8_t* pcm = buf;
     size_t pcmLen = len;
 
@@ -150,15 +201,88 @@ void AudioPlayer::Play(const uint8_t* buf, size_t len) {
         assert(static_cast<size_t>(maxOut * ch) <= kResampleBufSamples &&
                "Resample output exceeds kResampleBufSamples — increase the buffer size");
 
-        const int32_t outFrames =
-            mResampler->Process(reinterpret_cast<const int16_t*>(pcm), inFrames, mResampleBuf.data(), maxOut);
-
-        DoPlay(reinterpret_cast<const uint8_t*>(mResampleBuf.data()),
+        const int32_t outFrames = mResampler->Process(reinterpret_cast<const int16_t*>(pcm), inFrames,
+                                                      mResampleBufS16.data(), maxOut);
+        DoPlay(reinterpret_cast<const uint8_t*>(mResampleBufS16.data()),
                static_cast<size_t>(outFrames * ch * sizeof(int16_t)));
         return;
     }
 
     // Step 3: passthrough (no resampling needed)
     DoPlay(pcm, pcmLen);
+}
+
+void AudioPlayer::Play(const float* buf, size_t frames) {
+    if (!mAudioSettings.UseFloatPipeline) {
+        SPDLOG_WARN("AudioPlayer::Play(float*) called in s16 mode — dropping buffer");
+        return;
+    }
+
+    // Stages of the float audio pipeline:
+    //   1. Resample the primary input (always stereo from the game engine)
+    //      to the device's output rate.
+    //   2. Mix in the optional secondary stereo source (FluidSynth) at the
+    //      output rate, with a tanh-style soft-clip. The source therefore
+    //      bypasses the resampler entirely and runs at native device quality.
+    //   3. Surround-decode stereo → 5.1 if in matrix-5.1 mode.
+    //   4. DoPlay the resulting interleaved float buffer.
+
+    // ── Stage 1: resample stereo to output rate ───────────────────────────
+    const float* stereoOutRate = buf;
+    int32_t outFrames = static_cast<int32_t>(frames);
+    if (mResampler) {
+        const int32_t inFrames = static_cast<int32_t>(frames);
+        const int32_t maxOut = mResampler->MaxOutputFrames(inFrames);
+
+        assert(static_cast<size_t>(maxOut * 2) <= kResampleBufSamples &&
+               "Resample output exceeds kResampleBufSamples — increase the buffer size");
+
+        outFrames = mResampler->Process(buf, inFrames, mResampleBuf.data(), maxOut);
+        stereoOutRate = mResampleBuf.data();
+    }
+
+    // ── Stage 2: mix the secondary source (post-resampler, output rate) ──
+    // We always write the mixed result back into mResampleBuf so the same
+    // pointer feeds the surround decode below.
+    if (mMixSource) {
+        assert(static_cast<size_t>(outFrames * 2) <= kResampleBufSamples &&
+               "Mix output exceeds kResampleBufSamples — increase the buffer size");
+        mMixSource(mMixSourceBuf.data(), outFrames);
+
+        // Tanh approximation used to soft-clip the secondary-source mix. Matches the
+        // curve used in SoH's OTRAudio_Thread before the float pipeline landed, so
+        // dynamics behave identically when the synth contributes a peaky signal.
+        auto SoftClipTanhApprox = [](float x) -> float {
+            const float x2 = x * x;
+            return x * (27.0f + x2) / (27.0f + 9.0f * x2);
+        };
+
+        for (int32_t i = 0; i < outFrames * 2; i++) {
+            mResampleBuf[i] = SoftClipTanhApprox(stereoOutRate[i] + mMixSourceBuf[i]);
+        }
+        stereoOutRate = mResampleBuf.data();
+    } else if (stereoOutRate != mResampleBuf.data()) {
+        // No mix and no resample: stereoOutRate still points at the caller's
+        // buffer. The surround decode below copies through its own buffer,
+        // and the stereo passthrough at the end works off whatever
+        // stereoOutRate points to, so no copy is needed here.
+    }
+
+    // ── Stage 3: surround decode (stereo → 5.1) ──────────────────────────
+    if (mAudioSettings.ChannelSetting == AudioChannelsSetting::audioMatrix51) {
+        if (!mSoundMatrixDecoder) {
+            SPDLOG_ERROR("AudioPlayer: Matrix 5.1 mode enabled but SoundMatrixDecoder is not initialized");
+            return;
+        }
+        const auto [surroundOut, surroundFrames] =
+            mSoundMatrixDecoder->Process(stereoOutRate, static_cast<size_t>(outFrames));
+        DoPlay(reinterpret_cast<const uint8_t*>(surroundOut),
+               static_cast<size_t>(surroundFrames) * 6 * sizeof(float));
+        return;
+    }
+
+    // ── Stage 4: stereo passthrough ──────────────────────────────────────
+    DoPlay(reinterpret_cast<const uint8_t*>(stereoOutRate),
+           static_cast<size_t>(outFrames) * 2 * sizeof(float));
 }
 } // namespace Ship

--- a/src/ship/audio/AudioPlayer.cpp
+++ b/src/ship/audio/AudioPlayer.cpp
@@ -1,5 +1,7 @@
 #include "ship/audio/AudioPlayer.h"
+#include "ship/audio/AudioResampler.h"
 #include "spdlog/spdlog.h"
+#include <cassert>
 
 namespace Ship {
 
@@ -13,6 +15,19 @@ bool AudioPlayer::Init() {
         SPDLOG_INFO("Initializing sound matrix decoder for surround");
         mSoundMatrixDecoder = std::make_unique<SoundMatrixDecoder>(mAudioSettings.SampleRate);
     }
+
+    // Initialize resampler if source and output rates differ
+    if (mAudioSettings.SourceSampleRate != mAudioSettings.SampleRate && mAudioSettings.SourceSampleRate > 0) {
+        SPDLOG_INFO("AudioPlayer: initializing resampler {} Hz → {} Hz, {} ch", mAudioSettings.SourceSampleRate,
+                    mAudioSettings.SampleRate, GetNumOutputChannels());
+        mResampler = std::make_unique<AudioResampler>(mAudioSettings.SourceSampleRate, mAudioSettings.SampleRate,
+                                                      GetNumOutputChannels());
+    } else {
+        SPDLOG_INFO("AudioPlayer: resampler disabled {} Hz → {} Hz, {} ch", mAudioSettings.SourceSampleRate,
+                    mAudioSettings.SampleRate, GetNumOutputChannels());
+        mResampler = nullptr;
+    }
+
     mInitialized = DoInit();
     return IsInitialized();
 }
@@ -25,11 +40,21 @@ int32_t AudioPlayer::GetSampleRate() const {
     return mAudioSettings.SampleRate;
 }
 
+int32_t AudioPlayer::GetSourceSampleRate() const {
+    return mAudioSettings.SourceSampleRate;
+}
+
 int32_t AudioPlayer::GetSampleLength() const {
     return mAudioSettings.SampleLength;
 }
 
 int32_t AudioPlayer::GetDesiredBuffered() const {
+    // Scale DesiredBuffered from source rate to output rate so callers
+    // (e.g. DoPlay fill threshold) work in output-rate frames consistently.
+    if (mAudioSettings.SourceSampleRate > 0 && mAudioSettings.SourceSampleRate != mAudioSettings.SampleRate) {
+        return (int32_t)((int64_t)mAudioSettings.DesiredBuffered * mAudioSettings.SampleRate /
+                         mAudioSettings.SourceSampleRate);
+    }
     return mAudioSettings.DesiredBuffered;
 }
 
@@ -39,6 +64,10 @@ AudioChannelsSetting AudioPlayer::GetAudioChannels() const {
 
 void AudioPlayer::SetSampleRate(int32_t rate) {
     mAudioSettings.SampleRate = rate;
+}
+
+void AudioPlayer::SetSourceSampleRate(int32_t rate) {
+    mAudioSettings.SourceSampleRate = rate;
 }
 
 void AudioPlayer::SetSampleLength(int32_t length) {
@@ -73,6 +102,12 @@ bool AudioPlayer::SetAudioChannels(AudioChannelsSetting channels) {
         mSoundMatrixDecoder.reset();
     }
 
+    // Rebuild resampler with new channel count
+    if (mAudioSettings.SourceSampleRate != mAudioSettings.SampleRate && mAudioSettings.SourceSampleRate > 0) {
+        mResampler = std::make_unique<AudioResampler>(mAudioSettings.SourceSampleRate, mAudioSettings.SampleRate,
+                                                      GetNumOutputChannels());
+    }
+
     return DoInit();
 }
 
@@ -88,21 +123,42 @@ int32_t AudioPlayer::GetNumOutputChannels() const {
 }
 
 void AudioPlayer::Play(const uint8_t* buf, size_t len) {
-    if (mAudioSettings.ChannelSetting != AudioChannelsSetting::audioMatrix51) {
-        // Stereo or Raw 5.1 passthrough
-        DoPlay(buf, len);
+    // Step 1: surround decode if needed (stereo → 5.1)
+    const uint8_t* pcm = buf;
+    size_t pcmLen = len;
+
+    std::vector<uint8_t> surroundBuf;
+
+    if (mAudioSettings.ChannelSetting == AudioChannelsSetting::audioMatrix51) {
+        if (!mSoundMatrixDecoder) {
+            SPDLOG_ERROR("AudioPlayer: Matrix 5.1 mode enabled but SoundMatrixDecoder is not initialized");
+            return;
+        }
+        const auto [surroundOut, surroundLen] = mSoundMatrixDecoder->Process(buf, len);
+        // Copy to local buffer so we own the memory through the resampler step
+        surroundBuf.assign(surroundOut, surroundOut + surroundLen);
+        pcm = surroundBuf.data();
+        pcmLen = surroundLen;
+    }
+
+    // Step 2: resample if source rate ≠ output rate
+    if (mResampler) {
+        const int ch = GetNumOutputChannels();
+        const int32_t inFrames = static_cast<int32_t>(pcmLen / (sizeof(int16_t) * ch));
+        const int32_t maxOut = mResampler->MaxOutputFrames(inFrames);
+
+        assert(static_cast<size_t>(maxOut * ch) <= kResampleBufSamples &&
+               "Resample output exceeds kResampleBufSamples — increase the buffer size");
+
+        const int32_t outFrames =
+            mResampler->Process(reinterpret_cast<const int16_t*>(pcm), inFrames, mResampleBuf.data(), maxOut);
+
+        DoPlay(reinterpret_cast<const uint8_t*>(mResampleBuf.data()),
+               static_cast<size_t>(outFrames * ch * sizeof(int16_t)));
         return;
     }
 
-    if (!mSoundMatrixDecoder) {
-        SPDLOG_ERROR("AudioPlayer: Matrix 5.1 mode enabled but SoundMatrixDecoder is not initialized");
-        return;
-    }
-
-    // Decode stereo to surround using sound matrix decoder
-    const auto [surroundOut, surroundLen] = mSoundMatrixDecoder->Process(buf, len);
-
-    // Play the audio
-    DoPlay(surroundOut, surroundLen);
+    // Step 3: passthrough (no resampling needed)
+    DoPlay(pcm, pcmLen);
 }
 } // namespace Ship

--- a/src/ship/audio/AudioResampler.cpp
+++ b/src/ship/audio/AudioResampler.cpp
@@ -129,7 +129,7 @@ int32_t AudioResampler::MaxOutputFrames(int32_t inFrames) const {
 //     2. Advance mPhase by Q. If mPhase >= P, subtract P and advance input by 1.
 // ---------------------------------------------------------------------------
 
-int32_t AudioResampler::Process(const int16_t* inBuf, int32_t inFrames, int16_t* outBuf, int32_t maxOutFrames) {
+int32_t AudioResampler::Process(const float* inBuf, int32_t inFrames, float* outBuf, int32_t maxOutFrames) {
     const int histLen = kTapsPerPhase - 1;
     const int ch = mNumChannels;
 
@@ -143,11 +143,10 @@ int32_t AudioResampler::Process(const int16_t* inBuf, int32_t inFrames, int16_t*
         window[i] = mHistory[i];
     }
 
-    /* Convert new input S16 → float, normalised to [-1, 1] for arithmetic,
-     * then back to S16 range at output. We keep S16 range (±32768) throughout
-     * to avoid an extra normalisation multiply — clampf handles the final clip. */
+    /* Append new input frames verbatim — samples are already float in the
+     * nominal [-1, 1] range so no conversion or normalisation is needed. */
     for (int i = 0; i < inFrames * ch; i++) {
-        window[histLen * ch + i] = (float)inBuf[i];
+        window[histLen * ch + i] = inBuf[i];
     }
 
     /* Resample */
@@ -163,9 +162,10 @@ int32_t AudioResampler::Process(const int16_t* inBuf, int32_t inFrames, int16_t*
             for (int tap = 0; tap < kTapsPerPhase; tap++) {
                 acc += window[(inPos + tap) * ch + c] * coeffs[tap];
             }
-            /* Clamp to S16 range */
-            acc = acc < -32768.0f ? -32768.0f : (acc > 32767.0f ? 32767.0f : acc);
-            outBuf[outFrames * ch + c] = (int16_t)acc;
+            /* Pass through float as-is. Soft-clip happens upstream
+             * (OTRAudio_Thread's mix step); the polyphase filter is
+             * unity-gain so brief excursions slightly above 1.0 are fine. */
+            outBuf[outFrames * ch + c] = acc;
         }
         outFrames++;
 
@@ -198,6 +198,37 @@ int32_t AudioResampler::Process(const int16_t* inBuf, int32_t inFrames, int16_t*
     }
 
     mPhase = phase;
+    return outFrames;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy s16 overload — wraps the float core with conversions at the
+// boundaries. Preserves the byte-exact behaviour libultraship consumers had
+// before the float pipeline landed.
+// ---------------------------------------------------------------------------
+
+int32_t AudioResampler::Process(const int16_t* inBuf, int32_t inFrames, int16_t* outBuf, int32_t maxOutFrames) {
+    const int ch = mNumChannels;
+    const int totalIn  = inFrames  * ch;
+    const int totalOut = maxOutFrames * ch;
+
+    std::vector<float> inF(totalIn);
+    std::vector<float> outF(totalOut);
+
+    constexpr float kS16ToFloat = 1.0f / 32768.0f;
+    for (int i = 0; i < totalIn; i++) {
+        inF[i] = static_cast<float>(inBuf[i]) * kS16ToFloat;
+    }
+
+    const int32_t outFrames = Process(inF.data(), inFrames, outF.data(), maxOutFrames);
+
+    const int outSamples = outFrames * ch;
+    for (int i = 0; i < outSamples; i++) {
+        float v = outF[i] * 32767.0f;
+        if (v >  32767.0f) v =  32767.0f;
+        if (v < -32768.0f) v = -32768.0f;
+        outBuf[i] = static_cast<int16_t>(v);
+    }
     return outFrames;
 }
 

--- a/src/ship/audio/AudioResampler.cpp
+++ b/src/ship/audio/AudioResampler.cpp
@@ -1,0 +1,204 @@
+#include "ship/audio/AudioResampler.h"
+
+#include <cmath>
+#include <cassert>
+#include <algorithm>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace Ship {
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+AudioResampler::AudioResampler(int32_t inRate, int32_t outRate, int32_t numChannels)
+    : mInRate(inRate), mOutRate(outRate), mNumChannels(numChannels), mPhase(0) {
+
+    int32_t g = GCD(inRate, outRate);
+    mP = outRate / g; /* upsample factor   (e.g. 3 for 32k→48k) */
+    mQ = inRate / g;  /* downsample factor (e.g. 2 for 32k→48k) */
+    mNumPhases = mP;
+
+    BuildFilter();
+
+    /* History: kTapsPerPhase-1 past frames per channel, zero-initialized
+     * so the first output frames fade in cleanly from silence. */
+    mHistory.assign((kTapsPerPhase - 1) * mNumChannels, 0.0f);
+}
+
+// ---------------------------------------------------------------------------
+// Filter construction — windowed-sinc lowpass, polyphase decomposition
+// ---------------------------------------------------------------------------
+
+float AudioResampler::BesselI0(float x) {
+    /* Modified Bessel function of the first kind, order 0.
+     * Used for Kaiser window computation.
+     * Series expansion — converges well for x < 20 (beta up to ~14). */
+    float sum = 1.0f;
+    float term = 1.0f;
+    float half_x = x * 0.5f;
+    for (int k = 1; k <= 30; k++) {
+        term *= (half_x / (float)k);
+        term *= (half_x / (float)k);
+        sum += term;
+        if (term < 1e-12f * sum)
+            break;
+    }
+    return sum;
+}
+
+float AudioResampler::KaiserWindow(int n, int N, float beta) {
+    /* Kaiser window of length N+1, sample n in [0, N].
+     * beta=6 gives ~60 dB stopband attenuation — good balance for audio. */
+    float r = 2.0f * (float)n / (float)N - 1.0f; /* normalise to [-1, 1] */
+    float inside = 1.0f - r * r;
+    if (inside < 0.0f)
+        inside = 0.0f;
+    return BesselI0(beta * sqrtf(inside)) / BesselI0(beta);
+}
+
+float AudioResampler::Sinc(float x) {
+    if (fabsf(x) < 1e-8f)
+        return 1.0f;
+    float px = (float)M_PI * x;
+    return sinf(px) / px;
+}
+
+void AudioResampler::BuildFilter() {
+    /* Total filter length: P * kTapsPerPhase taps.
+     * Cutoff at fc = 0.5 / max(P, Q) in normalised frequency (relative to
+     * the upsampled rate P*inRate = P*outRate/Q). For 32k→48k: P=3, Q=2,
+     * fc = 0.5/3 ≈ 0.167. */
+    const int totalTaps = mNumPhases * kTapsPerPhase;
+    const float fc = 0.5f / (float)std::max(mP, mQ);
+    const float beta = 6.0f;
+    const int N = totalTaps - 1;
+
+    std::vector<float> h(totalTaps);
+
+    /* Windowed sinc prototype filter */
+    for (int i = 0; i < totalTaps; i++) {
+        float x = (float)i - (float)N * 0.5f;
+        h[i] = 2.0f * fc * Sinc(2.0f * fc * x) * KaiserWindow(i, N, beta);
+    }
+
+    /* Polyphase decomposition: interleave into mNumPhases banks.
+     * Phase p contains taps h[p], h[p+P], h[p+2P], ...
+     * Normalise by P so energy is preserved after upsampling. */
+    mCoeffs.resize(mNumPhases * kTapsPerPhase);
+    for (int phase = 0; phase < mNumPhases; phase++) {
+        for (int tap = 0; tap < kTapsPerPhase; tap++) {
+            mCoeffs[phase * kTapsPerPhase + tap] = h[phase + tap * mNumPhases] * (float)mP;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+
+void AudioResampler::Reset() {
+    std::fill(mHistory.begin(), mHistory.end(), 0.0f);
+    mPhase = 0;
+}
+
+// ---------------------------------------------------------------------------
+// MaxOutputFrames
+// ---------------------------------------------------------------------------
+
+int32_t AudioResampler::MaxOutputFrames(int32_t inFrames) const {
+    /* ceil((inFrames * P) / Q) */
+    return (int32_t)(((int64_t)inFrames * mP + mQ - 1) / mQ);
+}
+
+// ---------------------------------------------------------------------------
+// Process — the core resampling loop
+//
+// Algorithm:
+//   We conceptually upsample by P (insert P-1 zeros between each input sample)
+//   then lowpass filter and downsample by Q.
+//   The polyphase decomposition lets us do this efficiently without computing
+//   the zero-padded samples: we advance through phases and only advance the
+//   input pointer when we complete Q phases.
+//
+//   For each output sample:
+//     1. Apply polyphase filter bank[mPhase] to the last kTapsPerPhase input frames.
+//     2. Advance mPhase by Q. If mPhase >= P, subtract P and advance input by 1.
+// ---------------------------------------------------------------------------
+
+int32_t AudioResampler::Process(const int16_t* inBuf, int32_t inFrames, int16_t* outBuf, int32_t maxOutFrames) {
+    const int histLen = kTapsPerPhase - 1;
+    const int ch = mNumChannels;
+
+    /* Build a contiguous float window: history + new input.
+     * history holds the last (kTapsPerPhase-1) input frames as float. */
+    const int windowFrames = histLen + inFrames;
+    std::vector<float> window(windowFrames * ch);
+
+    /* Copy history */
+    for (int i = 0; i < histLen * ch; i++) {
+        window[i] = mHistory[i];
+    }
+
+    /* Convert new input S16 → float, normalised to [-1, 1] for arithmetic,
+     * then back to S16 range at output. We keep S16 range (±32768) throughout
+     * to avoid an extra normalisation multiply — clampf handles the final clip. */
+    for (int i = 0; i < inFrames * ch; i++) {
+        window[histLen * ch + i] = (float)inBuf[i];
+    }
+
+    /* Resample */
+    int32_t outFrames = 0;
+    int32_t inPos = 0; /* current input frame position in window[] */
+    int32_t phase = mPhase;
+
+    while (inPos + kTapsPerPhase <= windowFrames && outFrames < maxOutFrames) {
+        const float* coeffs = &mCoeffs[phase * kTapsPerPhase];
+
+        for (int c = 0; c < ch; c++) {
+            float acc = 0.0f;
+            for (int tap = 0; tap < kTapsPerPhase; tap++) {
+                acc += window[(inPos + tap) * ch + c] * coeffs[tap];
+            }
+            /* Clamp to S16 range */
+            acc = acc < -32768.0f ? -32768.0f : (acc > 32767.0f ? 32767.0f : acc);
+            outBuf[outFrames * ch + c] = (int16_t)acc;
+        }
+        outFrames++;
+
+        /* Advance phase by Q; when phase wraps, consume one input frame */
+        phase += mQ;
+        if (phase >= mP) {
+            phase -= mP;
+            inPos++;
+        }
+    }
+
+    /* Save tail of window as new history */
+    const int consumed = inPos; /* input frames consumed from window */
+    const int remaining = histLen - (inFrames - consumed);
+
+    if (inFrames >= histLen) {
+        /* Enough new input to fill history entirely from inBuf */
+        for (int i = 0; i < histLen * ch; i++) {
+            mHistory[i] = window[(windowFrames - histLen) * ch + i];
+        }
+    } else {
+        /* Partial update: shift old history and append new input */
+        const int keep = histLen - inFrames;
+        for (int i = 0; i < keep * ch; i++) {
+            mHistory[i] = mHistory[inFrames * ch + i];
+        }
+        for (int i = 0; i < inFrames * ch; i++) {
+            mHistory[keep * ch + i] = window[histLen * ch + i];
+        }
+    }
+
+    mPhase = phase;
+    return outFrames;
+}
+
+} // namespace Ship

--- a/src/ship/audio/CoreAudioAudioPlayer.cpp
+++ b/src/ship/audio/CoreAudioAudioPlayer.cpp
@@ -34,7 +34,10 @@ bool CoreAudioAudioPlayer::DoInit() {
 
     mNumChannels = this->GetAudioChannels() == AudioChannelsSetting::audioStereo ? 2 : 6;
 
-    const size_t bytesPerSample = sizeof(int16_t);
+    // Sample width follows the pipeline mode: float HD = 32-bit float,
+    // legacy = 16-bit signed integer.
+    const bool useFloat = this->IsUsingFloatPipeline();
+    const size_t bytesPerSample = useFloat ? sizeof(float) : sizeof(int16_t);
     const size_t bytesPerFrame = bytesPerSample * mNumChannels;
 
     mRingBufferSize = 6000 * bytesPerFrame;
@@ -72,12 +75,14 @@ bool CoreAudioAudioPlayer::DoInit() {
     AudioStreamBasicDescription format;
     format.mSampleRate = this->GetSampleRate();
     format.mFormatID = kAudioFormatLinearPCM;
-    format.mFormatFlags = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked;
+    format.mFormatFlags = useFloat
+        ? (kLinearPCMFormatFlagIsFloat | kLinearPCMFormatFlagIsPacked)
+        : (kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked);
     format.mBytesPerPacket = bytesPerFrame;
     format.mFramesPerPacket = 1;
     format.mBytesPerFrame = bytesPerFrame;
     format.mChannelsPerFrame = mNumChannels;
-    format.mBitsPerChannel = 16;
+    format.mBitsPerChannel = useFloat ? 32 : 16;
 
     status = AudioUnitSetProperty(mAudioUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &format,
                                   sizeof(format));
@@ -123,7 +128,7 @@ int CoreAudioAudioPlayer::Buffered() {
         buffered = mRingBufferSize - (mRingBufferReadPos - mRingBufferWritePos);
     }
 
-    const size_t bytesPerFrame = sizeof(int16_t) * mNumChannels;
+    const size_t bytesPerFrame = (this->IsUsingFloatPipeline() ? sizeof(float) : sizeof(int16_t)) * mNumChannels;
     int samples = buffered / bytesPerFrame;
 
     pthread_mutex_unlock(&mMutex);
@@ -133,7 +138,7 @@ int CoreAudioAudioPlayer::Buffered() {
 void CoreAudioAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
     pthread_mutex_lock(&mMutex);
 
-    const size_t bytesPerFrame = sizeof(int16_t) * mNumChannels;
+    const size_t bytesPerFrame = (this->IsUsingFloatPipeline() ? sizeof(float) : sizeof(int16_t)) * mNumChannels;
     const size_t maxBuffered = 6000 * bytesPerFrame;
 
     size_t available;

--- a/src/ship/audio/SDLAudioPlayer.cpp
+++ b/src/ship/audio/SDLAudioPlayer.cpp
@@ -32,12 +32,12 @@ bool SDLAudioPlayer::DoInit() {
     SDL_AudioSpec want, have;
     SDL_zero(want);
     want.freq = this->GetSampleRate();
-    want.format = AUDIO_S16SYS;
-    want.channels = mNumChannels;
-    want.samples = this->GetSampleLength();
-    want.callback = NULL;
+    want.format = this->IsUsingFloatPipeline() ? AUDIO_F32SYS : AUDIO_S16SYS;
+    want.channels = this->GetNumOutputChannels();
+    want.samples = GetSampleLength();
+    want.callback = nullptr;
 
-    mDevice = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
+    mDevice = SDL_OpenAudioDevice(nullptr, 0, &want, &have, 0);
     if (mDevice == 0) {
         SPDLOG_ERROR("SDL_OpenAudio error: {}", SDL_GetError());
         return false;
@@ -50,7 +50,8 @@ bool SDLAudioPlayer::DoInit() {
 }
 
 int SDLAudioPlayer::Buffered() {
-    return SDL_GetQueuedAudioSize(mDevice) / (sizeof(int16_t) * mNumChannels);
+    const size_t sampleSize = this->IsUsingFloatPipeline() ? sizeof(float) : sizeof(int16_t);
+    return SDL_GetQueuedAudioSize(mDevice) / (sampleSize * mNumChannels);
 }
 
 void SDLAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {

--- a/src/ship/audio/SoundMatrixDecoder.cpp
+++ b/src/ship/audio/SoundMatrixDecoder.cpp
@@ -210,19 +210,15 @@ float SoundMatrixDecoder::ProcessDelay(float sample, CircularDelay& buffer) {
     return output;
 }
 
-int16_t SoundMatrixDecoder::Saturate(float value) {
-    if (value > 32767.0f) {
-        return 32767;
-    }
-    if (value < -32768.0f) {
-        return -32768;
-    }
-    return static_cast<int16_t>(value);
+float SoundMatrixDecoder::Saturate(float value) {
+    // Soft cap at ±1.0; upstream soft-clip handles any dramatic overshoots.
+    if (value > 1.0f)  return 1.0f;
+    if (value < -1.0f) return -1.0f;
+    return value;
 }
 
-std::tuple<const uint8_t*, int> SoundMatrixDecoder::Process(const uint8_t* buf, size_t len) {
-    const int16_t* stereoInput = reinterpret_cast<const int16_t*>(buf);
-    int samplePairs = len / (2 * sizeof(int16_t));
+std::tuple<const float*, int> SoundMatrixDecoder::Process(const float* stereoInput, size_t frames) {
+    const int samplePairs = static_cast<int>(frames);
 
     // Resize output buffer if needed
     size_t samplesNeeded = static_cast<size_t>(samplePairs) * 6;
@@ -231,8 +227,8 @@ std::tuple<const uint8_t*, int> SoundMatrixDecoder::Process(const uint8_t* buf, 
     }
 
     for (int i = 0; i < samplePairs; ++i) {
-        float inL = static_cast<float>(stereoInput[i * 2]);
-        float inR = static_cast<float>(stereoInput[i * 2 + 1]);
+        float inL = stereoInput[i * 2];
+        float inR = stereoInput[i * 2 + 1];
 
         // Center: sum of L+R, band-limited
         float ctr = (inL + inR) * Gains::gCenter;
@@ -278,7 +274,38 @@ std::tuple<const uint8_t*, int> SoundMatrixDecoder::Process(const uint8_t* buf, 
         mSurroundBuffer[i * 6 + 5] = Saturate(surrR);
     }
 
-    return { reinterpret_cast<const uint8_t*>(mSurroundBuffer.data()), samplePairs * 6 * sizeof(int16_t) };
+    return { mSurroundBuffer.data(), samplePairs };
+}
+
+// ---------------------------------------------------------------------------
+// Legacy s16 overload — wraps the float Process with conversions so
+// existing libultraship consumers see byte-exact behaviour.
+// ---------------------------------------------------------------------------
+
+std::tuple<const uint8_t*, int> SoundMatrixDecoder::Process(const uint8_t* buf, size_t len) {
+    const int16_t* stereoInput = reinterpret_cast<const int16_t*>(buf);
+    const size_t samplePairs   = len / (2 * sizeof(int16_t));
+
+    std::vector<float> stereoF(samplePairs * 2);
+    constexpr float kS16ToFloat = 1.0f / 32768.0f;
+    for (size_t i = 0; i < samplePairs * 2; i++) {
+        stereoF[i] = static_cast<float>(stereoInput[i]) * kS16ToFloat;
+    }
+
+    const auto [surroundOut, surroundFrames] = Process(stereoF.data(), samplePairs);
+
+    const size_t surroundSamples = static_cast<size_t>(surroundFrames) * 6;
+    if (mSurroundBufferS16.size() < surroundSamples) {
+        mSurroundBufferS16.resize(surroundSamples);
+    }
+    for (size_t i = 0; i < surroundSamples; i++) {
+        float v = surroundOut[i] * 32767.0f;
+        if (v >  32767.0f) v =  32767.0f;
+        if (v < -32768.0f) v = -32768.0f;
+        mSurroundBufferS16[i] = static_cast<int16_t>(v);
+    }
+    return { reinterpret_cast<const uint8_t*>(mSurroundBufferS16.data()),
+             static_cast<int>(surroundSamples * sizeof(int16_t)) };
 }
 
 } // namespace Ship

--- a/src/ship/audio/WasapiAudioPlayer.cpp
+++ b/src/ship/audio/WasapiAudioPlayer.cpp
@@ -32,11 +32,16 @@ bool WasapiAudioPlayer::SetupStream() {
         // Use GetNumOutputChannels() to determine stereo vs surround
         mNumChannels = this->GetNumOutputChannels();
 
+        // Device format mirrors the pipeline mode: 32-bit IEEE float for the
+        // HD path, 16-bit signed integer for the legacy s16 path.
+        const bool useFloat = this->IsUsingFloatPipeline();
+        const WORD formatTag = useFloat ? WAVE_FORMAT_IEEE_FLOAT : WAVE_FORMAT_PCM;
+        const WORD bitsPerSample = useFloat ? 32 : 16;
         if (mNumChannels == 2) {
             WAVEFORMATEX desired;
-            desired.wFormatTag = WAVE_FORMAT_PCM;
+            desired.wFormatTag = formatTag;
             desired.nChannels = mNumChannels; // Stereo audio
-            desired.wBitsPerSample = 16;      // 16-bit audio
+            desired.wBitsPerSample = bitsPerSample;
             desired.nSamplesPerSec = this->GetSampleRate();
             desired.nBlockAlign = desired.nChannels * desired.wBitsPerSample / 8;
             desired.nAvgBytesPerSec = desired.nSamplesPerSec * desired.nBlockAlign;
@@ -46,18 +51,18 @@ bool WasapiAudioPlayer::SetupStream() {
                 AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
                 2000000, 0, &desired, nullptr));
         } else if (mNumChannels == 6) {
-            // 5.1 surround (6 channels)
+            // 5.1 surround (6 channels) — sub-format mirrors the mode.
             WAVEFORMATEXTENSIBLE desired;
             desired.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
-            desired.Format.nChannels = mNumChannels; // 6 channels for 5.1 audio
-            desired.Format.wBitsPerSample = 16;      // 16-bit audio
+            desired.Format.nChannels = mNumChannels;
+            desired.Format.wBitsPerSample = bitsPerSample;
             desired.Format.nSamplesPerSec = this->GetSampleRate();
             desired.Format.nBlockAlign = desired.Format.nChannels * desired.Format.wBitsPerSample / 8;
             desired.Format.nAvgBytesPerSec = desired.Format.nSamplesPerSec * desired.Format.nBlockAlign;
             desired.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
             desired.dwChannelMask = KSAUDIO_SPEAKER_5POINT1;
-            desired.Samples.wValidBitsPerSample = 16;
-            desired.SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
+            desired.Samples.wValidBitsPerSample = bitsPerSample;
+            desired.SubFormat = useFloat ? KSDATAFORMAT_SUBTYPE_IEEE_FLOAT : KSDATAFORMAT_SUBTYPE_PCM;
 
             ThrowIfFailed(mClient->Initialize(
                 AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
@@ -129,7 +134,8 @@ void WasapiAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
         }
     }
     try {
-        UINT32 frames = len / (mNumChannels * sizeof(int16_t));
+        const size_t sampleSize = this->IsUsingFloatPipeline() ? sizeof(float) : sizeof(int16_t);
+        UINT32 frames = len / (mNumChannels * sampleSize);
         UINT32 padding;
         ThrowIfFailed(mClient->GetCurrentPadding(&padding));
 
@@ -143,7 +149,7 @@ void WasapiAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
 
         BYTE* data;
         ThrowIfFailed(mRenderClient->GetBuffer(frames, &data));
-        memcpy(data, buf, frames * mNumChannels * sizeof(int16_t));
+        memcpy(data, buf, frames * mNumChannels * sampleSize);
         ThrowIfFailed(mRenderClient->ReleaseBuffer(frames, 0));
 
         if (!mStarted && padding + frames > 1500) {


### PR DESCRIPTION
AudioPlayer gains a parallel float-precision pipeline that consumers can
opt into via AudioSettings::UseFloatPipeline. The s16 path is unchanged
and remains the default, so existing libultraship consumers keep their
byte-exact contract; SoH flips to float when FluidSynth is enabled.

Based on top of #1106 
Closes #1106 

New entry points

- AudioPlayer::Play(const float*, size_t frames) alongside the legacy
  Play(const uint8_t*, size_t len). Each Play asserts it's called in
  the matching mode and drops the buffer with a warning otherwise.
- AudioPlayer::SetUseFloatPipeline(bool) — runtime mode switch via
  DoClose → flip → DoInit. Reverts on failure.
- AudioPlayer::SetMixSource(std::function<void(float*, int)>) — a
  secondary stereo source mixed in *after* the resampler so its
  contribution skips the rate-conversion step entirely. Returns false
  in s16 mode. AudioPlayer sums the source with a tanh-style soft-clip
  before any surround decode.
- audiobridge: AudioPlayerPlayFrame (legacy uint8_t) preserved;
  AudioPlayerPlayFrameF32 added for the float path.

DSP layer

- AudioResampler::Process gains a float overload that operates on
  interleaved float [-1, 1]. The original int16_t overload is preserved
  and wraps the float core with boundary conversions and clamping.
- SoundMatrixDecoder::Process likewise: native float overload plus a
  legacy uint8_t (s16) overload that converts at the boundaries. Both
  reuse the float-internal filter / phase / delay state.

Backends
- SDL / PipeWire / WASAPI / CoreAudio DoInit reads
  IsUsingFloatPipeline() and configures the device format (F32 vs S16).
  Buffered() divides by the matching sample size.
- PipeWire's ring init, sample width in OnProcess, and underrun
  fade-out math all branch on the same flag.

AudioPlayer reorder in float mode
- Stages: resample stereo → optional MixSource sum + soft-clip →
  surround decode (matrix-5.1) → DoPlay. Lets a secondary source
  produced at GetSampleRate() bypass the resampler.
- Resampler channel count differs between modes: stereo (2) in float
  mode (mix + surround decode follow), GetNumOutputChannels() in s16
  mode (legacy decode-first order preserved). RebuildResampler() picks
  the right value on Init / SetUseFloatPipeline / SetAudioChannels.