### PR TITLE
Fix NullAudioPlayer::Buffered() returning 0 (audio-thread spin/hang)

### DIFF
--- a/src/ship/audio/NullAudioPlayer.cpp
+++ b/src/ship/audio/NullAudioPlayer.cpp
@@ -16,7 +16,9 @@ void NullAudioPlayer::DoClose() {
 }
 
 int NullAudioPlayer::Buffered() {
-    return 0;
+    // Report the device as always full; it discards all audio, so returning the
+    // true count (0) makes the producer spin feeding it forever and hang.
+    return GetDesiredBuffered();
 }
 
 void NullAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {


### PR DESCRIPTION
It discards all audio, so reporting 0 made the producer spin feeding it forever and starve the gfx thread. Return the desired buffered count, as the header already documents.