### PR TITLE
Fix partial depth clears drifting at non-4:3 aspect ratios

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2997,6 +2997,9 @@ void Interpreter::GfxDpFillRectangle(int32_t ulx, int32_t uly, int32_t lrx, int3
         float y = expanded_lry / 4.0f;
         float w = (expanded_lrx - ulx) / 4.0f;
         float h = (expanded_lry - uly) / 4.0f;
+        float halfNativeWidth = (float)HALF_SCREEN_WIDTH(mActiveFrameBuffer);
+        x = halfNativeWidth + AdjXForAspectRatio(x - halfNativeWidth);
+        w = AdjXForAspectRatio(w);
 
         struct XYWidthHeight area;
         area.x = (int16_t)x;


### PR DESCRIPTION
The z-buffer branch of GfxDpFillRectangle mapped the clear rect through AdjustViewportOrScissor, which stretches raster coordinates by RATIO_X. Geometry takes a different path: AdjXForAspectRatio scales by RATIO_Y and centers on the native viewport. The two mappings only agree at the native center, so a depth hole punched for a model near the screen edge landed
several percent of the screen width away from it and the model stayed z-clipped against the world.

Pre-compress x/width about the native center so the later RATIO_X multiply reproduces the geometry mapping. No-op at 4:3.
