### PR TITLE
fix(audio): fix SDL backend buffer sizing causing audio cuts/glitches when CPU is struggling

### DIFF
--- a/include/ship/audio/SDLAudioPlayer.h
+++ b/include/ship/audio/SDLAudioPlayer.h
@@ -50,6 +50,6 @@ class SDLAudioPlayer final : public AudioPlayer {
 
   private:
     SDL_AudioDeviceID mDevice = 0; ///< Handle to the opened SDL audio device.
-    int32_t mNumChannels = 2;      ///< Number of output channels (2 for stereo, 6 for 5.1).
+    uint8_t mNumChannels = 2;      ///< Number of output channels (2 for stereo, 6 for 5.1).
 };
 } // namespace Ship

--- a/src/ship/audio/SDLAudioPlayer.cpp
+++ b/src/ship/audio/SDLAudioPlayer.cpp
@@ -13,7 +13,8 @@ void SDLAudioPlayer::DoClose() {
     if (mDevice != 0) {
         // Pause playback first
         SDL_PauseAudioDevice(mDevice, 1);
-        // Clear any queued audio to prevent glitches when reopening
+
+        // Prevent stale audio when reopening
         SDL_ClearQueuedAudio(mDevice);
         SDL_CloseAudioDevice(mDevice);
         mDevice = 0;
@@ -21,29 +22,38 @@ void SDLAudioPlayer::DoClose() {
 }
 
 bool SDLAudioPlayer::DoInit() {
-    if (SDL_Init(SDL_INIT_AUDIO) != 0) {
+    if (SDL_InitSubSystem(SDL_INIT_AUDIO) != 0) {
         SPDLOG_ERROR("SDL init error: {}", SDL_GetError());
         return false;
     }
 
-    // Always open with the correct number of output channels
-    mNumChannels = this->GetNumOutputChannels();
-
     SDL_AudioSpec want, have;
     SDL_zero(want);
+
     want.freq = this->GetSampleRate();
     want.format = AUDIO_S16SYS;
-    want.channels = mNumChannels;
-    want.samples = this->GetSampleLength();
-    want.callback = NULL;
+    want.channels = this->GetNumOutputChannels();
 
-    mDevice = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
+    // Increase backend/device buffering slightly
+    // to reduce rare underruns/glitches.
+    //
+    // IMPORTANT:
+    // This is NOT part of the emulator buffering logic.
+    // It only affects SDL/backend latency.
+    want.samples = GetSampleLength() * 2;
+
+    want.callback = nullptr;
+
+    mDevice = SDL_OpenAudioDevice(nullptr, 0, &want, &have, 0);
+
     if (mDevice == 0) {
-        SPDLOG_ERROR("SDL_OpenAudio error: {}", SDL_GetError());
+        SPDLOG_ERROR("SDL_OpenAudioDevice error: {}", SDL_GetError());
         return false;
     }
 
-    SPDLOG_INFO("SDL Audio initialized: {} channels, {} Hz", mNumChannels, this->GetSampleRate());
+    mNumChannels = have.channels;
+
+    SPDLOG_INFO("SDL audio initialized: {} Hz, {} channels, {} samples", have.freq, have.channels, have.samples);
 
     SDL_PauseAudioDevice(mDevice, 0);
     return true;
@@ -54,9 +64,6 @@ int SDLAudioPlayer::Buffered() {
 }
 
 void SDLAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
-    if (Buffered() < 6000) {
-        // Don't fill the audio buffer too much in case this happens
-        SDL_QueueAudio(mDevice, buf, len);
-    }
+    SDL_QueueAudio(mDevice, buf, len);
 }
 } // namespace Ship


### PR DESCRIPTION
Port-maintenance counterpart of #1107.

Fixes SDL-backend buffer sizing that caused audio cuts/glitches when the CPU is
struggling:

- Use `SDL_InitSubSystem(SDL_INIT_AUDIO)` instead of `SDL_Init()` so unrelated
  SDL subsystems aren't reinitialised.
- Double the hardware buffer size (`GetSampleLength() * 2`) to reduce backend
  underruns. This only affects SDL/backend latency, not the emulator buffering
  logic.
- Remove the hardcoded 6000-frame fill guard in `DoPlay()`; it was an arbitrary
  threshold that starved audio on slow frames. SDL's internal queue handles
  backpressure.
- Read the actual channel count back from SDL's `have` spec instead of assuming
  the requested value was honoured.
- Minor: `NULL` -> `nullptr`, style cleanup, clearer init log.

Applies cleanly onto port-maintenance.
