### PR TITLE
macOS: prefer package-manager SDL2 over a stale system framework

### DIFF
--- a/cmake/dependencies/mac.cmake
+++ b/cmake/dependencies/mac.cmake
@@ -1,5 +1,25 @@
 include(FetchContent)
 
+#=================== macOS dependency discovery ===================
+# A stale or partial /Library/Frameworks/SDL2.framework can shadow a working
+# Homebrew/MacPorts SDL2 and break find_package(SDL2): its bundled CMake config
+# points SDL2_INCLUDE_DIR at a non-existent /Library/Headers, so configuration
+# fails even when a working package-manager SDL2 is installed. Search frameworks
+# last so package-manager installs win, and add the Homebrew prefix to the search
+# path so SDL2's CMake config is found without a manual -DSDL2_DIR.
+set(CMAKE_FIND_FRAMEWORK LAST)
+find_program(BREW_EXECUTABLE brew)
+if (BREW_EXECUTABLE)
+    execute_process(
+        COMMAND ${BREW_EXECUTABLE} --prefix
+        OUTPUT_VARIABLE BREW_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (BREW_PREFIX)
+        list(APPEND CMAKE_PREFIX_PATH "${BREW_PREFIX}")
+    endif()
+endif()
+
 #=================== spdlog ===================
 # macports has issues with this because of fmt
 # brew doesn't support building multiarch


### PR DESCRIPTION
## Problem
On macOS, a stale or partial `/Library/Frameworks/SDL2.framework` (left behind by some installers) shadows a working Homebrew/MacPorts SDL2 and breaks configuration:

```
File or directory /Library/Headers referenced by variable SDL2_INCLUDE_DIR does not exist !
```

The framework's bundled CMake config sets `SDL2_INCLUDE_DIR` to a non-existent `/Library/Headers`, so `find_package(SDL2 REQUIRED)` fails even though a perfectly good SDL2 is installed via Homebrew. The only current workaround is to pass `-DSDL2_DIR=...` (or delete the system framework) manually.

## Fix
In `cmake/dependencies/mac.cmake`, search frameworks **last** and add the Homebrew prefix to the search path, so the package-manager SDL2 (and its CMake config) is preferred automatically:

```cmake
set(CMAKE_FIND_FRAMEWORK LAST)
find_program(BREW_EXECUTABLE brew)
if (BREW_EXECUTABLE)
    execute_process(COMMAND ${BREW_EXECUTABLE} --prefix
                    OUTPUT_VARIABLE BREW_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
    if (BREW_PREFIX)
        list(APPEND CMAKE_PREFIX_PATH "${BREW_PREFIX}")
    endif()
endif()
```

Scoped to the macOS dependency path; no effect on other platforms. One file changed; branched off current `main`.
