### PR TITLE
Skip some clamps and stride calculations for replacement textures

### DIFF
--- a/include/ship/resource/ResourceManager.h
+++ b/include/ship/resource/ResourceManager.h
@@ -224,6 +224,15 @@ class ResourceManager {
     size_t UnloadResource(const std::string& filePath);
 
     /**
+     * @brief Inserts a runtime-built resource into the cache so LoadResource[Process] returns it by
+     *        path, without any backing archive file. Used for textures synthesized at runtime.
+     *        Evict with UnloadResource(filePath).
+     * @param filePath Virtual path the resource will be retrievable under.
+     * @param resource The resource to cache.
+     */
+    void CacheExternalResource(const std::string& filePath, std::shared_ptr<IResource> resource);
+
+    /**
      * @brief Writes raw data into an archive and optionally evicts the stale cache entry.
      * @param identifier Identifier of the resource to write.
      * @param data       Raw bytes to write.

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -578,12 +578,12 @@ void Interpreter::ImportTextureRgba16(int tile, bool importReplacement) {
         renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13; // < 1.625x
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
-    // Skip the clamp for replacement textures
-    bool blended = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].blended;
-    if (!blended && (pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
+    // HD replacement textures must still clamp to the rendered tile region
+    bool isHd = metadata->h_byte_scale != 1 || metadata->v_pixel_scale != 1;
+    if ((isHd || pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if (!blended && (pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
+    if ((isHd || pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -647,12 +647,12 @@ void Interpreter::ImportTextureRgba32(int tile, bool importReplacement) {
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
-    // Skip the clamp for replacement textures
-    bool blended = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].blended;
-    if (!blended && (pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
+    // HD replacement textures must still clamp to the rendered tile region
+    bool isHd = metadata->h_byte_scale != 1 || metadata->v_pixel_scale != 1;
+    if ((isHd || pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if (!blended && (pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
+    if ((isHd || pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -953,12 +953,12 @@ void Interpreter::ImportTextureCi4(int tile, bool importReplacement) {
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
-    // Skip the clamp for replacement textures
-    bool blended = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].blended;
-    if (!blended && (pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
+    // HD replacement textures must still clamp to the rendered tile region
+    bool isHd = metadata->h_byte_scale != 1 || metadata->v_pixel_scale != 1;
+    if ((isHd || pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if (!blended && (pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
+    if ((isHd || pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -1047,12 +1047,12 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
-    // Skip the clamp for replacement textures
-    bool blended = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].blended;
-    if (!blended && (pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
+    // HD replacement textures must still clamp to the rendered tile region
+    bool isHd = metadata->h_byte_scale != 1 || metadata->v_pixel_scale != 1;
+    if ((isHd || pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if (!blended && (pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
+    if ((isHd || pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -1925,12 +1925,13 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             uint32_t loadedPx = tex_width[i] * tex_height[i];
             uint32_t renderedPx = tex_width2[i] * tex_height2[i];
             bool pyrLike = renderedPx > 0 && loadedPx > renderedPx && loadedPx * 8 < renderedPx * 13;
-            // Skip the clamp for replacement textures
-            bool blended = mRdp->loaded_texture[i].blended;
-            if (!blended && (pyrLike || (cms & G_TX_CLAMP)) && tex_width2[i] > 0 && tex_width2[i] < tex_width[i]) {
+            // HD replacements must clamp to the tile region
+            bool isHd = mRdp->loaded_texture[i].raw_tex_metadata.h_byte_scale != 1 ||
+                        mRdp->loaded_texture[i].raw_tex_metadata.v_pixel_scale != 1;
+            if ((isHd || pyrLike || (cms & G_TX_CLAMP)) && tex_width2[i] > 0 && tex_width2[i] < tex_width[i]) {
                 tex_width[i] = tex_width2[i];
             }
-            if (!blended && (pyrLike || (cmt & G_TX_CLAMP)) && tex_height2[i] > 0 && tex_height2[i] < tex_height[i]) {
+            if ((isHd || pyrLike || (cmt & G_TX_CLAMP)) && tex_height2[i] > 0 && tex_height2[i] < tex_height[i]) {
                 tex_height[i] = tex_height2[i];
             }
 

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -578,10 +578,12 @@ void Interpreter::ImportTextureRgba16(int tile, bool importReplacement) {
         renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13; // < 1.625x
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
-    if ((pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
+    // Skip the clamp for replacement textures
+    bool blended = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].blended;
+    if (!blended && (pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if ((pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
+    if (!blended && (pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -645,10 +647,12 @@ void Interpreter::ImportTextureRgba32(int tile, bool importReplacement) {
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
-    if ((pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
+    // Skip the clamp for replacement textures
+    bool blended = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].blended;
+    if (!blended && (pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if ((pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
+    if (!blended && (pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -949,10 +953,12 @@ void Interpreter::ImportTextureCi4(int tile, bool importReplacement) {
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
-    if ((pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
+    // Skip the clamp for replacement textures
+    bool blended = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].blended;
+    if (!blended && (pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if ((pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
+    if (!blended && (pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -1041,10 +1047,12 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
-    if ((pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
+    // Skip the clamp for replacement textures
+    bool blended = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].blended;
+    if (!blended && (pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if ((pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
+    if (!blended && (pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -1917,10 +1925,12 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             uint32_t loadedPx = tex_width[i] * tex_height[i];
             uint32_t renderedPx = tex_width2[i] * tex_height2[i];
             bool pyrLike = renderedPx > 0 && loadedPx > renderedPx && loadedPx * 8 < renderedPx * 13;
-            if ((pyrLike || (cms & G_TX_CLAMP)) && tex_width2[i] > 0 && tex_width2[i] < tex_width[i]) {
+            // Skip the clamp for replacement textures
+            bool blended = mRdp->loaded_texture[i].blended;
+            if (!blended && (pyrLike || (cms & G_TX_CLAMP)) && tex_width2[i] > 0 && tex_width2[i] < tex_width[i]) {
                 tex_width[i] = tex_width2[i];
             }
-            if ((pyrLike || (cmt & G_TX_CLAMP)) && tex_height2[i] > 0 && tex_height2[i] < tex_height[i]) {
+            if (!blended && (pyrLike || (cmt & G_TX_CLAMP)) && tex_height2[i] > 0 && tex_height2[i] < tex_height[i]) {
                 tex_height[i] = tex_height2[i];
             }
 
@@ -2471,7 +2481,13 @@ void Interpreter::GfxDpLoadBlock(uint8_t tile, uint32_t uls, uint32_t ult, uint3
     // The standard gDPLoadTextureBlock macro sets width=1, but manually-built DL
     // commands may set the real pixel width.
     uint32_t actual_line_bytes = size_bytes;
-    if (mRdp->texture_to_load.width > 1) {
+    const RawTexMetadata& blkMeta = mRdp->texture_to_load.raw_tex_metadata;
+    bool blkHd = blkMeta.h_byte_scale != 1 || blkMeta.v_pixel_scale != 1;
+    if (mRdp->texture_to_load.width > 1 && blkHd && blkMeta.height > 0 && size_bytes % blkMeta.height == 0) {
+        // HD-upscaled textures report a sentinel SetTextureImage width, so the per-line stride
+        // derived from it is bogus. The resource's stored height is authoritative.
+        actual_line_bytes = size_bytes / blkMeta.height;
+    } else if (mRdp->texture_to_load.width > 1) {
         uint32_t candidate;
         switch (mRdp->texture_to_load.siz) {
             case G_IM_SIZ_4b:

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1153,7 +1153,10 @@ void Interpreter::ImportTextureRaw(int tile, bool importReplacement) {
         memset(mTexUploadBuffer + resourceImageSizeBytes, 0, numLoadedBytes - resourceImageSizeBytes);
     }
 
-    mRapi->UploadTexture(mTexUploadBuffer, resultNewLineSize / 4, resultNewHeight);
+    // Describe the buffer by what was actually packed (the loaded HD stride)
+    uint32_t uploadWidth = safeLineSizeBytes / 4;
+    uint32_t uploadHeight = safeLineSizeBytes > 0 ? safeLoadedBytes / safeLineSizeBytes : 0;
+    mRapi->UploadTexture(mTexUploadBuffer, uploadWidth, uploadHeight);
 }
 
 void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -421,6 +421,11 @@ size_t ResourceManager::UnloadResource(const std::string& filePath) {
     return UnloadResource({ filePath, mDefaultCacheOwner, mDefaultCacheArchive });
 }
 
+void ResourceManager::CacheExternalResource(const std::string& filePath, std::shared_ptr<IResource> resource) {
+    const std::lock_guard<std::mutex> lock(mMutex);
+    mResourceCache[{ filePath, mDefaultCacheOwner, mDefaultCacheArchive }] = resource;
+}
+
 bool ResourceManager::WriteResource(const ResourceIdentifier& identifier, const std::vector<uint8_t>& data,
                                     bool unloadFile) {
     std::shared_ptr<Archive> archive = identifier.Parent;


### PR DESCRIPTION
#1043 introduced a regression for alt assets which are much larger than native game textures. In accordance, these need to follow different rules. Regressions spotted in Ghostship, tested and verified resolved.