### PR TITLE
fix: round interpolated texture tile sizes

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -545,6 +545,14 @@ static uint32_t GetEffectiveLineSize(uint32_t lineSizeBytes, uint32_t fullImageL
     return tileLineSizeBytes;
 }
 
+static uint32_t GetTileSizeFromCoordinates(float low, float high) {
+    float size = (high - low + 4.0f) / 4.0f;
+    if (size <= 0.0f) {
+        return 0;
+    }
+    return static_cast<uint32_t>(lroundf(size));
+}
+
 void Interpreter::ImportTextureRgba16(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata;
     const uint8_t* addr =
@@ -570,8 +578,8 @@ void Interpreter::ImportTextureRgba16(int tile, bool importReplacement) {
     // Clamp to the rendered region only when the loaded buffer is ~1.33x of it (mipmap
     // pyramid signature). Window-scrolling tiles have loaded ≈ rendered or loaded >> rendered;
     // skip both. CLAMP wrap mode always opts in.
-    uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
-    uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+    uint32_t tile_w = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].uls, mRdp->texture_tile[tile].lrs);
+    uint32_t tile_h = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].ult, mRdp->texture_tile[tile].lrt);
     uint32_t loadedPixels = width * height;
     uint32_t renderedPixels = tile_w * tile_h;
     bool pyramidLike =
@@ -638,8 +646,8 @@ void Interpreter::ImportTextureRgba32(int tile, bool importReplacement) {
     // Clamp to the rendered region only when the loaded buffer is ~1.33x of it (mipmap
     // pyramid signature). Window-scrolling tiles have loaded ≈ rendered or loaded >> rendered;
     // skip both. CLAMP wrap mode always opts in.
-    uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
-    uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+    uint32_t tile_w = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].uls, mRdp->texture_tile[tile].lrs);
+    uint32_t tile_h = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].ult, mRdp->texture_tile[tile].lrt);
     uint32_t loadedPixels = width * height;
     uint32_t renderedPixels = tile_w * tile_h;
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
@@ -942,8 +950,8 @@ void Interpreter::ImportTextureCi4(int tile, bool importReplacement) {
     // Clamp to the rendered region only when the loaded buffer is ~1.33x of it (mipmap
     // pyramid signature). Window-scrolling tiles have loaded ≈ rendered or loaded >> rendered;
     // skip both. CLAMP wrap mode always opts in.
-    uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
-    uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+    uint32_t tile_w = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].uls, mRdp->texture_tile[tile].lrs);
+    uint32_t tile_h = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].ult, mRdp->texture_tile[tile].lrt);
     uint32_t loadedPixels = width * height;
     uint32_t renderedPixels = tile_w * tile_h;
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
@@ -1034,8 +1042,8 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
     // Clamp to the rendered region only when the loaded buffer is ~1.33x of it (mipmap
     // pyramid signature). Window-scrolling tiles have loaded ≈ rendered or loaded >> rendered;
     // skip both. CLAMP wrap mode always opts in.
-    uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
-    uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+    uint32_t tile_w = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].uls, mRdp->texture_tile[tile].lrs);
+    uint32_t tile_h = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].ult, mRdp->texture_tile[tile].lrt);
     uint32_t loadedPixels = width * height;
     uint32_t renderedPixels = tile_w * tile_h;
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
@@ -1909,8 +1917,8 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             }
             tex_width[i] = line_size;
 
-            tex_width2[i] = (uint32_t)(int32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
-            tex_height2[i] = (uint32_t)(int32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+            tex_width2[i] = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].uls, mRdp->texture_tile[tile].lrs);
+            tex_height2[i] = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].ult, mRdp->texture_tile[tile].lrt);
 
             // Same pyramid-like ratio gate as ImportTexture: only clamp when loaded pixels
             // are close to rendered pixels (mipmap), not when much bigger (window scroll).


### PR DESCRIPTION
## Summary

This fixes interpolated texture tile dimensions being truncated after `uls/ult/lrs/lrt` interpolation.

The bug showed up on macOS/Apple Silicon as animated water/lava textures visibly jittering when interpolation is active. In the Fire Temple lava repro, one replay phase derived a different rendered texture window from the interpolated tile coordinates:

```text
replay=1
tile0=(0.000,6.333,124.000,130.333)
renderSize0=(32, 31)
texSize0=(32, 31)
```

Adjacent phases for the same surface stayed `32x32`, so the visible symptom was an alternating `32x32` / `32x31` texture window.

```
replay0=(0.000,6.000,124.000,130.000) renderSize0=(32, 32)
replay1=(0.000,6.333,124.000,130.333) renderSize0=(32, 31) # bugged!
replay2=(0.000,6.667,124.000,130.667) renderSize0=(32, 32)
```

## Root Cause

Several paths in `src/fast/interpreter.cpp` derive rendered/imported tile dimensions with:

```cpp
(high - low + 4) / 4
```

Those results were then cast directly to integer types. With interpolated float coordinates, a texel count that is logically `32.0` can land slightly below the integer boundary, so truncation turns it into `31`.

That makes the texture clamp/import and draw-time texture size calculations disagree across interpolation phases, producing the observed water/lava animation jitter.

## Fix

Add `GetTileSizeFromCoordinates()` and use it for the tile-size calculations that derive dimensions from interpolated tile coordinates. It keeps non-positive sizes clamped to `0` and rounds the derived texel count with `lroundf`.

## Related Links

- Fixes Kenix3/libultraship#1119
- Shipwright report: HarbourMasters/Shipwright#6666

## Validation

- `cmake -S . -B build -DLUS_BUILD_TESTS=OFF`
- `cmake --build build --target libultraship -j 8`
- `cmake -S . -B build -DLUS_BUILD_TESTS=ON`
- `cmake --build build --target lus_tests -j 8`
- `ctest --test-dir build --output-on-failure`
