### PR TITLE
Fix shutdown crash

### DIFF
--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -137,9 +137,9 @@ class Fast3dGui : public Ship::Gui {
 
   protected:
     void ImGuiWMInit() override;
-    void ImGuiWMShutdown() override;
+    void ImGuiWMShutdown(Ship::Window* window) override;
     void ImGuiBackendInit() override;
-    void ImGuiBackendShutdown() override;
+    void ImGuiBackendShutdown(Ship::Window* window) override;
     void ImGuiBackendNewFrame() override;
     void ImGuiWMNewFrame() override;
     void ImGuiRenderDrawData(ImDrawData* data) override;

--- a/include/ship/window/gui/Gui.h
+++ b/include/ship/window/gui/Gui.h
@@ -199,16 +199,18 @@ class Gui {
     virtual void ImGuiWMInit();
 
     /** @brief Shuts down the platform/window-manager ImGui backend.
-     *  The base implementation is a no-op. */
-    virtual void ImGuiWMShutdown();
+     *  The base implementation is a no-op.
+     *  @param window The Window currently being torn down. */
+    virtual void ImGuiWMShutdown(Ship::Window* window);
 
     /** @brief Initialises the renderer ImGui backend (DX11 / OpenGL / Metal).
      *  The base implementation is a no-op. */
     virtual void ImGuiBackendInit();
 
     /** @brief Shuts down the renderer ImGui backend.
-     *  The base implementation is a no-op. */
-    virtual void ImGuiBackendShutdown();
+     *  The base implementation is a no-op.
+     *  @param window The Window currently being torn down. */
+    virtual void ImGuiBackendShutdown(Ship::Window* window);
 
     /**
      * @brief Submits the ImGui draw data to the active graphics backend.

--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -120,8 +120,11 @@ void Fast3dGui::ImGuiWMInit() {
     RefreshImGuiGamepads();
 }
 
-void Fast3dGui::ImGuiWMShutdown() {
-    auto window = Ship::Context::GetInstance()->GetWindow();
+void Fast3dGui::ImGuiWMShutdown(Ship::Window* window) {
+    if (window == nullptr) {
+        return;
+    }
+
     switch (window->GetWindowBackend()) {
 #ifdef ENABLE_OPENGL
         case WindowBackend::FAST3D_SDL_OPENGL:
@@ -177,8 +180,11 @@ void Fast3dGui::ImGuiBackendInit() {
     }
 }
 
-void Fast3dGui::ImGuiBackendShutdown() {
-    auto window = Ship::Context::GetInstance()->GetWindow();
+void Fast3dGui::ImGuiBackendShutdown(Ship::Window* window) {
+    if (window == nullptr) {
+        return;
+    }
+
     switch (window->GetWindowBackend()) {
 #ifdef ENABLE_OPENGL
         case WindowBackend::FAST3D_SDL_OPENGL:

--- a/src/ship/window/gui/Gui.cpp
+++ b/src/ship/window/gui/Gui.cpp
@@ -109,18 +109,18 @@ void Gui::ImGuiWMInit() {
 }
 
 void Gui::ShutDownImGui(Ship::Window* window) {
-    ImGuiWMShutdown();
-    ImGuiBackendShutdown();
+    ImGuiWMShutdown(window);
+    ImGuiBackendShutdown(window);
     ImGui::DestroyContext();
 }
 
-void Gui::ImGuiWMShutdown() {
+void Gui::ImGuiWMShutdown(Ship::Window* window) {
 }
 
 void Gui::ImGuiBackendInit() {
 }
 
-void Gui::ImGuiBackendShutdown() {
+void Gui::ImGuiBackendShutdown(Ship::Window* window) {
 }
 
 bool Gui::SupportsViewports() {


### PR DESCRIPTION
Pass the window down to the shutdown functions instead of using `Ship::Context::GetInstance()->GetWindow()` which is nulled out in the Context Destructor.