### PR TITLE
Fix GfxDebuggerWindow.cpp

### DIFF
--- a/src/libultraship/window/gui/GfxDebuggerWindow.cpp
+++ b/src/libultraship/window/gui/GfxDebuggerWindow.cpp
@@ -660,7 +660,7 @@ void GfxDebuggerWindow::DrawDisas() {
 
                 if (isNew && metadata.resource != nullptr) {
                     gui->UnloadTexture(name);
-                    gui->LoadGuiTexture(name, *metadata.resource, "", ImVec4{ 1.0f, 1.0f, 1.0f, 1.0f });
+                    gui->LoadGuiTexture(name, "", "", ImVec4{ 1.0f, 1.0f, 1.0f, 1.0f });
                 }
 
                 ImGui::Image(gui->GetTextureByName(name), ImVec2{ 100.0f, 100.0f });
@@ -684,7 +684,7 @@ void GfxDebuggerWindow::DrawDisas() {
 
                 // if (isNew && g_rdp.texture_to_load.raw_tex_metadata.resource != nullptr) {
                 //     gui->UnloadTexture(TO_LOAD_TEX);
-                //     gui->LoadGuiTexture(TO_LOAD_TEX, *g_rdp.texture_to_load.raw_tex_metadata.resource,
+                //     gui->LoadGuiTexture(TO_LOAD_TEX, "", "",
                 //                         ImVec4{ 1.0f, 1.0f, 1.0f, 1.0f });
                 // }
 


### PR DESCRIPTION
The gui load command now expects a str path. The pointer is no longer allowed. Replaced with empty str.

Couldn't find a way to put the path in at this spot.