### PR TITLE
Only populate event callers map in debug builds

### DIFF
--- a/src/ship/events/EventSystem.cpp
+++ b/src/ship/events/EventSystem.cpp
@@ -59,6 +59,8 @@ void EventSystem::CallEvent(const EventID id, IEvent* event, const char* file, c
         listener.Function(event);
     }
 
+#ifdef _DEBUG
+    // Event Debugger is a dev tool and shouldn't be compiled into Releases
     auto& info = registry.Callers[key];
 
     if (info.Path == nullptr) {
@@ -67,6 +69,7 @@ void EventSystem::CallEvent(const EventID id, IEvent* event, const char* file, c
     }
 
     info.Count++;
+#endif
 }
 
 } // namespace Ship


### PR DESCRIPTION
In production, the event debugger is a high cost. The debugger wouldn't usually be used by consumers, and developers testing Release builds can just as easily disable the preprocessor gate.