### PR TITLE
Skip N64 segmented-range guard in SETTIMG when a resource was loaded

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -3852,6 +3852,7 @@ bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
     // from the resource, but raw textures would leave them at 0.
     rawTexMetdata.h_byte_scale = 1;
     rawTexMetdata.v_pixel_scale = 1;
+    bool resourceLoaded = false;
 
     if ((i & 1) != 1) {
         if (gfx_check_image_signature(imgData) == 1) {
@@ -3871,26 +3872,32 @@ bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
             rawTexMetdata.v_pixel_scale = tex->VPixelScale;
             rawTexMetdata.type = tex->Type;
             rawTexMetdata.resource = tex;
+            resourceLoaded = true;
         }
     }
 
-    // If the resolved address is still in the N64 segmented range, SegAddr
-    // failed to resolve it (segment not set up). Skip to avoid dereferencing
-    // invalid memory.
+    // If no resource was loaded and the address is still in the N64 segmented
+    // range, SegAddr failed to resolve it (segment not set up). Skip to avoid
+    // dereferencing invalid memory. When a resource was loaded, `i` is a host
+    // heap pointer into `tex->ImageData`, which can be below 0x0FFFFFFF on
+    // systems where ASLR is disabled (e.g. `setarch --addr-no-randomize` or
+    // when running under a debugger that disables ASLR by default).
     // For Windows, also check if the address is not from a dll because this validation returns a false positive caused
     // by how the virtual memory is allocated.
+    if (!resourceLoaded) {
 #ifdef _WIN32
-    HMODULE module = nullptr;
-    if (i <= 0x0FFFFFFF &&
-        !(GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                             reinterpret_cast<LPCSTR>(i), &module))) {
-        return false;
-    }
+        HMODULE module = nullptr;
+        if (i <= 0x0FFFFFFF &&
+            !(GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                                 reinterpret_cast<LPCSTR>(i), &module))) {
+            return false;
+        }
 #else
-    if (i <= 0x0FFFFFFF) {
-        return false;
-    }
+        if (i <= 0x0FFFFFFF) {
+            return false;
+        }
 #endif
+    }
 
     gfx->GfxDpSetTextureImage(C0(21, 3), C0(19, 2), C0(0, 12) + 1, imgData, texFlags, rawTexMetdata, (void*)i);
 


### PR DESCRIPTION
## Summary

`gfx_set_timg_handler_rdp` rejects any resolved address ≤ `0x0FFFFFFF` as an "unresolved N64 segmented address" (added in #1042). The check fires *after* a successful OTR resource load, where `i` has been reassigned to the host pointer `tex->ImageData`. On Linux with ASLR enabled, that heap pointer reliably lands well above the threshold, so the bug is invisible in normal use.

When ASLR is disabled — via `setarch --addr-no-randomize`, or implicitly by gdb's default `set disable-randomization on` — the heap starts low enough that legitimate `tex->ImageData` pointers fall under `0x0FFFFFFF`. The guard then rejects nearly every texture load, leaving stale F3D state behind. Downstream import functions read mismatched format/dimensions and emit garbled textures.

## Fix

Track whether a resource was loaded and only apply the range check in the no-resource fallback case, where `i` is still the raw `SegAddr` result that the guard is actually meant to filter.

## Reproduction

Before this change, with vanilla SoH + this libultraship:

```sh
cd build/soh
setarch --addr-no-randomize ./soh.elf
# or just run under gdb — same effect, since gdb disables ASLR by default
```

Result: garbled textures on the N64 logo intro, file select, and title screens. With the patch, all three render cleanly.

The visible upload divergence:

```
ASLRUPLOADSRC fn=ImportTextureI8 width=192 height=2   # ASLR on
ASLRUPLOADSRC fn=ImportTextureI8 width=384 height=2   # ASLR off — wrong texture in tmem[0]
```

## Test plan

- [x] Verified locally on Fedora 44 in a distrobox: corruption reproduces with `setarch --addr-no-randomize` on the parent commit, disappears with this patch applied.
- [ ] No regression in normal-ASLR runs (heap pointers are above the threshold either way; behavior unchanged).
- [ ] Windows path untouched (`!resourceLoaded` gates both the Linux and Windows branches identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)