### PR TITLE
fix(fast3d): upload RAW block-load textures by per-line stride, not block size

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1201,11 +1201,12 @@ void Interpreter::ImportTextureRaw(int tile, bool importReplacement) {
         memset(mTexUploadBuffer + resourceImageSizeBytes, 0, numLoadedBytes - resourceImageSizeBytes);
     }
 
-    // Describe the buffer by what was actually packed (the loaded HD stride)
-    uint32_t uploadWidth = safeLineSizeBytes / 4;
-    uint32_t uploadHeight = safeLineSizeBytes > 0 ? safeLoadedBytes / safeLineSizeBytes : 0;
-    // LoadBlock can record the whole image as one line, turning e.g. a 256x256
-    // texture into a 65536x1 upload. That exceeds GPU limits and aborts on Metal.
+    // Describe the buffer by the per-line HD stride. loaded_texture.line_size_bytes spans the whole
+    // image for block loads, which collapses the upload to an Nx1 strip and corrupts the texture;
+    // resultNewLineSize (tile line_size * h_byte_scale) is the true per-row stride for both loads.
+    uint32_t uploadWidth = resultNewLineSize / 4;
+    uint32_t uploadHeight = resultNewLineSize > 0 ? safeLoadedBytes / resultNewLineSize : 0;
+    // Safety net: a genuinely oversized replacement can still exceed the GPU limit and abort on Metal.
     if (uploadWidth > (uint32_t)mRapi->GetMaxTextureSize()) {
         if (safeLoadedBytes == (uint64_t)width * height * 4) {
             // buffer holds the full image, use its real dimensions


### PR DESCRIPTION

<img width="603" height="129" alt="corrupted_buttons" src="https://github.com/user-attachments/assets/27a0dfdc-874f-4b33-bd62-71ce7b827de2" />


## Summary

Alt-asset / HD texture-pack textures that are loaded via `LoadBlock` (button prompts, C-button symbols, etc.) render as garbage stripes or a solid block. Vanilla is unaffected; it only appears with a replacement pack enabled.

## Root cause

Regression from #1118. It rewrote `ImportTextureRaw`'s fallback upload to describe the buffer with `loaded_texture.line_size_bytes`:

```cpp
uint32_t uploadWidth  = safeLineSizeBytes / 4;
uint32_t uploadHeight = safeLineSizeBytes > 0 ? safeLoadedBytes / safeLineSizeBytes : 0;
```

For a **block-loaded** texture, `line_size_bytes` spans the *entire image* (a `LoadBlock` is one contiguous "line"), so this collapses the upload to an `N x 1` strip. Instrumented, a 768x256 RGBA32 button replacement (`gCBtnSymbolsTex`):

```
fast=false   (block load reports origH = 736/48 = 15 rows -> newH 240 != resH 256)
FALLBACK  upW=188416  upH=1          <- uploaded as 188416 x 1
          altWidth(resultNewLineSize/4)=768   <- correct per-row stride
```

The fast path is skipped because the block load reports a non-integer original height (`736 bytes / 48-byte line = 15.33 -> 15`), so `resultNewHeight (240) != resource height (256)`. Before #1118 the fallback used `resultNewLineSize / 4 = 768` (correct width).

## Fix

Describe the buffer by the per-line HD stride `resultNewLineSize` (`tile line_size x h_byte_scale`) -- the true per-row stride for both block and tile loads -- and derive height from the loaded bytes. The OOB clamp added by #1118 is preserved.

```cpp
uint32_t uploadWidth  = resultNewLineSize / 4;                                          // 768
uint32_t uploadHeight = resultNewLineSize > 0 ? safeLoadedBytes / resultNewLineSize : 0; // 245
```

## Scope and testing

Fixes any alt-asset/HD replacement loaded via `LoadBlock`. Tested with an Xbox/N64 button texture pack: the in-game equip prompt and C-button symbols now render correctly. Fast-path textures (the vast majority of HD textures) are untouched since they never reach this fallback.

Same root PR (#1118) as #1135.
