### PR TITLE
Add Palette4bpp Support for Texture Loading into ImGui

### DIFF
--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -86,7 +86,7 @@ class Fast3dGui : public Ship::Gui {
      * @param path Virtual resource path of the source image.
      * @param tint RGBA tint multiplied over the image (use ImVec4(1,1,1,1) for no tint).
      */
-    void LoadGuiTexture(const std::string& name, const std::string& path, const ImVec4& tint);
+    void LoadGuiTexture(const std::string& name, const std::string& path, const std::string& palettePath = "", const ImVec4& tint = ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
 
     /**
      * @brief Returns true if a texture with the given name is already cached.
@@ -100,7 +100,7 @@ class Fast3dGui : public Ship::Gui {
      * @param tex  Source texture data.
      * @param tint RGBA tint.
      */
-    void LoadGuiTexture(const std::string& name, const Fast::Texture& tex, const ImVec4& tint);
+    void LoadGuiTexture(const std::string& name, const Fast::Texture& tex, const std::string& palettePath = "", const ImVec4& tint = ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
 
     /**
      * @brief Removes the texture with the given name from the cache and frees GPU resources.

--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -86,7 +86,8 @@ class Fast3dGui : public Ship::Gui {
      * @param path Virtual resource path of the source image.
      * @param tint RGBA tint multiplied over the image (use ImVec4(1,1,1,1) for no tint).
      */
-    void LoadGuiTexture(const std::string& name, const std::string& path, const std::string& palettePath = "", const ImVec4& tint = ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
+    void LoadGuiTexture(const std::string& name, const std::string& path, const std::string& palettePath = "",
+                        const ImVec4& tint = ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
 
     /**
      * @brief Returns true if a texture with the given name is already cached.
@@ -100,7 +101,8 @@ class Fast3dGui : public Ship::Gui {
      * @param tex  Source texture data.
      * @param tint RGBA tint.
      */
-    void LoadGuiTexture(const std::string& name, const Fast::Texture& tex, const std::string& palettePath = "", const ImVec4& tint = ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
+    void LoadGuiTexture(const std::string& name, const Fast::Texture& tex, const std::string& palettePath = "",
+                        const ImVec4& tint = ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
 
     /**
      * @brief Removes the texture with the given name from the cache and frees GPU resources.

--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -575,7 +575,7 @@ void Fast3dGui::LoadTextureFromResource(const std::string& name, std::shared_ptr
     mGuiTextures[name] = texture->Metadata;
 }
 
-void Fast3dGui::LoadGuiTexture(const std::string& name, const Fast::Texture& res, const ImVec4& tint) {
+void Fast3dGui::LoadGuiTexture(const std::string& name, const Fast::Texture& res, const std::string& palettePath, const ImVec4 & tint) {
     GfxRenderingAPI* api = mInterpreter.lock()->GetCurrentRenderingAPI();
     std::vector<uint8_t> texBuffer;
     texBuffer.reserve(res.Width * res.Height * 4);
@@ -583,7 +583,7 @@ void Fast3dGui::LoadGuiTexture(const std::string& name, const Fast::Texture& res
     // For HD textures we need to load the buffer raw (similar to inside gfx_pp)
     if ((res.Flags & TEX_FLAG_LOAD_AS_RAW) != 0) {
         // Raw loading doesn't support TLUT textures
-        if (res.Type == Fast::TextureType::Palette4bpp || res.Type == Fast::TextureType::Palette8bpp) {
+        if (res.Type == Fast::TextureType::Palette8bpp) {
             // TODO convert other image types
             SPDLOG_WARN("ImGui::ResourceLoad: Attempting to load unsupported image type");
             return;
@@ -607,6 +607,50 @@ void Fast3dGui::LoadGuiTexture(const std::string& name, const Fast::Texture& res
                     texBuffer.push_back(g);
                     texBuffer.push_back(b);
                     texBuffer.push_back(a);
+                }
+                break;
+            }
+            case Fast::TextureType::Palette4bpp: {
+                if (palettePath.empty()) {
+                    SPDLOG_WARN("ImGui::ResourceLoad: Palette4bpp requires a palette path for asset: {}", name);
+                    return;
+                }
+
+                auto paletteRes = std::static_pointer_cast<Fast::Texture>(
+                    Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(palettePath)
+                );
+
+                if (!paletteRes || !paletteRes->ImageData) {
+                    SPDLOG_WARN("ImGui::ResourceLoad: Failed to load palette asset from path: {}", palettePath);
+                    return;
+                }
+
+                for (int32_t i = 0; i < res.Width * res.Height; i += 2) {
+                    uint8_t b = res.ImageData[i / 2];
+
+                    uint8_t idx1 = b >> 4;
+                    uint8_t p1_b1 = paletteRes->ImageData[idx1 * 2 + 0];
+                    uint8_t p1_b2 = paletteRes->ImageData[idx1 * 2 + 1];
+                    uint8_t r1 = (p1_b1 >> 3) * 0xFF / 0x1F;
+                    uint8_t g1 = (((p1_b1 & 7) << 2) | (p1_b2 >> 6)) * 0xFF / 0x1F;
+                    uint8_t b1 = ((p1_b2 >> 1) & 0x1F) * 0xFF / 0x1F;
+                    uint8_t a1 = 0xFF * (p1_b2 & 1);
+                    texBuffer.push_back(r1);
+                    texBuffer.push_back(g1);
+                    texBuffer.push_back(b1);
+                    texBuffer.push_back(a1);
+
+                    uint8_t idx2 = b & 0xF;
+                    uint8_t p2_b1 = paletteRes->ImageData[idx2 * 2 + 0];
+                    uint8_t p2_b2 = paletteRes->ImageData[idx2 * 2 + 1];
+                    uint8_t r2 = (p2_b1 >> 3) * 0xFF / 0x1F;
+                    uint8_t g2 = (((p2_b1 & 7) << 2) | (p2_b2 >> 6)) * 0xFF / 0x1F;
+                    uint8_t b2 = ((p2_b2 >> 1) & 0x1F) * 0xFF / 0x1F;
+                    uint8_t a2 = 0xFF * (p2_b2 & 1);
+                    texBuffer.push_back(r2);
+                    texBuffer.push_back(g2);
+                    texBuffer.push_back(b2);
+                    texBuffer.push_back(a2);
                 }
                 break;
             }
@@ -709,11 +753,11 @@ void Fast3dGui::LoadGuiTexture(const std::string& name, const Fast::Texture& res
     mGuiTextures[name] = asset;
 }
 
-void Fast3dGui::LoadGuiTexture(const std::string& name, const std::string& path, const ImVec4& tint) {
+void Fast3dGui::LoadGuiTexture(const std::string& name, const std::string& path, const std::string& palettePath, const ImVec4& tint) {
     const auto res = static_cast<Fast::Texture*>(
         Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(path, true).get());
 
-    LoadGuiTexture(name, *res, tint);
+    LoadGuiTexture(name, *res, palettePath, tint);
 }
 
 void Fast3dGui::UnloadTexture(const std::string& name) {

--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -617,8 +617,7 @@ void Fast3dGui::LoadGuiTexture(const std::string& name, const Fast::Texture& res
                 }
 
                 auto paletteRes = std::static_pointer_cast<Fast::Texture>(
-                    Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(palettePath)
-                );
+                    Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(palettePath));
 
                 if (!paletteRes || !paletteRes->ImageData) {
                     SPDLOG_WARN("ImGui::ResourceLoad: Failed to load palette asset from path: {}", palettePath);

--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -575,7 +575,8 @@ void Fast3dGui::LoadTextureFromResource(const std::string& name, std::shared_ptr
     mGuiTextures[name] = texture->Metadata;
 }
 
-void Fast3dGui::LoadGuiTexture(const std::string& name, const Fast::Texture& res, const std::string& palettePath, const ImVec4 & tint) {
+void Fast3dGui::LoadGuiTexture(const std::string& name, const Fast::Texture& res, const std::string& palettePath,
+                               const ImVec4& tint) {
     GfxRenderingAPI* api = mInterpreter.lock()->GetCurrentRenderingAPI();
     std::vector<uint8_t> texBuffer;
     texBuffer.reserve(res.Width * res.Height * 4);
@@ -752,7 +753,8 @@ void Fast3dGui::LoadGuiTexture(const std::string& name, const Fast::Texture& res
     mGuiTextures[name] = asset;
 }
 
-void Fast3dGui::LoadGuiTexture(const std::string& name, const std::string& path, const std::string& palettePath, const ImVec4& tint) {
+void Fast3dGui::LoadGuiTexture(const std::string& name, const std::string& path, const std::string& palettePath,
+                               const ImVec4& tint) {
     const auto res = static_cast<Fast::Texture*>(
         Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(path, true).get());
 

--- a/src/libultraship/window/gui/GfxDebuggerWindow.cpp
+++ b/src/libultraship/window/gui/GfxDebuggerWindow.cpp
@@ -646,7 +646,7 @@ void GfxDebuggerWindow::DrawDisas() {
 
                 if (isNew && metadata.resource != nullptr) {
                     gui->UnloadTexture(name);
-                    gui->LoadGuiTexture(name, *metadata.resource, ImVec4{ 1.0f, 1.0f, 1.0f, 1.0f });
+                    gui->LoadGuiTexture(name, *metadata.resource, nullptr, ImVec4{ 1.0f, 1.0f, 1.0f, 1.0f });
                 }
 
                 ImGui::Image(gui->GetTextureByName(name), ImVec2{ 100.0f, 100.0f });


### PR DESCRIPTION
This adds Palette4bpp texture type support for Fast3d, enabling textures of that format to be loaded into ImGui.