### PR TITLE
fix(crash): replace exit(1) in ShutdownHandler with SDL_QUIT event (port-maintenance)

### DIFF
--- a/src/ship/debug/CrashHandler.cpp
+++ b/src/ship/debug/CrashHandler.cpp
@@ -203,7 +203,9 @@ static void ErrorHandler(int sig, siginfo_t* sigInfo, void* data) {
 }
 
 static void ShutdownHandler(int sig, siginfo_t* sigInfo, void* data) {
-    exit(1);
+    SDL_Event event;
+    event.type = SDL_QUIT;
+    SDL_PushEvent(&event);
 }
 
 #elif _WIN32


### PR DESCRIPTION
Port-maintenance counterpart of #1114, scoped to the signal-handler fix.

`ShutdownHandler` (SIGINT/SIGTERM) called `exit(1)` directly. `exit()` is not
async-signal-safe: it runs C++ destructors and `atexit` handlers, some of which
try to acquire mutexes still held by the audio thread, so the shutdown deadlocks
and the OS aborts it as a crash. This pushes an `SDL_QUIT` event instead, letting
the main event loop tear down cleanly through the existing `Close()` path.

Note: #1114's second commit ("Hold on Window shared_ptr longer") is intentionally
omitted here. It guarded against dereferencing the window `shared_ptr` after
release during ImGui shutdown, but on port-maintenance the ImGui WM/backend
methods already dispatch on the cached `mImpl.Backend` enum and never touch the
live window during shutdown, so that fix is not needed on this branch.
