### PR TITLE
fix(fast3d): don't clamp HD textures to an undefined tile region

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -546,11 +546,12 @@ static uint32_t GetEffectiveLineSize(uint32_t lineSizeBytes, uint32_t fullImageL
 }
 
 static uint32_t GetTileSizeFromCoordinates(float low, float high) {
-    float size = (high - low + 4.0f) / 4.0f;
-    if (size <= 0.0f) {
+    // An unset tile (high <= low) defines no region; return 0 so callers skip the tile-region clamp
+    // instead of collapsing the texture to the phantom 1-texel size the +4 formula would yield.
+    if (high <= low) {
         return 0;
     }
-    return static_cast<uint32_t>(lroundf(size));
+    return static_cast<uint32_t>(lroundf((high - low + 4.0f) / 4.0f));
 }
 
 void Interpreter::ImportTextureRgba16(int tile, bool importReplacement) {


### PR DESCRIPTION

<img width="198" height="211" alt="zelda_eye" src="https://github.com/user-attachments/assets/d4dac7c1-e1cf-44e0-9ef6-0735707e5768" />


## Summary

With an HD texture pack, characters whose CI eye/face textures are loaded via segment with an unset tile size render those textures as a small repeated grid. Most visible on adult Zelda / Sheik in the Temple of Time. Vanilla textures are unaffected; it only appears with HD replacements enabled.

## Root cause

Regression from #1118. That change made HD replacement textures always clamp their sampled width/height to the rendered tile region (`tex_width2`/`tex_height2`) via the `isHd` flag in `GfxSpTri1`.

These eye textures use a tile with no size set (`lrs == uls == 0`), so `tex_width2 = (lrs - uls + 4) / 4 = 1`. The `isHd` clause then clamps `tex_width` from its real 32 down to 1. Since `tex_width` is also the UV normalizer (`u / tex_width`), the vertex UVs (authored 0..32) now span 0..32, and with wrap addressing (`cms == 0`) the upscaled texture tiles ~32x across the primitive.

Instrumentation at the clamp, one HD CI8 draw (broken eye `i=1` vs. a face tile `i=0` with a real region):

```
i=1  hbs=32 vps=8  tw=32->1  tw2=1   uls=0 lrs=0    cms=0 cmt=0  siz=CI8   <- clamped to 1
i=0  hbs=64 vps=16 tw=192    tw2=192 uls=0 lrs=764  cms=2 cmt=2  siz=CI8   <- no-op (correct)
```

Before #1118 these textures rendered fine: they are wrap-mode and not pyramid-like, so the tile-region clamp never applied.

## Fix

Only force the HD tile-region clamp when the tile actually defines a region (`lrs > uls` / `lrt > ult`). The pyramid-like and explicit `G_TX_CLAMP` paths are unchanged, and HD textures that genuinely define a smaller sub-region (the case #1118 targeted) still clamp as before.

## Scope and testing

Affects any HD pack drawing actors that segment-swap a CI eye/face texture with an unset tile size (adult Zelda, Sheik, likely others). Tested with an HD pack on the Temple of Time Sheik-reveal cutscene: the eye renders correctly after the change, with no regressions seen on other textures (HUD, world, faces with real tile regions).
