### PR TITLE
fast3d: accept in-module low pointers in the SETTIMG guard on non-Windows

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -7,6 +7,9 @@
 #include <stdbool.h>
 #include <assert.h>
 #include <stdio.h>
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
 
 #include <any>
 #include <map>
@@ -3934,6 +3937,27 @@ bool gfx_othermode_h_handler_f3d(F3DGfx** cmd0) {
     return false;
 }
 
+// A resolved address still in the N64 segmented range (<= 0x0FFFFFFF) usually means SegAddr
+// failed to resolve it (segment not set up). Keep it only if it belongs to a loaded module,
+// where it's a real low pointer (e.g. a static TLUT) rather than an unresolved segment addr.
+static bool IsValidResolvedAddress(uintptr_t addr) {
+    if (addr > 0x0FFFFFFF) {
+        return true;
+    }
+
+    // Still in the N64 segmented range, but might be a false positive (a real low pointer).
+#ifdef _WIN32
+    // For Windows, check whether the address belongs to a dll.
+    HMODULE module = nullptr;
+    return GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                              reinterpret_cast<LPCSTR>(addr), &module) != 0;
+#else
+    // For non-Windows platforms, check whether the address belongs to a loaded object.
+    Dl_info info;
+    return dladdr(reinterpret_cast<void*>(addr), &info) != 0;
+#endif
+}
+
 bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
     Interpreter* gfx = mInstance.lock().get();
     F3DGfx* cmd = *cmd0;
@@ -3968,23 +3992,9 @@ bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
         }
     }
 
-    // If the resolved address is still in the N64 segmented range, SegAddr
-    // failed to resolve it (segment not set up). Skip to avoid dereferencing
-    // invalid memory.
-    // For Windows, also check if the address is not from a dll because this validation returns a false positive caused
-    // by how the virtual memory is allocated.
-#ifdef _WIN32
-    HMODULE module = nullptr;
-    if (i <= 0x0FFFFFFF &&
-        !(GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                             reinterpret_cast<LPCSTR>(i), &module))) {
+    if (!IsValidResolvedAddress(i)) {
         return false;
     }
-#else
-    if (i <= 0x0FFFFFFF) {
-        return false;
-    }
-#endif
 
     gfx->GfxDpSetTextureImage(C0(21, 3), C0(19, 2), C0(0, 12) + 1, imgData, texFlags, rawTexMetdata, (void*)i);
 


### PR DESCRIPTION
## Summary

`gfx_set_timg_handler_rdp` rejects any resolved address `<= 0x0FFFFFFF` as an unresolved N64 segment address (guard added in #1042). The Win32 branch exempts addresses that belong to a loaded module (`GetModuleHandleExA`), but the non-Windows branch never got that check — it rejects *every* low address.

On a non-PIE build, a valid host pointer to statically-linked data is low, and such a pointer can legitimately reach SETTIMG. That makes this guard reject real pointers.

## How it surfaces (downstream)

The trigger I hit is in a **consuming port (Ship of Harkinian) — not libultraship code**. Its `GfxPrint` debug-text printer loads its font palette straight from a static array:

```c
// DOWNSTREAM (Ship of Harkinian), soh/src/code/gfxprint.c — shown only to illustrate the input
u16 sGfxPrintFontTLUT[64] = { ... };
...
gDPLoadTLUT(this->dList++, 64, 256, sGfxPrintFontTLUT);
```

`&sGfxPrintFontTLUT` is a real pointer into the executable, but it's low and not an OTR resource, so this guard skips its SETTIMG. Inside **libultraship**, the skipped SETTIMG leaves `texture_to_load` stale (the preceding font-pixel SETTIMG left `siz = G_IM_SIZ_4b`), and the following `LoadTLUT` hits `SUPPORT_CHECK(texture_to_load.siz == G_IM_SIZ_16b)` — an assert in debug builds, and no palette (blank text) in release.

Any raw in-binary low pointer reaching SETTIMG hits this; `GfxPrint` is just the one that shows up early and everywhere debug text is drawn, on non-PIE Linux.

## Fix

Extract the guard into `IsValidResolvedAddress` and give the non-Windows path the `dladdr` equivalent of the Win32 module check: a low address that resolves to a loaded object is a real pointer, not an unresolved segment address. Provenance-based, so it's correct regardless of ASLR, and `dladdr` is only reached for addresses `<= 0x0FFFFFFF` (rare — heap textures short-circuit), so there's no per-texture cost.

## Test plan

Repro vehicle is the downstream port (Ship of Harkinian) on non-PIE Linux, debug (assert-enabled) build, dev tools enabled:
- Bisected the boot crash to #1042: its parent (`a2eb3fec`, #1020) is clean; #1042 (`67861a90`) crashes with the `LoadTLUT` `siz` assert.
- With this change on current `port-maintenance`, the crash is gone and downstream debug text renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
