### PR TITLE
Round scaled viewport and scissor edges outward

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2200,10 +2200,20 @@ void Interpreter::AdjustVIewportOrScissor(XYWidthHeight* area) {
             area->y = mNativeDimensions.height - area->y;
         }
 
-        area->width *= RATIO_X(mActiveFrameBuffer, mCurDimensions);
-        area->height *= RATIO_Y(mActiveFrameBuffer, mCurDimensions);
-        area->x *= RATIO_X(mActiveFrameBuffer, mCurDimensions);
-        area->y *= RATIO_Y(mActiveFrameBuffer, mCurDimensions);
+        // Scale by computing both edges and rounding them outward: the fields
+        // are integers, so scaling width/x independently truncates and can
+        // leave the right/bottom edge up to 2px short of the true edge
+        // (visible as an unrendered column at the window edge).
+        {
+            const float rx = RATIO_X(mActiveFrameBuffer, mCurDimensions);
+            const float ry = RATIO_Y(mActiveFrameBuffer, mCurDimensions);
+            const float x2 = (area->x + (float)area->width) * rx;
+            const float y2 = (area->y + (float)area->height) * ry;
+            area->x = (int16_t)floorf(area->x * rx);
+            area->y = (int16_t)floorf(area->y * ry);
+            area->width = (uint32_t)(ceilf(x2) - area->x);
+            area->height = (uint32_t)(ceilf(y2) - area->y);
+        }
 
         if (!mRendersToFb || (mMsaaLevel > 1 && mCurDimensions.width == mGameWindowViewport.width &&
                               mCurDimensions.height == mGameWindowViewport.height)) {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2224,10 +2224,15 @@ void Interpreter::AdjustVIewportOrScissor(XYWidthHeight* area) {
         area->y = mActiveFrameBuffer->second.orig_height - area->y;
 
         if (mActiveFrameBuffer->second.resize) {
-            area->width *= RATIO_X(mActiveFrameBuffer, mCurDimensions);
-            area->height *= RATIO_Y(mActiveFrameBuffer, mCurDimensions);
-            area->x *= RATIO_X(mActiveFrameBuffer, mCurDimensions);
-            area->y *= RATIO_Y(mActiveFrameBuffer, mCurDimensions);
+            // Same as above.
+            const float rx = RATIO_X(mActiveFrameBuffer, mCurDimensions);
+            const float ry = RATIO_Y(mActiveFrameBuffer, mCurDimensions);
+            const float x2 = (area->x + (float)area->width) * rx;
+            const float y2 = (area->y + (float)area->height) * ry;
+            area->x = (int16_t)floorf(area->x * rx);
+            area->y = (int16_t)floorf(area->y * ry);
+            area->width = (uint32_t)(ceilf(x2) - area->x);
+            area->height = (uint32_t)(ceilf(y2) - area->y);
         }
     }
 }


### PR DESCRIPTION
When AdjustVIewportOrScissor scales a rectangle into window pixels, x and width are scaled independently into integer fields, so both truncate. The converted right and bottom edges can land up to two pixels short of the true edge. With the game's fullscreen scissor that clips every scene draw slightly early, which shows up as an unrendered column at the window edge at some aspect ratios (only passes with a different scissor state still paint there, so it reads as a black strip that a few elements bleed into).

Fix: compute both edges in float and round them outward, so a scaled rectangle always covers the region the original rectangle did.

Found and play-verified in SpaghettiKart on macOS (the black edge column is gone at the aspect ratios that showed it), but the code path is shared by every port and backend.