### PR TITLE
Fix Metal crash when LoadBlock uploads a texture as one giant line

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1156,6 +1156,19 @@ void Interpreter::ImportTextureRaw(int tile, bool importReplacement) {
     // Describe the buffer by what was actually packed (the loaded HD stride)
     uint32_t uploadWidth = safeLineSizeBytes / 4;
     uint32_t uploadHeight = safeLineSizeBytes > 0 ? safeLoadedBytes / safeLineSizeBytes : 0;
+    // LoadBlock can record the whole image as one line, turning e.g. a 256x256
+    // texture into a 65536x1 upload. That exceeds GPU limits and aborts on Metal.
+    if (uploadWidth > (uint32_t)mRapi->GetMaxTextureSize()) {
+        if (safeLoadedBytes == (uint64_t)width * height * 4) {
+            // buffer holds the full image, use its real dimensions
+            uploadWidth = width;
+            uploadHeight = height;
+        } else {
+            // partial load, fall back to the tile-derived dimensions
+            uploadWidth = resultNewLineSize / 4;
+            uploadHeight = resultNewHeight;
+        }
+    }
     mRapi->UploadTexture(mTexUploadBuffer, uploadWidth, uploadHeight);
 }
 


### PR DESCRIPTION
LoadBlock can record entire image as single line, so 256x256 texture becomes 65536x1 upload. If that exceeds GPU maximum texture size Metal crashes. When upload width is too wide, reshape. If buffer holds full image, use image's real dimensions; otherwise use tile-derived line size & height

See page 8 of https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf