### PR TITLE
Fix missing rumble/LED/gyro for PS4/PS5 controllers over Bluetooth

### DIFF
--- a/src/libultraship/libultra/os.cpp
+++ b/src/libultraship/libultra/os.cpp
@@ -24,6 +24,10 @@ int32_t osContInit(OSMesgQueue* mq, uint8_t* controllerBits, OSContStatus* statu
     }
 
     SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5, "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
     if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {
         SPDLOG_ERROR("Failed to initialize SDL game controllers ({})", SDL_GetError());
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Rumble, LED control, and gyro are unavailable when connected via Bluetooth because SDL2 gates them behind "extended input report" mode, off by default, which must be requested via hint before SDL_Init().

Tested on macOS 15.6.1, rumble/LED/gyro now work over Bluetooth.