### PR TITLE
Normalize replacement-texture UVs by the original texture's dimensions

### DIFF
--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -229,6 +229,7 @@ struct LoadedVertex {
 
 struct RawTexMetadata {
     uint16_t width, height;
+    uint16_t orig_width = 0, orig_height = 0; // replaced texture's dims (hi-res packs); 0 = n/a
     float h_byte_scale = 1, v_pixel_scale = 1;
     std::shared_ptr<Fast::Texture> resource;
     Fast::TextureType type;
@@ -304,6 +305,11 @@ struct RDP {
         uint8_t tmem_index; // 0 or 1 for offset 0 kB or offset 2 kB, respectively
     } texture_tile[8];
     bool textures_changed[2];
+    // True while a framebuffer (SelectTextureFb) is the active texture source.
+    // FB binds bypass the settimg/load metadata path, so loaded_texture[] still
+    // describes the previously loaded texture — consumers of that metadata
+    // (e.g. hi-res replacement UV normalization) must not apply it to FB draws.
+    bool fb_texture_selected = false;
 
     uint8_t first_tile_index;
 

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -229,6 +229,7 @@ struct LoadedVertex {
 
 struct RawTexMetadata {
     uint16_t width, height;
+    uint16_t orig_width = 0, orig_height = 0; // replaced texture's dims (hi-res packs); 0 = n/a
     float h_byte_scale = 1, v_pixel_scale = 1;
     std::shared_ptr<Fast::Texture> resource;
     Fast::TextureType type;
@@ -303,6 +304,11 @@ struct RDP {
         uint8_t tmem_index; // 0 or 1 for offset 0 kB or offset 2 kB, respectively
     } texture_tile[8];
     bool textures_changed[2];
+    // True while a framebuffer (SelectTextureFb) is the active texture source.
+    // FB binds bypass the settimg/load metadata path, so loaded_texture[] still
+    // describes the previously loaded texture — consumers of that metadata
+    // (e.g. hi-res replacement UV normalization) must not apply it to FB draws.
+    bool fb_texture_selected = false;
 
     uint8_t first_tile_index;
 

--- a/include/fast/resource/type/Texture.h
+++ b/include/fast/resource/type/Texture.h
@@ -32,6 +32,11 @@ class Texture final : public Ship::Resource<uint8_t> {
 
     TextureType Type;
     uint16_t Width, Height;
+    // Dimensions of the texture this one replaces (hi-res texture packs):
+    // 0 = not a replacement / same as Width/Height. Used to normalize UVs in
+    // the original texture's texel space so tile clamp-overhang doesn't crop
+    // the replacement art.
+    uint16_t OrigWidth = 0, OrigHeight = 0;
     uint32_t Flags = 0;
     float HByteScale = 1.0;
     float VPixelScale = 1.0;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1291,9 +1291,11 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
             Flush();
             mRapi->SelectTextureFb(fbIt->second);
             mRdp->textures_changed[i] = false;
+            mRdp->fb_texture_selected = true;
             return;
         }
     }
+    mRdp->fb_texture_selected = false;
 
     if (origAddr == nullptr) {
         // Try the other TMEM slot -- some multi-tile setups only load one slot
@@ -2030,6 +2032,17 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             }
             tex_width[i] = line_size;
 
+            {
+                const RawTexMetadata* imgMeta =
+                    &mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata;
+                uint32_t imgFlags = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].tex_flags;
+                if (!mRdp->fb_texture_selected && (imgFlags & TEX_FLAG_LOAD_AS_IMG) != 0 && imgMeta->orig_width > 0 &&
+                    imgMeta->orig_height > 0) {
+                    tex_width[i] = imgMeta->orig_width;
+                    tex_height[i] = imgMeta->orig_height;
+                }
+            }
+
             tex_width2[i] = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].uls, mRdp->texture_tile[tile].lrs);
             tex_height2[i] = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].ult, mRdp->texture_tile[tile].lrt);
 
@@ -2658,6 +2671,7 @@ void Interpreter::GfxDpLoadBlock(uint8_t tile, uint32_t uls, uint32_t ult, uint3
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].tex_flags = mRdp->texture_to_load.tex_flags;
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata = mRdp->texture_to_load.raw_tex_metadata;
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].addr = mRdp->texture_to_load.addr;
+    mRdp->fb_texture_selected = false;
     // fprintf(stderr, "GfxDpLoadBlock: line_size = 0x%x; orig = 0x%x; bpp=%d; lrs=%d\n", size_bytes,
     // orig_size_bytes,
     //         mRdp->texture_to_load.siz, lrs);
@@ -2731,6 +2745,7 @@ void Interpreter::GfxDpLoadTile(uint8_t tile, uint32_t uls, uint32_t ult, uint32
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].tex_flags = mRdp->texture_to_load.tex_flags;
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata = mRdp->texture_to_load.raw_tex_metadata;
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].addr = mRdp->texture_to_load.addr + start_offset_bytes;
+    mRdp->fb_texture_selected = false;
 
     const std::string_view texPath =
         mRdp->texture_to_load.raw_tex_metadata.resource != nullptr
@@ -3160,6 +3175,8 @@ void Interpreter::Gfxs2dexBgCopy(F3DuObjBg* bg) {
         texFlags = tex->Flags;
         rawTexMetadata.width = tex->Width;
         rawTexMetadata.height = tex->Height;
+        rawTexMetadata.orig_width = tex->OrigWidth;
+        rawTexMetadata.orig_height = tex->OrigHeight;
         rawTexMetadata.h_byte_scale = tex->HByteScale;
         rawTexMetadata.v_pixel_scale = tex->VPixelScale;
         rawTexMetadata.type = tex->Type;
@@ -3197,6 +3214,8 @@ void Interpreter::Gfxs2dexBg1cyc(F3DuObjBg* bg) {
         texFlags = tex->Flags;
         rawTexMetadata.width = tex->Width;
         rawTexMetadata.height = tex->Height;
+        rawTexMetadata.orig_width = tex->OrigWidth;
+        rawTexMetadata.orig_height = tex->OrigHeight;
         rawTexMetadata.h_byte_scale = tex->HByteScale;
         rawTexMetadata.v_pixel_scale = tex->VPixelScale;
         rawTexMetadata.type = tex->Type;
@@ -4041,6 +4060,8 @@ bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
             texFlags = tex->Flags;
             rawTexMetdata.width = tex->Width;
             rawTexMetdata.height = tex->Height;
+            rawTexMetdata.orig_width = tex->OrigWidth;
+            rawTexMetdata.orig_height = tex->OrigHeight;
             rawTexMetdata.h_byte_scale = tex->HByteScale;
             rawTexMetdata.v_pixel_scale = tex->VPixelScale;
             rawTexMetdata.type = tex->Type;
@@ -4077,6 +4098,8 @@ bool gfx_set_timg_otr_hash_handler_custom(F3DGfx** cmd0) {
         texFlags = texture->Flags;
         rawTexMetadata.width = texture->Width;
         rawTexMetadata.height = texture->Height;
+        rawTexMetadata.orig_width = texture->OrigWidth;
+        rawTexMetadata.orig_height = texture->OrigHeight;
         rawTexMetadata.h_byte_scale = texture->HByteScale;
         rawTexMetadata.v_pixel_scale = texture->VPixelScale;
         rawTexMetadata.type = texture->Type;
@@ -4133,6 +4156,8 @@ bool gfx_set_timg_otr_filepath_handler_custom(F3DGfx** cmd0) {
         texFlags = texture->Flags;
         rawTexMetadata.width = texture->Width;
         rawTexMetadata.height = texture->Height;
+        rawTexMetadata.orig_width = texture->OrigWidth;
+        rawTexMetadata.orig_height = texture->OrigHeight;
         rawTexMetadata.h_byte_scale = texture->HByteScale;
         rawTexMetadata.v_pixel_scale = texture->VPixelScale;
         rawTexMetadata.type = texture->Type;
@@ -4263,6 +4288,7 @@ bool gfx_set_timg_fb_handler_custom(F3DGfx** cmd0) {
     gfx->mRapi->SelectTextureFb((uint32_t)cmd->words.w1);
     gfx->mRdp->textures_changed[0] = false;
     gfx->mRdp->textures_changed[1] = false;
+    gfx->mRdp->fb_texture_selected = true;
     return false;
 }
 

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1183,9 +1183,11 @@ void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
             Flush();
             mRapi->SelectTextureFb(fbIt->second);
             mRdp->textures_changed[i] = false;
+            mRdp->fb_texture_selected = true;
             return;
         }
     }
+    mRdp->fb_texture_selected = false;
 
     if (origAddr == nullptr) {
         // Try the other TMEM slot -- some multi-tile setups only load one slot
@@ -1922,6 +1924,27 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             }
             tex_width[i] = line_size;
 
+            // Hi-res replacement images (texture packs) upload the full
+            // replacement, whose art spans the ORIGINAL texture's texel
+            // space. The tile-byte-derived dims above can exceed the real
+            // texture (the game samples an oversized tile and relies on
+            // clamp), which would leave the bottom/right of the replacement
+            // art unsampled — visible as glyphs cut off with 4K packs.
+            // Normalize by the original texture's dims instead; the sampler
+            // clamp covers the tile overhang exactly like N64 clamp did.
+            {
+                const RawTexMetadata* imgMeta =
+                    &mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata;
+                uint32_t imgFlags = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].tex_flags;
+                // fb_texture_selected: FB binds bypass settimg/load, so the slot's
+                // metadata is stale — never apply it to framebuffer-sourced draws.
+                if (!mRdp->fb_texture_selected && (imgFlags & TEX_FLAG_LOAD_AS_IMG) != 0 && imgMeta->orig_width > 0 &&
+                    imgMeta->orig_height > 0) {
+                    tex_width[i] = imgMeta->orig_width;
+                    tex_height[i] = imgMeta->orig_height;
+                }
+            }
+
             tex_width2[i] = (uint32_t)(int32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
             tex_height2[i] = (uint32_t)(int32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
 
@@ -2514,6 +2537,7 @@ void Interpreter::GfxDpLoadBlock(uint8_t tile, uint32_t uls, uint32_t ult, uint3
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].tex_flags = mRdp->texture_to_load.tex_flags;
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata = mRdp->texture_to_load.raw_tex_metadata;
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].addr = mRdp->texture_to_load.addr;
+    mRdp->fb_texture_selected = false;
     // fprintf(stderr, "GfxDpLoadBlock: line_size = 0x%x; orig = 0x%x; bpp=%d; lrs=%d\n", size_bytes,
     // orig_size_bytes,
     //         mRdp->texture_to_load.siz, lrs);
@@ -2587,6 +2611,7 @@ void Interpreter::GfxDpLoadTile(uint8_t tile, uint32_t uls, uint32_t ult, uint32
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].tex_flags = mRdp->texture_to_load.tex_flags;
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata = mRdp->texture_to_load.raw_tex_metadata;
     mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].addr = mRdp->texture_to_load.addr + start_offset_bytes;
+    mRdp->fb_texture_selected = false;
 
     const std::string_view texPath =
         mRdp->texture_to_load.raw_tex_metadata.resource != nullptr
@@ -3013,6 +3038,8 @@ void Interpreter::Gfxs2dexBgCopy(F3DuObjBg* bg) {
         texFlags = tex->Flags;
         rawTexMetadata.width = tex->Width;
         rawTexMetadata.height = tex->Height;
+        rawTexMetadata.orig_width = tex->OrigWidth;
+        rawTexMetadata.orig_height = tex->OrigHeight;
         rawTexMetadata.h_byte_scale = tex->HByteScale;
         rawTexMetadata.v_pixel_scale = tex->VPixelScale;
         rawTexMetadata.type = tex->Type;
@@ -3050,6 +3077,8 @@ void Interpreter::Gfxs2dexBg1cyc(F3DuObjBg* bg) {
         texFlags = tex->Flags;
         rawTexMetadata.width = tex->Width;
         rawTexMetadata.height = tex->Height;
+        rawTexMetadata.orig_width = tex->OrigWidth;
+        rawTexMetadata.orig_height = tex->OrigHeight;
         rawTexMetadata.h_byte_scale = tex->HByteScale;
         rawTexMetadata.v_pixel_scale = tex->VPixelScale;
         rawTexMetadata.type = tex->Type;
@@ -3873,6 +3902,8 @@ bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
             texFlags = tex->Flags;
             rawTexMetdata.width = tex->Width;
             rawTexMetdata.height = tex->Height;
+            rawTexMetdata.orig_width = tex->OrigWidth;
+            rawTexMetdata.orig_height = tex->OrigHeight;
             rawTexMetdata.h_byte_scale = tex->HByteScale;
             rawTexMetdata.v_pixel_scale = tex->VPixelScale;
             rawTexMetdata.type = tex->Type;
@@ -3923,6 +3954,8 @@ bool gfx_set_timg_otr_hash_handler_custom(F3DGfx** cmd0) {
         texFlags = texture->Flags;
         rawTexMetadata.width = texture->Width;
         rawTexMetadata.height = texture->Height;
+        rawTexMetadata.orig_width = texture->OrigWidth;
+        rawTexMetadata.orig_height = texture->OrigHeight;
         rawTexMetadata.h_byte_scale = texture->HByteScale;
         rawTexMetadata.v_pixel_scale = texture->VPixelScale;
         rawTexMetadata.type = texture->Type;
@@ -3979,6 +4012,8 @@ bool gfx_set_timg_otr_filepath_handler_custom(F3DGfx** cmd0) {
         texFlags = texture->Flags;
         rawTexMetadata.width = texture->Width;
         rawTexMetadata.height = texture->Height;
+        rawTexMetadata.orig_width = texture->OrigWidth;
+        rawTexMetadata.orig_height = texture->OrigHeight;
         rawTexMetadata.h_byte_scale = texture->HByteScale;
         rawTexMetadata.v_pixel_scale = texture->VPixelScale;
         rawTexMetadata.type = texture->Type;
@@ -4109,6 +4144,7 @@ bool gfx_set_timg_fb_handler_custom(F3DGfx** cmd0) {
     gfx->mRapi->SelectTextureFb((uint32_t)cmd->words.w1);
     gfx->mRdp->textures_changed[0] = false;
     gfx->mRdp->textures_changed[1] = false;
+    gfx->mRdp->fb_texture_selected = true;
     return false;
 }
 


### PR DESCRIPTION
## Problem

N64 games often point a tile at a region slightly **larger** than the texture it samples (e.g. a 27×19 tile over a 26×16 texture), relying on hardware CLAMP to repeat the edge texels. The interpreter derives UV normalization from the tile, which is correct for original assets — but hi-res replacement images (`TEX_FLAG_LOAD_AS_IMG`) span the **original texture's** texel space, so tile-derived normalization means the bottom/right of the replacement art is never sampled.

With 4K texture packs in SpaghettiKart this shows as every font glyph and menu banner visibly cropped at the bottom (~16% of each glyph missing); the same pack renders correctly in N64Recomp, which maps texels exactly.

## Fix

- `Fast::Texture` gains `OrigWidth`/`OrigHeight` (the replaced texture's dims; 0 = not a replacement). Ports set them when they load a replacement image — a follow-up SpaghettiKart PR does this from the binary texture header.
- `RawTexMetadata` carries them through all five metadata fill sites.
- `GfxSpTri1` normalizes UVs by the original dims for replacement draws; the sampler's clamp then covers the tile overhang exactly like N64 clamp did.
- **Framebuffer guard:** FB binds (`SelectTextureFb`) bypass the settimg/load path, leaving stale metadata in the TMEM slot. A new `RDP::fb_texture_selected` flag (set on FB selection, cleared on load/import of a regular texture) keeps the override away from FB-sourced draws — without it, FB copies (e.g. MK64's Luigi Raceway jumbotron feed) get shredded by a previous texture's metadata.

Verified in SpaghettiKart on macOS with the MK64-Reloaded 4K pack: glyphs/banners render full-height, original assets unchanged, and the jumbotron live feed is intact. No behavior change when no replacement is loaded (`OrigWidth == 0` short-circuits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)