### PR TITLE
[port-maintenance] fix an undefined symbol in `NON_PORTABLE` builds

### DIFF
--- a/src/ship/Context.cpp
+++ b/src/ship/Context.cpp
@@ -556,7 +556,7 @@ std::string Context::GetAppDirectoryPath(const std::string& appName) {
 #endif
 
 #ifdef NON_PORTABLE
-    const std::string& effectiveAppName = appName.empty() ? GetInstance()->mShortName : appName;
+    const std::string& effectiveAppName = appName.empty() ? GetRawInstance()->mShortName : appName;
     char* prefpath = SDL_GetPrefPath(NULL, effectiveAppName.c_str());
     if (prefpath != NULL) {
         std::string ret(prefpath);


### PR DESCRIPTION
It looks like this was the only site where `Context::GetInstance` was not changed over to `Context::GetRawInstance` in #1103. I've been applying the same solution in a git patch on various nix/nixos builds without any *obvious* issues, so I may as well PR this.