### PR TITLE
SDL3 audio backend

### DIFF
--- a/include/ship/audio/Audio.h
+++ b/include/ship/audio/Audio.h
@@ -9,7 +9,7 @@ namespace Ship {
 class Config;
 
 /** @brief Identifies the audio backend implementation in use. */
-enum class AudioBackend { WASAPI, SDL, COREAUDIO, NUL };
+enum class AudioBackend { WASAPI, SDL, SDL3, COREAUDIO, NUL };
 
 /**
  * @brief Manages audio playback through a platform-specific AudioPlayer.

--- a/include/ship/audio/AudioPlayer.h
+++ b/include/ship/audio/AudioPlayer.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "stdint.h"
-#include "stddef.h"
+#include <cstdint>
+#include <cstddef>
 #include <string>
 #include <memory>
 #include "ship/audio/AudioChannelsSetting.h"
@@ -38,7 +38,7 @@ class AudioPlayer {
      */
     AudioPlayer(AudioSettings settings) : mAudioSettings(settings) {
     }
-    ~AudioPlayer();
+    virtual ~AudioPlayer();
 
     /**
      * @brief Calls DoInit() and sets the initialised flag on success.
@@ -153,14 +153,3 @@ class AudioPlayer {
     bool mInitialized = false;
 };
 } // namespace Ship
-
-#ifdef _WIN32
-#include "WasapiAudioPlayer.h"
-#endif
-
-#ifdef __APPLE__
-#include "CoreAudioAudioPlayer.h"
-#endif
-
-#include "SDLAudioPlayer.h"
-#include "NullAudioPlayer.h"

--- a/include/ship/audio/SDL3AudioPlayer.h
+++ b/include/ship/audio/SDL3AudioPlayer.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#if ENABLE_SDL3
+
+#include "ship/audio/AudioPlayer.h"
+
+#include <memory>
+
+namespace Ship {
+
+/*
+ * SDL3AudioPlayer — cross-platform audio backend built on SDL3's audio-stream
+ * API, independent of the SDL2 the rest of the engine uses for window / input /
+ * ImGui.
+ *
+ * Pull model:
+ *   - SDL3 owns the audio thread and invokes our callback when the device needs
+ *     more samples; we never create a thread ourselves.
+ *   - A ring buffer bridges the producer (DoPlay, game thread) and that callback
+ *     (SDL3 audio thread).
+ *   - On underrun the last good chunk is replayed with a linear fade-out instead
+ *     of inserting silence, which masks load spikes perceptually.
+ */
+class SDL3AudioPlayer : public AudioPlayer {
+  public:
+    explicit SDL3AudioPlayer(AudioSettings settings);
+    ~SDL3AudioPlayer() override;
+
+    bool DoInit() override;
+    void DoClose() override;
+    int Buffered() override;
+    void DoPlay(const uint8_t* buf, size_t len) override;
+
+  private:
+    // Using an opaque std::unique_ptr<Impl> (aka. pimpl) here to allow
+    // SDL3 to live side-by-side with the rest of libultraship (window,
+    // input, ImGui), built against SDL2. SDL2 and SDL3 cannot coexist in
+    // one translation unit. Hiding the SDL3 types inside Impl is what
+    // keeps this header includable from SDL2 code.
+    // We can reconsider later if SDL3 is used everywhere.
+    struct Impl;
+    std::unique_ptr<Impl> mImpl;
+};
+
+} // namespace Ship
+
+#endif // #if ENABLE_SDL3

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,34 @@ add_subdirectory("fast")
 
 add_subdirectory("libultraship")
 
+#=================== SDL3 audio backend (optional) ===================
+
+# The SDL3 audio backend is built on SDL3's audio API only, independent of the
+# SDL2 the rest of the engine uses for window / input / ImGui.
+find_package(SDL3 CONFIG QUIET)
+if(SDL3_FOUND)
+    target_compile_definitions(libultraship PRIVATE ENABLE_SDL3=1)
+
+    # SDL3 is needed at build time for HEADERS ONLY. SDL3AudioPlayer.cpp loads the
+    # SDL3 library at runtime (dlopen / LoadLibrary, local visibility) and calls it
+    # through resolved function pointers, so we deliberately do NOT link it.
+    #
+    # Linking SDL3 normally is wrong here: the engine also links SDL2 (window /
+    # input / ImGui), and on ELF that puts both libraries' SDL_* symbols in one
+    # global table. The names common to both (SDL_InitSubSystem, SDL_GetError, ...)
+    # then bind to SDL2, so SDL3's audio subsystem is never initialised and stream
+    # creation fails. Loading SDL3 privately avoids this and makes it an optional
+    # runtime dependency. SDL3::Headers is a headers-only target that (unlike
+    # SDL3::SDL3) carries no SDL_VERSION compatibility property, so it coexists with
+    # SDL2 without tripping CMake's COMPATIBLE_INTERFACE_STRING guard.
+    target_link_libraries(libultraship PRIVATE SDL3::Headers)
+    target_link_libraries(libultraship PRIVATE ${CMAKE_DL_LIBS})
+    message(STATUS "libultraship: SDL3 found - SDL3 audio backend enabled (loaded at runtime)")
+else()
+    target_compile_definitions(libultraship PRIVATE ENABLE_SDL3=0)
+    message(STATUS "libultraship: SDL3 not found - SDL3 audio backend disabled")
+endif()
+
 #=================== Ship ===================
 
 add_subdirectory("ship")

--- a/src/ship/CMakeLists.txt
+++ b/src/ship/CMakeLists.txt
@@ -17,6 +17,10 @@ if (NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     list(FILTER Source_Files__Audio EXCLUDE REGEX "audio/CoreAudioAudioPlayer.*")
 endif()
 
+if (NOT SDL3_FOUND)
+    list(FILTER Source_Files__Audio EXCLUDE REGEX "audio/SDL3AudioPlayer.*")
+endif()
+
 source_group("audio" FILES ${Source_Files__Audio})
 target_sources(libultraship PRIVATE ${Source_Files__Audio})
 

--- a/src/ship/audio/Audio.cpp
+++ b/src/ship/audio/Audio.cpp
@@ -1,8 +1,19 @@
 #include "ship/audio/Audio.h"
 
+#ifdef _WIN32
+#include "ship/audio/WasapiAudioPlayer.h"
+#endif
+
 #ifdef __APPLE__
 #include "ship/audio/CoreAudioAudioPlayer.h"
 #endif
+
+#if ENABLE_SDL3
+#include "ship/audio/SDL3AudioPlayer.h"
+#endif
+
+#include "ship/audio/SDLAudioPlayer.h"
+#include "ship/audio/NullAudioPlayer.h"
 
 #include "ship/Context.h"
 #include "ship/config/Config.h"
@@ -24,6 +35,11 @@ void Audio::InitAudioPlayer() {
 #ifdef __APPLE__
         case AudioBackend::COREAUDIO:
             mAudioPlayer = std::make_shared<CoreAudioAudioPlayer>(this->mAudioSettings);
+            break;
+#endif
+#if ENABLE_SDL3
+        case AudioBackend::SDL3:
+            mAudioPlayer = std::make_shared<SDL3AudioPlayer>(this->mAudioSettings);
             break;
 #endif
         case AudioBackend::SDL:
@@ -50,6 +66,9 @@ void Audio::Init() {
 #endif
 #ifdef __APPLE__
     mAvailableAudioBackends->push_back(AudioBackend::COREAUDIO);
+#endif
+#if ENABLE_SDL3
+    mAvailableAudioBackends->push_back(AudioBackend::SDL3);
 #endif
     mAvailableAudioBackends->push_back(AudioBackend::SDL);
     mAvailableAudioBackends->push_back(AudioBackend::NUL);
@@ -87,18 +106,27 @@ AudioBackend Audio::GetSavedAudioBackend() {
         return AudioBackend::SDL;
     }
 
+    if (backendName == "sdl3") {
+        return AudioBackend::SDL3;
+    }
+
     if (backendName == "null") {
         return AudioBackend::NUL;
     }
 
     SPDLOG_TRACE("Could not find AudioBackend matching value from config file ({}). Returning default AudioBackend.",
                  backendName);
+
 #ifdef _WIN32
     return AudioBackend::WASAPI;
 #endif
 
 #ifdef __APPLE__
     return AudioBackend::COREAUDIO;
+#endif
+
+#if ENABLE_SDL3
+    return AudioBackend::SDL3;
 #endif
 
     return AudioBackend::SDL;
@@ -116,6 +144,9 @@ void Audio::SetCurrentAudioBackend(AudioBackend backend) {
             break;
         case AudioBackend::SDL:
             mConfig->SetString("Window.AudioBackend", "sdl");
+            break;
+        case AudioBackend::SDL3:
+            mConfig->SetString("Window.AudioBackend", "sdl3");
             break;
         case AudioBackend::NUL:
             mConfig->SetString("Window.AudioBackend", "null");

--- a/src/ship/audio/SDL3AudioPlayer.cpp
+++ b/src/ship/audio/SDL3AudioPlayer.cpp
@@ -1,0 +1,482 @@
+#if ENABLE_SDL3
+
+#include "ship/audio/SDL3AudioPlayer.h"
+#include <spdlog/spdlog.h>
+
+#include <atomic>
+#include <cstring>
+#include <mutex>
+#include <vector>
+
+#include <SDL3/SDL_audio.h>
+#include <SDL3/SDL_init.h>
+#include <SDL3/SDL_error.h>
+
+// SDL3 is loaded at runtime (see Impl::LoadSdl3); we include its headers for
+// types/constants but never link it, so we need the platform's dynamic loader.
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+namespace Ship {
+
+// ===========================================================================
+// SDL3AudioPlayer::Impl — all SDL3 state and the audio-thread machinery.
+// Because it lives entirely in this .cpp, the pull callback can take the real
+// SDL_AudioStream* and SDL types appear nowhere in the header.
+// ===========================================================================
+
+struct SDL3AudioPlayer::Impl {
+    bool Open(int sampleRate, int numChannels, int desiredBuffered);
+    void Close();
+    int Buffered();
+    void Play(const uint8_t* buf, size_t len);
+
+    // SDL3 pull callback (SDL_AudioStreamCallback). userdata is this Impl.
+    static void SDLCALL AudioStreamCallback(void* userdata, SDL_AudioStream* stream, int additional_amount,
+                                            int total_amount);
+
+    // --- Dynamically-loaded SDL3 entry points ------------------------------
+    // We dlopen() SDL3 with local visibility and call it only through these
+    // pointers, rather than linking it. The engine also links SDL2 (window /
+    // input / ImGui); on ELF that puts both libraries' SDL_* symbols in one
+    // global table, and the names common to both (SDL_InitSubSystem,
+    // SDL_GetError, ...) bind to SDL2 -- so SDL_InitSubSystem would init SDL2's
+    // audio while the SDL3-only SDL_OpenAudioDeviceStream runs against SDL3's
+    // uninitialised subsystem, and the stream open fails. Loading SDL3 privately
+    // (RTLD_LOCAL) keeps its symbols out of the global table entirely. It also
+    // makes SDL3 an optional *runtime* dependency: if it is missing, Open() fails
+    // cleanly and Audio falls back to another backend instead of the executable
+    // refusing to start.
+    bool LoadSdl3();
+    void UnloadSdl3();
+
+    void* mSdl3Lib = nullptr;
+    decltype(&SDL_InitSubSystem) pInitSubSystem = nullptr;
+    decltype(&SDL_QuitSubSystem) pQuitSubSystem = nullptr;
+    decltype(&SDL_GetError) pGetError = nullptr;
+    decltype(&SDL_OpenAudioDeviceStream) pOpenAudioDeviceStream = nullptr;
+    decltype(&SDL_ResumeAudioStreamDevice) pResumeAudioStreamDevice = nullptr;
+    decltype(&SDL_PutAudioStreamData) pPutAudioStreamData = nullptr;
+    decltype(&SDL_DestroyAudioStream) pDestroyAudioStream = nullptr;
+
+    // --- Ring buffer: power-of-two size, unbounded read/write pointers ---
+    struct RingBuffer {
+        std::vector<uint8_t> data;
+        uint32_t mask = 0; // data.size() - 1
+        int64_t rdptr = 0;
+        int64_t wrptr = 0;
+    } mRing;
+
+    void RingInit(uint32_t bytes);
+    int32_t RingAvailable() const;
+    int32_t RingSpace() const;
+    int32_t RingRead(uint8_t* dst, int32_t bytes);
+    int32_t RingWrite(const uint8_t* src, int32_t bytes);
+
+    SDL_AudioStream* mStream = nullptr;
+    bool mAudioSubsystemInitialized = false;
+    int mNumChannels = 2;
+
+    std::mutex mMutex;
+    std::atomic<int> mRunning{ 0 };
+
+    // Scratch the callback assembles a burst into before handing it to SDL3.
+    // Pre-sized in Open so the audio thread does not allocate in steady state.
+    std::vector<uint8_t> mScratch;
+
+    // Underrun recovery: last successfully played chunk, replayed with fade-out.
+    std::vector<uint8_t> mLastChunk;
+    bool mLastChunkValid = false;
+    bool mUnderrunFaded = false;
+};
+
+// ---------------------------------------------------------------------------
+// Ring buffer helpers
+// ---------------------------------------------------------------------------
+
+static constexpr uint32_t NextPow2(uint32_t v) {
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    return v + 1;
+}
+
+void SDL3AudioPlayer::Impl::RingInit(uint32_t bytes) {
+    uint32_t sz = NextPow2(bytes);
+    mRing.data.assign(sz, 0);
+    mRing.mask = sz - 1;
+    mRing.rdptr = mRing.wrptr = 0;
+}
+
+int32_t SDL3AudioPlayer::Impl::RingAvailable() const {
+    return static_cast<int32_t>(mRing.wrptr - mRing.rdptr);
+}
+
+int32_t SDL3AudioPlayer::Impl::RingSpace() const {
+    return static_cast<int32_t>(mRing.data.size()) - RingAvailable();
+}
+
+int32_t SDL3AudioPlayer::Impl::RingRead(uint8_t* dst, int32_t bytes) {
+    int32_t avail = RingAvailable();
+    if (bytes > avail)
+        bytes = avail;
+    if (bytes <= 0)
+        return 0;
+
+    const uint32_t size = static_cast<uint32_t>(mRing.data.size());
+    uint32_t off = static_cast<uint32_t>(mRing.rdptr & mRing.mask);
+    uint32_t chunk = size - off;
+    if (chunk > static_cast<uint32_t>(bytes))
+        chunk = static_cast<uint32_t>(bytes);
+
+    std::memcpy(dst, mRing.data.data() + off, chunk);
+    if (chunk < static_cast<uint32_t>(bytes))
+        std::memcpy(dst + chunk, mRing.data.data(), bytes - chunk);
+
+    mRing.rdptr += bytes;
+    return bytes;
+}
+
+int32_t SDL3AudioPlayer::Impl::RingWrite(const uint8_t* src, int32_t bytes) {
+    int32_t space = RingSpace();
+    if (bytes > space)
+        bytes = space;
+    if (bytes <= 0)
+        return 0;
+
+    const uint32_t size = static_cast<uint32_t>(mRing.data.size());
+    uint32_t off = static_cast<uint32_t>(mRing.wrptr & mRing.mask);
+    uint32_t chunk = size - off;
+    if (chunk > static_cast<uint32_t>(bytes))
+        chunk = static_cast<uint32_t>(bytes);
+
+    std::memcpy(mRing.data.data() + off, src, chunk);
+    if (chunk < static_cast<uint32_t>(bytes))
+        std::memcpy(mRing.data.data(), src + chunk, bytes - chunk);
+
+    mRing.wrptr += bytes;
+    return bytes;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime SDL3 loading (see the note on the function-pointer members above)
+// ---------------------------------------------------------------------------
+
+bool SDL3AudioPlayer::Impl::LoadSdl3() {
+    if (mSdl3Lib != nullptr) {
+        return true; // already loaded
+    }
+
+#if defined(_WIN32)
+    mSdl3Lib = static_cast<void*>(LoadLibraryA("SDL3.dll"));
+#elif defined(__APPLE__)
+    mSdl3Lib = dlopen("libSDL3.0.dylib", RTLD_NOW | RTLD_LOCAL);
+#else
+    mSdl3Lib = dlopen("libSDL3.so.0", RTLD_NOW | RTLD_LOCAL);
+#endif
+    if (mSdl3Lib == nullptr) {
+        SPDLOG_ERROR("SDL3: unable to load the SDL3 library at runtime; SDL3 audio backend unavailable");
+        return false;
+    }
+
+    auto resolve = [this](const char* name) -> void* {
+#if defined(_WIN32)
+        return reinterpret_cast<void*>(GetProcAddress(static_cast<HMODULE>(mSdl3Lib), name));
+#else
+        return dlsym(mSdl3Lib, name);
+#endif
+    };
+
+    pInitSubSystem = reinterpret_cast<decltype(pInitSubSystem)>(resolve("SDL_InitSubSystem"));
+    pQuitSubSystem = reinterpret_cast<decltype(pQuitSubSystem)>(resolve("SDL_QuitSubSystem"));
+    pGetError = reinterpret_cast<decltype(pGetError)>(resolve("SDL_GetError"));
+    pOpenAudioDeviceStream = reinterpret_cast<decltype(pOpenAudioDeviceStream)>(resolve("SDL_OpenAudioDeviceStream"));
+    pResumeAudioStreamDevice =
+        reinterpret_cast<decltype(pResumeAudioStreamDevice)>(resolve("SDL_ResumeAudioStreamDevice"));
+    pPutAudioStreamData = reinterpret_cast<decltype(pPutAudioStreamData)>(resolve("SDL_PutAudioStreamData"));
+    pDestroyAudioStream = reinterpret_cast<decltype(pDestroyAudioStream)>(resolve("SDL_DestroyAudioStream"));
+
+    if (pInitSubSystem == nullptr || pQuitSubSystem == nullptr || pGetError == nullptr ||
+        pOpenAudioDeviceStream == nullptr || pResumeAudioStreamDevice == nullptr || pPutAudioStreamData == nullptr ||
+        pDestroyAudioStream == nullptr) {
+        SPDLOG_ERROR("SDL3: failed to resolve required SDL3 audio symbols");
+        UnloadSdl3();
+        return false;
+    }
+
+    return true;
+}
+
+void SDL3AudioPlayer::Impl::UnloadSdl3() {
+    pInitSubSystem = nullptr;
+    pQuitSubSystem = nullptr;
+    pGetError = nullptr;
+    pOpenAudioDeviceStream = nullptr;
+    pResumeAudioStreamDevice = nullptr;
+    pPutAudioStreamData = nullptr;
+    pDestroyAudioStream = nullptr;
+
+    if (mSdl3Lib != nullptr) {
+#if defined(_WIN32)
+        FreeLibrary(static_cast<HMODULE>(mSdl3Lib));
+#else
+        dlclose(mSdl3Lib);
+#endif
+        mSdl3Lib = nullptr;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Open
+// ---------------------------------------------------------------------------
+
+bool SDL3AudioPlayer::Impl::Open(int sampleRate, int numChannels, int desiredBuffered) {
+    if (!LoadSdl3()) {
+        return false;
+    }
+
+    if (!pInitSubSystem(SDL_INIT_AUDIO)) {
+        SPDLOG_ERROR("SDL3: SDL_InitSubSystem(SDL_INIT_AUDIO) failed: {}", pGetError());
+        Close();
+        return false;
+    }
+    mAudioSubsystemInitialized = true;
+
+    mNumChannels = numChannels;
+
+    const uint32_t bytesPerFrame = sizeof(int16_t) * static_cast<uint32_t>(mNumChannels);
+
+    // Ring buffer: 2 x desiredBuffered frames (already scaled to output rate by
+    // AudioPlayer::GetDesiredBuffered). Comfortable headroom above the producer
+    // fill threshold so DoPlay() never hits the full-ring guard during normal
+    // playback. The next-pow2 rounding in RingInit adds a small extra margin.
+    const uint32_t ringFrames = static_cast<uint32_t>(desiredBuffered) * 2;
+    RingInit(ringFrames * bytesPerFrame);
+
+    // Last-chunk buffer for underrun fade-out: one desiredBuffered worth of
+    // frames so it can always hold a complete producer chunk.
+    const uint32_t lastChunkSize = static_cast<uint32_t>(desiredBuffered) * bytesPerFrame;
+    mLastChunk.assign(lastChunkSize, 0);
+    mLastChunkValid = false;
+    mUnderrunFaded = false;
+
+    // Pre-size the callback scratch so the audio thread does not allocate during
+    // steady-state playback. A single device burst is far smaller than this.
+    mScratch.assign(lastChunkSize, 0);
+
+    SDL_AudioSpec spec;
+    SDL_zero(spec);
+    spec.format = SDL_AUDIO_S16; // native-endian signed 16-bit; SoH produces S16
+    spec.channels = mNumChannels;
+    spec.freq = sampleRate;
+
+    // Open the default playback device with our pull callback. SDL3 routes this
+    // to the platform's native audio API (PipeWire / PulseAudio / ALSA on Linux,
+    // CoreAudio on macOS, WASAPI on Windows, etc.).
+    mStream = pOpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, AudioStreamCallback, this);
+    if (mStream == nullptr) {
+        SPDLOG_ERROR("SDL3: SDL_OpenAudioDeviceStream failed: {}", pGetError());
+        Close();
+        return false;
+    }
+
+    mRunning.store(1, std::memory_order_release);
+
+    // Streams returned by SDL_OpenAudioDeviceStream start paused.
+    if (!pResumeAudioStreamDevice(mStream)) {
+        SPDLOG_ERROR("SDL3: SDL_ResumeAudioStreamDevice failed: {}", pGetError());
+        Close();
+        return false;
+    }
+
+    SPDLOG_INFO("SDL3 audio initialized: {} ch, {} Hz", mNumChannels, sampleRate);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Close
+// ---------------------------------------------------------------------------
+
+void SDL3AudioPlayer::Impl::Close() {
+    mRunning.store(0, std::memory_order_release);
+
+    if (mStream != nullptr) {
+        // Destroying the stream stops the callback and closes the bound device.
+        // SDL joins the audio thread, so no callback runs after this returns —
+        // it is therefore safe to release the buffers below.
+        if (pDestroyAudioStream != nullptr) {
+            pDestroyAudioStream(mStream);
+        }
+        mStream = nullptr;
+    }
+
+    mRing.data.clear();
+    mRing.data.shrink_to_fit();
+    mRing.mask = 0;
+    mRing.rdptr = mRing.wrptr = 0;
+
+    mLastChunk.clear();
+    mLastChunk.shrink_to_fit();
+    mLastChunkValid = false;
+    mUnderrunFaded = false;
+
+    mScratch.clear();
+    mScratch.shrink_to_fit();
+
+    if (mAudioSubsystemInitialized) {
+        if (pQuitSubSystem != nullptr) {
+            pQuitSubSystem(SDL_INIT_AUDIO);
+        }
+        mAudioSubsystemInitialized = false;
+    }
+
+    // Release the library last; this nulls the function pointers, so it must come
+    // after the pQuitSubSystem / pDestroyAudioStream calls above.
+    UnloadSdl3();
+}
+
+// ---------------------------------------------------------------------------
+// Buffered — returns queued frames (called from the producer / main thread)
+// ---------------------------------------------------------------------------
+
+int SDL3AudioPlayer::Impl::Buffered() {
+    std::lock_guard<std::mutex> lock(mMutex);
+    const int bytesPerFrame = static_cast<int>(sizeof(int16_t)) * mNumChannels;
+    return RingAvailable() / bytesPerFrame;
+}
+
+// ---------------------------------------------------------------------------
+// Play — push PCM from the producer / game thread into the ring buffer
+// ---------------------------------------------------------------------------
+
+void SDL3AudioPlayer::Impl::Play(const uint8_t* buf, size_t len) {
+    if (!mRunning.load(std::memory_order_acquire))
+        return;
+
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    // Whole-chunk-or-nothing: refuse the incoming buffer if it does not fit
+    // entirely. A partial write would create a PCM discontinuity audible as a
+    // click. The producer in OTRAudio_Thread guards against this condition by
+    // skipping a wake when there is no room for the smallest next burst.
+    if (RingSpace() >= static_cast<int32_t>(len)) {
+        RingWrite(buf, static_cast<int32_t>(len));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AudioStreamCallback — SDL3 RT callback, pulls audio from the ring buffer
+// ---------------------------------------------------------------------------
+
+void SDLCALL SDL3AudioPlayer::Impl::AudioStreamCallback(void* userdata, SDL_AudioStream* stream, int additional_amount,
+                                                        int /*total_amount*/) {
+    auto* self = static_cast<Impl*>(userdata);
+
+    // additional_amount is the number of bytes SDL needs right now to keep the
+    // device fed. SDL may also call with 0 purely as a notification.
+    if (additional_amount <= 0)
+        return;
+    if (!self->mRunning.load(std::memory_order_acquire))
+        return;
+
+    const int stride = static_cast<int>(sizeof(int16_t)) * self->mNumChannels;
+    // SDL requests frame-aligned byte counts, but round down defensively.
+    const int32_t n_bytes = (additional_amount / stride) * stride;
+    if (n_bytes <= 0)
+        return;
+    const int32_t n_frames = n_bytes / stride;
+
+    // Grow the scratch only if SDL ever asks for more than the pre-sized burst
+    // (rare; it stabilises after the first such callback).
+    if (self->mScratch.size() < static_cast<size_t>(n_bytes))
+        self->mScratch.resize(static_cast<size_t>(n_bytes));
+    uint8_t* dst = self->mScratch.data();
+
+    // trylock: this is a RT callback and must never block. If the producer holds
+    // mMutex, emit silence rather than blocking — the underrun recovery on a
+    // later callback masks the gap.
+    if (!self->mMutex.try_lock()) {
+        std::memset(dst, 0, static_cast<size_t>(n_bytes));
+        self->pPutAudioStreamData(stream, dst, n_bytes);
+        return;
+    }
+
+    const int32_t avail = self->RingAvailable();
+    const int32_t lastChunkSize = static_cast<int32_t>(self->mLastChunk.size());
+
+    if (avail >= n_bytes) {
+        // Normal path: ring buffer has enough data.
+        self->RingRead(dst, n_bytes);
+        self->mUnderrunFaded = false;
+
+        // Save for underrun recovery.
+        if (n_bytes <= lastChunkSize) {
+            std::memcpy(self->mLastChunk.data(), dst, static_cast<size_t>(n_bytes));
+            self->mLastChunkValid = true;
+        }
+    } else if (self->mLastChunkValid && !self->mUnderrunFaded) {
+        // Underrun recovery: replay the last chunk with a linear fade-out. A
+        // faded repeat is perceptually far less harsh than a silence click.
+        const uint32_t copy =
+            (n_bytes <= lastChunkSize) ? static_cast<uint32_t>(n_bytes) : static_cast<uint32_t>(lastChunkSize);
+        std::memcpy(dst, self->mLastChunk.data(), copy);
+        if (copy < static_cast<uint32_t>(n_bytes))
+            std::memset(dst + copy, 0, static_cast<size_t>(n_bytes) - copy);
+
+        // Apply linear fade-out (S16 samples only — SoH always produces S16).
+        for (int32_t i = 0; i < n_frames; ++i) {
+            const double gain = 1.0 - static_cast<double>(i) / static_cast<double>(n_frames);
+            for (int ch = 0; ch < self->mNumChannels; ++ch) {
+                const int off = (i * self->mNumChannels + ch) * static_cast<int>(sizeof(int16_t));
+                auto* s = reinterpret_cast<int16_t*>(dst + off);
+                *s = static_cast<int16_t>(static_cast<double>(*s) * gain);
+            }
+        }
+        self->mUnderrunFaded = true;
+    } else {
+        // Complete underrun: output silence.
+        std::memset(dst, 0, static_cast<size_t>(n_bytes));
+    }
+
+    self->mMutex.unlock();
+
+    self->pPutAudioStreamData(stream, dst, n_bytes);
+}
+
+// ===========================================================================
+// SDL3AudioPlayer — thin AudioPlayer facade delegating to Impl.
+// ===========================================================================
+
+SDL3AudioPlayer::SDL3AudioPlayer(AudioSettings settings) : AudioPlayer(settings), mImpl(std::make_unique<Impl>()) {
+}
+
+SDL3AudioPlayer::~SDL3AudioPlayer() {
+    SPDLOG_TRACE("destruct SDL3 audio player");
+    mImpl->Close();
+}
+
+bool SDL3AudioPlayer::DoInit() {
+    return mImpl->Open(GetSampleRate(), GetNumOutputChannels(), GetDesiredBuffered());
+}
+
+void SDL3AudioPlayer::DoClose() {
+    mImpl->Close();
+}
+
+int SDL3AudioPlayer::Buffered() {
+    return mImpl->Buffered();
+}
+
+void SDL3AudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
+    mImpl->Play(buf, len);
+}
+
+} // namespace Ship
+
+#endif // #if ENABLE_SDL3


### PR DESCRIPTION
This brings SDL3 as an optional dependency to allow using SDL3 as an audio backend. This is working much better on Linux than the only SDL2 audio backend available.

As discussed in #1105 and #1107, currently the SDL audio backend has quite a lot of audio artifacts. On Windows and macOS, the dedicated WASAPI and CoreAudio backends make it less important, as  these backends are of good quality (fewer audio artifacts), but Linux only has the SDL2 backend available.
Since fixing SDL2 backend or merging my PipeWire backend (Linux modern audio api) does not seem to have a lot of interest, it was discussed an SDL3 backend would be a better fit for the project.

This PR does not need to migrate the whole project to SDL3, and is designed to work on all platforms (only tested on Linux so far), while we are waiting for a full migration.

To achieve SDL2 + SDL3 loading side-by-side, SDL3 is loaded dynamically (rather than linked) on purpose: SDL2 and SDL3 export overlapping SDL_* symbol names, so linking both into one binary makes the shared names (e.g. SDL_InitSubSystem) bind to SDL2 — breaking SDL3 init. Loading SDL3 with local visibility (RTLD_LOCAL) keeps its symbols isolated, and also makes it a soft runtime dependency.

Closes #1111