### PR TITLE
Fix internal resolution truncation.

### DIFF
--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -33,6 +33,8 @@
 #include <imgui_impl_dx11.h>
 #include <imgui_impl_win32.h>
 
+#include <cmath>
+
 // NOLINTNEXTLINE
 IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 #endif
@@ -456,9 +458,9 @@ void Fast3dGui::ApplyResolutionChanges() {
 
     if (verticalResolutionToggle) { // Use fixed vertical resolution
         if (aspectRatioIsEnabled) {
-            newWidth = uint32_t(float(verticalPixelCount / aspectRatioY) * aspectRatioX);
+            newWidth = std::lround(verticalPixelCount * aspectRatioX / aspectRatioY);
         } else {
-            newWidth = uint32_t(float(verticalPixelCount * size.x / size.y));
+            newWidth = std::lround(verticalPixelCount * size.x / size.y);
         }
         newHeight = verticalPixelCount;
     } else { // Use the window's resolution
@@ -466,9 +468,9 @@ void Fast3dGui::ApplyResolutionChanges() {
             if (((float)mInterpreter.lock()->mGameWindowViewport.height /
                  mInterpreter.lock()->mGameWindowViewport.width) < (aspectRatioY / aspectRatioX)) {
                 // when pillarboxed
-                newWidth = uint32_t(float(mInterpreter.lock()->mCurDimensions.height / aspectRatioY) * aspectRatioX);
+                newWidth = std::lround(mInterpreter.lock()->mCurDimensions.height * aspectRatioX / aspectRatioY);
             } else { // when letterboxed
-                newHeight = uint32_t(float(mInterpreter.lock()->mCurDimensions.width / aspectRatioX) * aspectRatioY);
+                newHeight = std::lround(mInterpreter.lock()->mCurDimensions.width * aspectRatioY / aspectRatioX);
             }
         } // else, having both options turned off does nothing.
     }


### PR DESCRIPTION
When resizing the window with a forced aspect ratio, even if resizing the window to the exact aspect ratio, the internal resolution is always off by 1.

It's fixed by rounding instead of truncating.
(`float` cast is not needed. It will cast it to a `float` automatically.)