### PR TITLE
Recover saved window backend by name when saved IDs go stale

### DIFF
--- a/include/fast/Fast3dWindow.h
+++ b/include/fast/Fast3dWindow.h
@@ -65,6 +65,7 @@ class Fast3dWindow : public Ship::Window {
     const char* GetKeyName(int32_t scancode) override;
 
     std::string GetWindowBackendName() override;
+    int32_t GetWindowBackendIdByName(const std::string& name) override;
 
     void SetCurrentDimensions(uint32_t width, uint32_t height) override;
     void SetCurrentDimensions(uint32_t width, uint32_t height, int32_t posX, int32_t posY) override;

--- a/include/ship/window/Window.h
+++ b/include/ship/window/Window.h
@@ -211,6 +211,15 @@ class Window {
      * override this to return backend-specific names such as "OpenGL", "Metal", or "DirectX 11".
      */
     virtual std::string GetWindowBackendName();
+    /**
+     * @brief Resolves a backend name (as produced by GetWindowBackendName) back to its ID.
+     * Subclasses that override GetWindowBackendName should override this with the reverse
+     * mapping. Used to recover saved configs when backend IDs are renumbered between
+     * versions: the stored name identifies the backend even when the stored ID has gone
+     * stale. Returns -1 when the name is unknown.
+     * @param name Backend name to resolve.
+     */
+    virtual int32_t GetWindowBackendIdByName(const std::string& name);
     /** @brief Returns the list of backends available on this platform. */
     std::shared_ptr<std::vector<int32_t>> GetAvailableWindowBackends();
     /**

--- a/src/fast/Fast3dWindow.cpp
+++ b/src/fast/Fast3dWindow.cpp
@@ -406,6 +406,19 @@ std::string Fast3dWindow::GetWindowBackendName() {
     }
 }
 
+int32_t Fast3dWindow::GetWindowBackendIdByName(const std::string& name) {
+    if (name == "DirectX 11") {
+        return WindowBackend::FAST3D_DXGI_DX11;
+    }
+    if (name == "OpenGL") {
+        return WindowBackend::FAST3D_SDL_OPENGL;
+    }
+    if (name == "Metal") {
+        return WindowBackend::FAST3D_SDL_METAL;
+    }
+    return -1;
+}
+
 void Fast3dWindow::SetCurrentDimensions(uint32_t width, uint32_t height) {
     SetCurrentDimensions(width, height, GetPosX(), GetPosY());
 }

--- a/src/ship/window/Window.cpp
+++ b/src/ship/window/Window.cpp
@@ -133,6 +133,24 @@ void Window::AddAvailableWindowBackend(int32_t backend) {
 
 int32_t Window::GetSavedWindowBackend() {
     auto backendId = mConfig->GetInt("Window.Backend.Id", -1);
+
+    // The saved name identifies the backend even when saved IDs go stale
+    // (backend IDs were renumbered once already, silently switching existing
+    // configs to a different renderer). When the name resolves to an
+    // available backend, trust it over the ID and heal the config.
+    auto backendName = mConfig->GetString("Window.Backend.Name", "");
+    if (!backendName.empty()) {
+        auto backendIdFromName = GetWindowBackendIdByName(backendName);
+        if (backendIdFromName != -1 && IsAvailableWindowBackend(backendIdFromName)) {
+            if (backendIdFromName != backendId) {
+                SPDLOG_INFO("Saved WindowBackend id ({}) does not match saved name \"{}\"; migrating config to id {}.",
+                            backendId, backendName, backendIdFromName);
+                mConfig->SetInt("Window.Backend.Id", backendIdFromName);
+            }
+            return backendIdFromName;
+        }
+    }
+
     if (IsAvailableWindowBackend(backendId)) {
         return backendId;
     }
@@ -149,5 +167,9 @@ int32_t Window::GetSavedWindowBackend() {
 
 std::string Window::GetWindowBackendName() {
     return "";
+}
+
+int32_t Window::GetWindowBackendIdByName(const std::string& name) {
+    return -1;
 }
 } // namespace Ship


### PR DESCRIPTION
Fixes #1153.

The config stores both `Window.Backend.Id` and `Window.Backend.Name`, but only the ID was read back on startup. The WindowBackend renumbering shifted every ID by one, so existing configs silently changed renderer: a saved Metal config re-resolved as OpenGL (with a noticeable frame pacing and audio hit on macOS), and a saved DirectX 11 config (old id 0) fell out of range and dropped to the platform default.

This makes `GetSavedWindowBackend` resolve the saved name first, through a new `GetWindowBackendIdByName` virtual (the reverse mapping of the existing `GetWindowBackendName`), and heal the stored ID when the two disagree. The name strings ("DirectX 11", "OpenGL", "Metal") predate the renumbering and are stable across it, so old configs land back on the renderer the user actually chose. Same approach as the config migration precedent in #362.

Behavior by case:
- Fresh install (no name, no id): unchanged, platform default.
- Current-format config (name and id agree): unchanged, fast path.
- Pre-renumbering Metal config (name "Metal", id 2): resolves to Metal, id healed.
- Pre-renumbering DirectX 11 config (name "DirectX 11", id 0): resolves to DX11, id healed.
- Unknown/garbage name: falls through to the existing id validation unchanged.

Compile-verified standalone on macOS (Apple Silicon) against port-maintenance; the case table above is from code inspection of the resolve path. Happy to runtime-verify with a doctored pre-renumbering config on a port-maintenance-based SpaghettiKart build if that's wanted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
