### PR TITLE
Resolve .meta aliases by archive priority

### DIFF
--- a/include/ship/resource/ResourceLoader.h
+++ b/include/ship/resource/ResourceLoader.h
@@ -111,6 +111,16 @@ class ResourceLoader {
     std::shared_ptr<ResourceInitData> ReadResourceInitData(const std::string& filePath,
                                                            std::shared_ptr<File> metaFileToLoad);
 
+    /**
+     * @brief Resolves a `.meta` alias at filePath, if one wins over the real asset.
+     * @param filePath   Virtual path being loaded.
+     * @param fileToLoad In/out: the highest-priority real asset at filePath (may be null). On a
+     *                   successful alias, this is replaced with the aliased target's file.
+     * @return The alias target's init data if its archive is equal-or-higher priority than the
+     *         real asset's; otherwise nullptr (fileToLoad left unchanged).
+     */
+    std::shared_ptr<ResourceInitData> ResolveMetaAlias(const std::string& filePath, std::shared_ptr<File>& fileToLoad);
+
     /** @brief Creates a ResourceInitData with default/zeroed fields. */
     static std::shared_ptr<ResourceInitData> CreateDefaultResourceInitData();
 

--- a/include/ship/resource/archive/Archive.h
+++ b/include/ship/resource/archive/Archive.h
@@ -156,6 +156,15 @@ class Archive : public std::enable_shared_from_this<Archive> {
     bool IsLoaded();
 
     /**
+     * @brief Load-order priority assigned by the ArchiveManager when the archive is mounted
+     * (higher = higher priority; the last-loaded archive wins conflicts). -1 if unset.
+     */
+    int32_t GetPriority();
+
+    /** @brief Sets the load-order priority. Called by the ArchiveManager. */
+    void SetPriority(int32_t priority);
+
+    /**
      * @brief Opens the underlying archive file or directory for reading.
      * @return true on success.
      */
@@ -194,6 +203,7 @@ class Archive : public std::enable_shared_from_this<Archive> {
     bool mIsChecksumValid;
     bool mHasGameVersion;
     uint32_t mGameVersion;
+    int32_t mPriority = -1;
     ArchiveManifest mManifest;
     std::string mPath;
     std::shared_ptr<std::unordered_map<uint64_t, std::string>> mHashes;

--- a/include/ship/resource/archive/ArchiveManager.h
+++ b/include/ship/resource/archive/ArchiveManager.h
@@ -144,6 +144,14 @@ class ArchiveManager {
     GetArchiveFromFile(const std::string& filePath); // Retrieves a ptr to the archive that the asset is inside of
 
     /**
+     * @brief Load-order priority of the archive that owns the given file (higher = higher
+     * priority; the last-loaded archive wins). Used to rank a real asset against an alias target.
+     * @param filePath Virtual path of the file.
+     * @return Priority index, or -1 if no loaded archive has the file.
+     */
+    int32_t GetFilePriority(const std::string& filePath);
+
+    /**
      * @brief Lists virtual paths of all files matching the given search mask across all archives.
      * @param searchMask Glob pattern (empty = list everything).
      * @return Sorted, deduplicated list of matching paths.

--- a/src/ship/resource/ResourceLoader.cpp
+++ b/src/ship/resource/ResourceLoader.cpp
@@ -182,6 +182,29 @@ std::shared_ptr<ResourceInitData> ResourceLoader::ReadResourceInitData(const std
     return initData;
 }
 
+// Position File::BufferOffset at the resource body. A currently-headed binary resource keeps an OTR
+// header ahead of its body; when init data was supplied externally (a caller or a `.meta`) rather
+// than parsed from that header, skip past it. Headerless buffers (a shader, or any asset once
+// Kenix3/libultraship#1160 removes the header) have no valid byte order / matching type and are left
+// at offset 0. Remove this and its call sites along with the header under #1160.
+static void SetBufferOffset(const std::shared_ptr<File>& file, const std::shared_ptr<ResourceInitData>& initData) {
+    if (file == nullptr || initData->Format != RESOURCE_FORMAT_BINARY || file->Buffer->size() < OTR_HEADER_SIZE) {
+        return;
+    }
+    auto reader = std::make_shared<BinaryReader>(std::make_shared<MemoryStream>(file->Buffer));
+    auto byteOrder = (Endianness)reader->ReadInt8();
+    if (byteOrder != Endianness::Little && byteOrder != Endianness::Big) {
+        return;
+    }
+    reader->SetEndianness(byteOrder);
+    reader->ReadInt8(); // isCustom
+    reader->ReadInt8(); // reserved
+    reader->ReadInt8(); // reserved
+    if (reader->ReadUInt32() == initData->Type) {
+        file->BufferOffset = OTR_HEADER_SIZE;
+    }
+}
+
 std::shared_ptr<ResourceInitData> ResourceLoader::ResolveMetaAlias(const std::string& filePath,
                                                                    std::shared_ptr<File>& fileToLoad) {
     auto resourceManager = Context::GetRawInstance()->GetResourceManager();
@@ -213,11 +236,13 @@ std::shared_ptr<IResource> ResourceLoader::LoadResource(std::string filePath, st
                                                         std::shared_ptr<ResourceInitData> initData) {
     // fileToLoad is the highest-priority real asset at filePath, or null when the resource
     // exists only as a `.meta` alias. Prefer a winning alias, else read the real asset's header.
+    bool legacyInitData = false;
     if (initData == nullptr) {
         initData = ResolveMetaAlias(filePath, fileToLoad);
     }
     if (initData == nullptr && fileToLoad != nullptr) {
         initData = ReadResourceInitDataLegacy(filePath, fileToLoad);
+        legacyInitData = true;
     }
 
     if (fileToLoad == nullptr) {
@@ -227,6 +252,9 @@ std::shared_ptr<IResource> ResourceLoader::LoadResource(std::string filePath, st
 
     switch (initData->Format) {
         case RESOURCE_FORMAT_BINARY:
+            if (!legacyInitData) {
+                SetBufferOffset(fileToLoad, initData);
+            }
             fileToLoad->Reader = CreateBinaryReader(fileToLoad, initData);
             break;
         case RESOURCE_FORMAT_XML:

--- a/src/ship/resource/ResourceLoader.cpp
+++ b/src/ship/resource/ResourceLoader.cpp
@@ -182,24 +182,42 @@ std::shared_ptr<ResourceInitData> ResourceLoader::ReadResourceInitData(const std
     return initData;
 }
 
-std::shared_ptr<IResource> ResourceLoader::LoadResource(std::string filePath, std::shared_ptr<File> fileToLoad,
-                                                        std::shared_ptr<ResourceInitData> initData) {
-    if (fileToLoad == nullptr) {
-        SPDLOG_ERROR("Failed to load resource: File not loaded");
+std::shared_ptr<ResourceInitData> ResourceLoader::ResolveMetaAlias(const std::string& filePath,
+                                                                   std::shared_ptr<File>& fileToLoad) {
+    auto resourceManager = Context::GetRawInstance()->GetResourceManager();
+    auto metaFileToLoad = resourceManager->LoadFileProcess(filePath + ".meta");
+    if (metaFileToLoad == nullptr) {
         return nullptr;
     }
 
-    if (initData == nullptr) {
-        auto metaFilePath = filePath + ".meta";
-        auto metaFileToLoad = Context::GetRawInstance()->GetResourceManager()->LoadFileProcess(metaFilePath);
+    auto metaInitData = ReadResourceInitData(filePath, metaFileToLoad);
+    auto aliasedFileToLoad = resourceManager->LoadFileProcess(metaInitData->Path);
+    if (aliasedFileToLoad == nullptr) {
+        return nullptr;
+    }
 
-        if (metaFileToLoad != nullptr) {
-            auto initDataFromMetaFile = ReadResourceInitData(filePath, metaFileToLoad);
-            fileToLoad = Context::GetRawInstance()->GetResourceManager()->LoadFileProcess(initDataFromMetaFile->Path);
-            initData = initDataFromMetaFile;
-        } else {
-            initData = ReadResourceInitDataLegacy(filePath, fileToLoad);
-        }
+    // The alias wins only if its target lives in an equal-or-higher priority archive than the
+    // real asset at filePath (ties go to the alias; a missing real asset reports priority -1).
+    auto archiveManager = resourceManager->GetArchiveManager();
+    int32_t realPriority = archiveManager->GetFilePriority(filePath);
+    int32_t aliasPriority = archiveManager->GetFilePriority(metaInitData->Path);
+    if (aliasPriority < realPriority) {
+        return nullptr;
+    }
+
+    fileToLoad = aliasedFileToLoad;
+    return metaInitData;
+}
+
+std::shared_ptr<IResource> ResourceLoader::LoadResource(std::string filePath, std::shared_ptr<File> fileToLoad,
+                                                        std::shared_ptr<ResourceInitData> initData) {
+    // fileToLoad is the highest-priority real asset at filePath, or null when the resource
+    // exists only as a `.meta` alias. Prefer a winning alias, else read the real asset's header.
+    if (initData == nullptr) {
+        initData = ResolveMetaAlias(filePath, fileToLoad);
+    }
+    if (initData == nullptr && fileToLoad != nullptr) {
+        initData = ReadResourceInitDataLegacy(filePath, fileToLoad);
     }
 
     if (fileToLoad == nullptr) {

--- a/src/ship/resource/ResourceLoader.cpp
+++ b/src/ship/resource/ResourceLoader.cpp
@@ -178,6 +178,7 @@ std::shared_ptr<ResourceInitData> ResourceLoader::ReadResourceInitData(const std
     initData->Type =
         Context::GetRawInstance()->GetResourceManager()->GetResourceLoader()->GetResourceType(parsed["type"]);
     initData->ResourceVersion = parsed["version"];
+    initData->IsCustom = parsed.value("isCustom", false);
 
     return initData;
 }

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -393,6 +393,12 @@ void ResourceManager::UnloadResourcesProcess(const ResourceFilter& filter) {
 
     for (const auto& key : *list.get()) {
         UnloadResource({ key, mDefaultCacheOwner, mDefaultCacheArchive });
+
+        // A `.meta` alias resource is cached under its base path, which is not itself a listed
+        // file. Evict it too so it can't survive stale after its target/dependencies are unloaded.
+        if (key.ends_with(".meta")) {
+            UnloadResource({ key.substr(0, key.size() - 5), mDefaultCacheOwner, mDefaultCacheArchive });
+        }
     }
 }
 

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -149,9 +149,11 @@ std::shared_ptr<IResource> ResourceManager::LoadResourceProcess(const ResourceId
         }
     }
 
-    // Get the file from the OTR
+    // Get the file from the OTR. It may be null when the resource exists only as a `.meta`
+    // alias (no real file at this path); fall through so the loader can resolve the alias,
+    // but only when a `.meta` for this path actually exists.
     auto file = LoadFileProcess(identifier.Path);
-    if (file == nullptr) {
+    if (file == nullptr && !mArchiveManager->HasFile(identifier.Path + ".meta")) {
         SPDLOG_TRACE("Failed to load resource file at path {}", identifier.Path);
         mResourceCache[identifier] = ResourceLoadError::NotFound;
         return nullptr;

--- a/src/ship/resource/archive/Archive.cpp
+++ b/src/ship/resource/archive/Archive.cpp
@@ -167,16 +167,23 @@ void Archive::SetLoaded(bool isLoaded) {
     mIsLoaded = isLoaded;
 }
 
+int32_t Archive::GetPriority() {
+    return mPriority;
+}
+
+void Archive::SetPriority(int32_t priority) {
+    mPriority = priority;
+}
+
 void Archive::SetGameVersion(uint32_t gameVersion) {
     mGameVersion = gameVersion;
 }
 
 void Archive::IndexFile(const std::string& filePath) {
-    if (filePath.length() > 5 && filePath.substr(filePath.length() - 5) == ".meta") {
-        IndexFile(filePath.substr(0, filePath.length() - 5));
-        return;
-    }
-
+    // Index every file under its literal name, including `.meta` sidecars. Keeping `foo`
+    // (a real asset) and `foo.meta` (its alias sidecar) as distinct entries lets resolution
+    // tell "has a real foo" from "has a foo.meta" — the previous suffix-stripping conflated
+    // the two, which is the root of the alias-shadowing bug.
     (*mHashes)[CRC64(filePath.c_str())] = filePath;
 }
 

--- a/src/ship/resource/archive/ArchiveManager.cpp
+++ b/src/ship/resource/archive/ArchiveManager.cpp
@@ -68,6 +68,14 @@ std::shared_ptr<Archive> ArchiveManager::GetArchiveFromFile(const std::string& f
     return mFileToArchive[CRC64(filePath.c_str())];
 }
 
+int32_t ArchiveManager::GetFilePriority(const std::string& filePath) {
+    auto it = mFileToArchive.find(CRC64(filePath.c_str()));
+    if (it == mFileToArchive.end() || it->second == nullptr) {
+        return -1;
+    }
+    return it->second->GetPriority();
+}
+
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::string& searchMask) {
     std::list<std::string> includes = {};
     if (!searchMask.empty()) {
@@ -275,6 +283,8 @@ std::shared_ptr<Archive> ArchiveManager::AddArchive(std::shared_ptr<Archive> arc
     SPDLOG_INFO("Adding Archive {} to Archive Manager", archive->GetPath());
 
     mArchives.push_back(archive);
+    // Index in mArchives is the load-order priority (last added = highest, wins conflicts).
+    archive->SetPriority(static_cast<int32_t>(mArchives.size() - 1));
     if (archive->HasGameVersion()) {
         mGameVersions.push_back(archive->GetGameVersion());
     }


### PR DESCRIPTION
## Summary

Reworks `.meta` alias resolution so a request for `X` loads the **highest-priority provider**
among:

- the real asset at `X`, and
- the target of any `X.meta` alias,

ranked by the archive each **asset** lives in (last-loaded archive wins; ties go to the alias).

Fixes #984
Resolves #1165 

- **#984** — `.meta` aliases stopped resolving. Root cause: `Archive::IndexFile` stripped the
  `.meta` suffix, conflating a real `foo` with its `foo.meta`, so the loader's `foo.meta` lookup
  could never resolve (and a `.meta`-only resource was unreachable).
- **#1165** — a `.meta` alias must fall back to the real asset when its target is missing, and (the
  cross-game case) a lower-priority archive's `.meta` whose target lives in a *higher*-priority
  archive must win over an intervening real asset.

## Model

`X.meta → Y` makes `Y` an alternate provider of `X`. Resolving `X` compares the real `X` against
the aliased `Y` by the priority of the archive where each **asset** lives (not where the `.meta`
lives), and loads the higher-priority one; ties go to the alias. "Fall back to the real asset" is
simply the case where the alias's target doesn't exist, so the real asset is the only provider
left.

## Changes

1. **`Archive::IndexFile`** — index every file under its literal name (no `.meta` stripping), so a
   real `foo` and its `foo.meta` are distinct index entries.
2. **`Archive::Get/SetPriority` + `ArchiveManager::GetFilePriority`** — O(1) load-order priority of
   the archive that owns a given path.
3. **`ResourceManager::LoadResourceProcess`** — only bail when neither the real file nor a `.meta`
   exists, so a resource that exists only as a `.meta` reaches the loader.
4. **`ResourceLoader::ResolveMetaAlias` / `LoadResource`** — pick the higher-priority provider
   (real asset vs alias target); ties go to the alias.

## Testing

Verified end-to-end in Ship of Harkinian with a dedicated test kit (companion testing PR:
https://github.com/HarbourMasters/Shipwright/pull/6977) that aliases the boot ship-logo DisplayList and recolors the assets so the loaded
one is obvious. It covers the full matrix:

- single-mod cases: target-present, fallback, meta-only, no-`.meta` regression;
- layered archive-priority cases: the cross-game "flagship" (a `.meta` below a real, whose target
  is higher, wins), "real above the alias target" (real wins), and "target below the `.meta`"
  (resolved by normal global lookup).

Baseline (stock engine) and after-fix results were both captured; every case matches, with five
result flips vs. baseline proving the fix.

## Notes

- Targets `port-maintenance`.
- Minor behavior change from the `Archive::IndexFile` change: a resource that exists *only* as `X.meta` is no longer in the
  base-name index, so `HasFile(X)` returns false for it. Resolution still works (the loader checks
  `X.meta`), but callers that gate on existence before loading would skip such a resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


