### PR TITLE
Fix unsynchronized resource-cache write on the not-found path

### DIFF
--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -164,6 +164,7 @@ std::shared_ptr<IResource> ResourceManager::LoadResourceProcess(const ResourceId
         } else {
             SPDLOG_TRACE("Failed to load resource file at hash {}", identifier.GetPathHash());
         }
+        const std::lock_guard<std::mutex> lock(mMutex);
         mResourceCache[identifier] = ResourceLoadError::NotFound;
         return nullptr;
     }


### PR DESCRIPTION
## Problem

`ResourceManager::LoadResourceProcess` writes the not-found marker into `mResourceCache` **without holding `mMutex`**, while the success path takes the lock. Concurrent cache misses (easy to hit with `LoadResourcesAsync` or several load threads) can corrupt the `unordered_map` and crash.

Observed in practice in SpaghettiKart on macOS: several worker threads racing into `emplace` on the same map, ending in SIGSEGV with 5 threads inside `mResourceCache` operations.

## Fix

Take the same `std::lock_guard` on the not-found write that the success path already uses.

Verified in extended play sessions on macOS (Apple Silicon) with a texture-load workload that previously reproduced the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)