### PR TITLE
fast3d: reshape RAW block-load texture uploads that arrive as a single line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -372,3 +372,5 @@ extern/nlohmann-json/*_jsonConfig*
 *.xcworkspace
 *.xcsettings
 build*
+# clang-format.exe fetched by run-clang-format.ps1
+/clang-format.exe

--- a/run-clang-format.ps1
+++ b/run-clang-format.ps1
@@ -1,0 +1,101 @@
+[CmdletBinding()]
+param(
+    [switch]$Check
+)
+
+$ErrorActionPreference = 'Stop'
+
+$llvmVersion = '14.0.6'
+$llvmUrl = "https://github.com/llvm/llvm-project/releases/download/llvmorg-$llvmVersion/LLVM-$llvmVersion-win64.exe"
+$localClangFormat = Join-Path $PSScriptRoot 'clang-format.exe'
+
+function Get-ClangFormatMajor {
+    param([string]$Exe)
+    try {
+        $versionText = & $Exe --version
+    } catch {
+        return $null
+    }
+    if ($versionText -match 'version\s+(\d+)\.') {
+        return [int]$Matches[1]
+    }
+    return $null
+}
+
+function Get-7ZipPath {
+    $cmd = Get-Command '7z.exe' -ErrorAction SilentlyContinue
+    if ($null -ne $cmd) {
+        return $cmd.Source
+    }
+    $defaultPath = 'C:\Program Files\7-Zip\7z.exe'
+    if (Test-Path $defaultPath -PathType Leaf) {
+        return $defaultPath
+    }
+    return $null
+}
+
+$clangFormat = $null
+
+if (Test-Path $localClangFormat -PathType Leaf) {
+    if ((Get-ClangFormatMajor $localClangFormat) -eq 14) {
+        $clangFormat = $localClangFormat
+    } else {
+        Write-Host 'Local clang-format.exe is not version 14, replacing it.'
+        Remove-Item $localClangFormat -Force
+    }
+}
+
+if ($null -eq $clangFormat) {
+    $onPath = Get-Command 'clang-format' -ErrorAction SilentlyContinue
+    if ($null -ne $onPath) {
+        if ((Get-ClangFormatMajor $onPath.Source) -eq 14) {
+            $clangFormat = $onPath.Source
+            Write-Host "Using clang-format from PATH: $clangFormat"
+        }
+    }
+}
+
+if ($null -eq $clangFormat) {
+    $sevenZip = Get-7ZipPath
+    if ($null -eq $sevenZip) {
+        Write-Host 'clang-format 14 was not found, and 7-Zip is needed to extract it from the LLVM installer.'
+        Write-Host 'Install 7-Zip, or put a clang-format 14 on PATH, then re-run.'
+        exit 1
+    }
+
+    $installer = Join-Path $PSScriptRoot "LLVM-$llvmVersion-win64.exe"
+    Write-Host "Downloading LLVM $llvmVersion to extract clang-format..."
+    Invoke-WebRequest -Uri $llvmUrl -OutFile $installer
+
+    Write-Host 'Extracting clang-format.exe...'
+    & $sevenZip e $installer 'bin\clang-format.exe' "-o$PSScriptRoot" -aoa | Out-Null
+    Remove-Item $installer -Force
+
+    if (-not (Test-Path $localClangFormat -PathType Leaf)) {
+        Write-Host 'Extraction failed: clang-format.exe was not produced.'
+        exit 1
+    }
+    $clangFormat = $localClangFormat
+}
+
+Write-Host "Using $(& $clangFormat --version)"
+
+$roots = @('src', 'include') | ForEach-Object { Join-Path $PSScriptRoot $_ } | Where-Object { Test-Path $_ }
+
+$files = Get-ChildItem -Path $roots -Recurse -File |
+    Where-Object { $_.Extension -in '.cpp', '.h' }
+
+if ($files.Count -eq 0) {
+    Write-Host 'No source files found. Run this from the repository root.'
+    exit 1
+}
+
+$index = 0
+foreach ($file in $files) {
+    $index++
+    $relativePath = $file.FullName.Substring($PSScriptRoot.Length + 1)
+    Write-Host "Formatting [$index/$($files.Count)] $relativePath"
+    & $clangFormat -i $file.FullName
+}
+
+Write-Host "Formatted $($files.Count) files."

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1204,9 +1204,9 @@ void Interpreter::ImportTextureRaw(int tile, bool importReplacement) {
     // Describe the buffer by what was actually packed (the loaded HD stride)
     uint32_t uploadWidth = safeLineSizeBytes / 4;
     uint32_t uploadHeight = safeLineSizeBytes > 0 ? safeLoadedBytes / safeLineSizeBytes : 0;
-    // LoadBlock can record the whole image as one line, turning e.g. a 256x256
-    // texture into a 65536x1 upload. That exceeds GPU limits and aborts on Metal.
-    if (uploadWidth > (uint32_t)mRapi->GetMaxTextureSize()) {
+    const bool singleLineLoad =
+        uploadHeight <= 1 && resultNewLineSize != 0 && resultNewLineSize < safeLineSizeBytes;
+    if (uploadWidth > (uint32_t)mRapi->GetMaxTextureSize() || singleLineLoad) {
         if (safeLoadedBytes == (uint64_t)width * height * 4) {
             // buffer holds the full image, use its real dimensions
             uploadWidth = width;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1204,8 +1204,7 @@ void Interpreter::ImportTextureRaw(int tile, bool importReplacement) {
     // Describe the buffer by what was actually packed (the loaded HD stride)
     uint32_t uploadWidth = safeLineSizeBytes / 4;
     uint32_t uploadHeight = safeLineSizeBytes > 0 ? safeLoadedBytes / safeLineSizeBytes : 0;
-    const bool singleLineLoad =
-        uploadHeight <= 1 && resultNewLineSize != 0 && resultNewLineSize < safeLineSizeBytes;
+    const bool singleLineLoad = uploadHeight <= 1 && resultNewLineSize != 0 && resultNewLineSize < safeLineSizeBytes;
     if (uploadWidth > (uint32_t)mRapi->GetMaxTextureSize() || singleLineLoad) {
         if (safeLoadedBytes == (uint64_t)width * height * 4) {
             // buffer holds the full image, use its real dimensions

--- a/src/libultraship/window/gui/GfxDebuggerWindow.cpp
+++ b/src/libultraship/window/gui/GfxDebuggerWindow.cpp
@@ -660,7 +660,7 @@ void GfxDebuggerWindow::DrawDisas() {
 
                 if (isNew && metadata.resource != nullptr) {
                     gui->UnloadTexture(name);
-                    gui->LoadGuiTexture(name, *metadata.resource, nullptr, ImVec4{ 1.0f, 1.0f, 1.0f, 1.0f });
+                    gui->LoadGuiTexture(name, *metadata.resource, "", ImVec4{ 1.0f, 1.0f, 1.0f, 1.0f });
                 }
 
                 ImGui::Image(gui->GetTextureByName(name), ImVec2{ 100.0f, 100.0f });


### PR DESCRIPTION
`LoadBlock` records the whole image as one line, so `ImportTextureRaw` describes the upload as `N x 1` and the image shears, each row offset against the last.

#1143 added a reshape for this but only fires it when the upload exceeds the GPU max texture size, since the case it was written for was a Metal abort. Replacement textures below that cap still shear on D3D11 where the cap is 16384.

Widen the existing trigger to any load that arrived as a single line and has a shorter true row stride to split by. The buffer description otherwise keeps `safeLineSizeBytes`, which is the stride the copy loop writes with.

Edit: also added a clang-format.ps1 file for ease of use on Windows and fixed a Gfx Debugger crash caused by #1157 adding an arg to `LoadGuiTexture`.