### PR TITLE
Add opt-in memoization of texture path resolution

### DIFF
--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -420,6 +420,7 @@ class Interpreter {
     ColorCombiner* LookupOrCreateColorCombiner(const ColorCombinerKey& key);
     void ShaderCacheClear();
     void TextureCacheClear();
+    std::shared_ptr<Ship::IResource> ResolveResourceCached(const char* path);
     bool TextureCacheLookup(int i, const TextureCacheKey& key);
     void TextureCacheDelete(const uint8_t* origAddr);
     void ImportTextureRgba16(int tile, bool importReplacement);
@@ -436,6 +437,10 @@ class Interpreter {
     void ImportTexture(int i, int tile, bool importReplacement);
     void ImportTextureMask(int i, int tile);
     void CalculateNormalDir(const F3DLight_t*, float coeffs[3]);
+    // Opt-in memoization of OTR texture-path resolution, keyed by display-list
+    // pointer and dropped with the texture cache. Safe for ports whose display
+    // lists carry stable path pointers; off by default.
+    void SetResolvedResourceCacheEnabled(bool enabled);
 
     void GfxSpMatrix(uint8_t params, const int32_t* addr);
     void GfxSpPopMatrix(uint32_t count);
@@ -502,6 +507,8 @@ class Interpreter {
     RenderingState mRenderingState{};
 
     GfxTextureCache mTextureCache{};
+    std::unordered_map<const void*, std::shared_ptr<Ship::IResource>> mResolvedResourceCache;
+    bool mResolvedResourceCacheEnabled = false;
     std::map<ColorCombinerKey, ColorCombiner> mColorCombinerPool; // color_combiner_pool;
     std::map<ColorCombinerKey, ColorCombiner>::iterator mPrevCombiner = mColorCombinerPool.end();
     uint8_t* mTexUploadBuffer = nullptr;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -441,12 +441,38 @@ ColorCombiner* Interpreter::LookupOrCreateColorCombiner(const ColorCombinerKey& 
     return &mPrevCombiner->second;
 }
 
+void Interpreter::SetResolvedResourceCacheEnabled(bool enabled) {
+    mResolvedResourceCacheEnabled = enabled;
+    if (!enabled) {
+        mResolvedResourceCache.clear();
+    }
+}
+
+// Texture binds resolve the same paths every frame; skip the resource
+// manager's string/hash/mutex work by memoizing on the pointer.
+std::shared_ptr<Ship::IResource> Interpreter::ResolveResourceCached(const char* path) {
+    if (path == nullptr) {
+        return nullptr;
+    }
+    if (!mResolvedResourceCacheEnabled) {
+        return Ship::Context::GetRawInstance()->GetResourceManager()->LoadResourceProcess(path);
+    }
+    auto it = mResolvedResourceCache.find(path);
+    if (it != mResolvedResourceCache.end()) {
+        return it->second;
+    }
+    auto res = Ship::Context::GetRawInstance()->GetResourceManager()->LoadResourceProcess(path);
+    mResolvedResourceCache[path] = res;
+    return res;
+}
+
 void Interpreter::TextureCacheClear() {
     for (const auto& entry : mTextureCache.map) {
         mTextureCache.free_texture_ids.push_back(entry.second.texture_id);
     }
     mTextureCache.map.clear();
     mTextureCache.lru.clear();
+    mResolvedResourceCache.clear();
     // Pre-allocate buckets so the map never rehashes during normal operation.
     // Rehashing invalidates all iterators, including those stored in LRU entries.
     mTextureCache.map.reserve(TEXTURE_CACHE_MAX_SIZE);
@@ -3949,8 +3975,8 @@ bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
 
     if ((i & 1) != 1) {
         if (gfx_check_image_signature(imgData) == 1) {
-            std::shared_ptr<Fast::Texture> tex = std::static_pointer_cast<Fast::Texture>(
-                Ship::Context::GetRawInstance()->GetResourceManager()->LoadResourceProcess(imgData));
+            std::shared_ptr<Fast::Texture> tex =
+                std::static_pointer_cast<Fast::Texture>(gfx->ResolveResourceCached(imgData));
 
             if (tex == nullptr) {
                 (*cmd0)++;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -462,7 +462,12 @@ std::shared_ptr<Ship::IResource> Interpreter::ResolveResourceCached(const char* 
         return it->second;
     }
     auto res = Ship::Context::GetRawInstance()->GetResourceManager()->LoadResourceProcess(path);
-    mResolvedResourceCache[path] = res;
+    // Only memoize a hit. The resource manager caches its own misses, so re-asking
+    // for one is cheap, and CacheExternalResource can turn a path that missed into a
+    // valid resource at runtime. A memoized null would outlive the resource itself.
+    if (res != nullptr) {
+        mResolvedResourceCache[path] = res;
+    }
     return res;
 }
 


### PR DESCRIPTION
Profiling Lighthouse in heavy scenes (max draw distance, high interpolation targets) showed OTR texture path resolution as the largest avoidable cost in the display list walk: ~10 ms/frame in `LoadResourceProcess` covering string construction, hash, cache mutex, and map lookup, all re-resolving the same handful of textures the scene binds every frame. The answer only changes when resources reload, so everything after the first bind is repeated work.

The per-bind cost is identical across ports; Lighthouse surfaces it because BK's open, prop-dense worlds under a draw-distance multiplier produce an order of magnitude more texture binds per frame than room-bounded games at equivalent settings. Processors with a weak single-thread beware.

Here's the solution I found:

- `Interpreter::ResolveResourceCached(path)`: memoizes path pointer -> resource on `G_SETTIMG`; straight pass-through when disabled.
- The table clears with `TextureCacheClear()`.
- `Interpreter::SetResolvedResourceCacheEnabled(bool)` is the opt-in, following the existing setter convention. Off by default: zero behavior change for existing ports.

No memory tradeoff: the resource manager's own cache already holds these resources, so the memo pins nothing new. If multiple ports adopt this and it's deemed a success then the opt-in could be removed entirely.
