### PR TITLE
Fix Windows crash handler producing unusable tracebacks

### DIFF
--- a/src/ship/debug/CrashHandler.cpp
+++ b/src/ship/debug/CrashHandler.cpp
@@ -11,6 +11,8 @@
 #include <excpt.h>
 
 #pragma comment(lib, "Dbghelp.lib")
+
+#include <filesystem>
 #endif
 
 namespace Ship {
@@ -310,6 +312,12 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
 #if defined(_M_AMD64)
     STACKFRAME64 stack;
     memset(&stack, 0, sizeof(STACKFRAME64));
+    stack.AddrPC.Offset = (*ctx).Rip;
+    stack.AddrPC.Mode = AddrModeFlat;
+    stack.AddrStack.Offset = (*ctx).Rsp;
+    stack.AddrStack.Mode = AddrModeFlat;
+    stack.AddrFrame.Offset = (*ctx).Rbp;
+    stack.AddrFrame.Mode = AddrModeFlat;
 #elif defined(WINDOWS_32_BIT)
     STACKFRAME stack;
     memset(&stack, 0, sizeof(STACKFRAME));
@@ -334,8 +342,20 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
     process = GetCurrentProcess();
     thread = GetCurrentThread();
 
-    SymSetOptions(SYMOPT_NO_IMAGE_SEARCH | SYMOPT_IGNORE_IMAGEDIR);
-    SymInitialize(process, "debug", true);
+    SymSetOptions(SYMOPT_NO_IMAGE_SEARCH | SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS);
+
+    // Search the directory the executable actually lives in, plus a "debug" subdirectory next to it,
+    // rather than a "debug" path relative to whatever the current working directory happens to be.
+    std::string searchPath = "debug";
+    char exePath[MAX_PATH];
+    if (GetModuleFileNameA(nullptr, exePath, sizeof(exePath)) != 0) {
+        std::filesystem::path exeDir = std::filesystem::path(exePath).parent_path();
+        if (!exeDir.empty()) {
+            searchPath = exeDir.string() + ";" + (exeDir / "debug").string() + ";debug";
+        }
+    }
+
+    SymInitialize(process, searchPath.c_str(), true);
 
     constexpr DWORD machineType =
 #if defined(_M_AMD64)
@@ -355,7 +375,26 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
         }
         symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
         symbol->MaxNameLen = MAX_SYM_NAME;
-        SymFromAddr(process, (ULONG64)stack.AddrPC.Offset, &displacement, symbol);
+        symbol->Name[0] = '\0';
+        symbol->Address = 0;
+        displacement = 0;
+
+        // SymFromAddr leaves the buffer untouched on failure, so its result must be checked before
+        // symbol->Name is read. Without it a failed lookup silently prints the previous frame's name.
+        const bool haveSymbol = SymFromAddr(process, (ULONG64)stack.AddrPC.Offset, &displacement, symbol) != FALSE;
+
+        // Resolve the owning module so the absolute PC can be reduced to a module-relative offset. An
+        // RVA stays meaningful without symbols: it can be looked up against a matching PDB or map file
+        // after the fact, whereas the ASLR-shifted absolute address cannot.
+        hModule = nullptr;
+        GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                          (LPCTSTR)(stack.AddrPC.Offset), &hModule);
+        if (hModule != nullptr) {
+            GetModuleFileNameA(hModule, module, sizeof(module));
+        } else {
+            strcpy_s(module, sizeof(module), "???");
+        }
+
 #if defined(_M_AMD64)
         IMAGEHLP_LINE64 line;
         line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
@@ -363,36 +402,83 @@ void CrashHandler::PrintStack(CONTEXT* ctx) {
         IMAGEHLP_LINE line;
         line.SizeOfStruct = sizeof(IMAGEHLP_LINE);
 #endif
-        if (SymGetLineFromAddr(process, stack.AddrPC.Offset, &disp, &line)) {
-            AppendStr("    ");
+
+        char addrString[80];
+        AppendStr("    ");
+
+        if (haveSymbol) {
             AppendStr(symbol->Name);
+            sprintf_s(addrString, std::size(addrString), "+0x%llX", displacement);
+            AppendStr(addrString);
+        } else {
+            AppendStr("<no symbol>");
+        }
+
+        if (haveSymbol && SymGetLineFromAddr(process, stack.AddrPC.Offset, &disp, &line)) {
             AppendStr(" in ");
             AppendStr(line.FileName);
-            char lineNumberStr[16];
-            sprintf_s(lineNumberStr, sizeof(lineNumberStr), " Line: %d", line.LineNumber);
-            AppendLine(lineNumberStr);
-        } else {
-            WRITE_VAR_M("    ", symbol->Name);
-            char addrString[20];
-            sprintf_s(addrString, std::size(addrString), "0x%016llX", symbol->Address);
-            WRITE_VAR_M("(", addrString);
-            AppendStr(")");
-            hModule = nullptr;
-            GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                              (LPCTSTR)(stack.AddrPC.Offset), &hModule);
-
-            if (hModule != nullptr) {
-                GetModuleFileNameA(hModule, module, sizeof(module));
-                WRITE_VAR_LINE_M(" in ", module);
-            } else {
-                WRITE_VAR_LINE_M(" in ", "???");
-            }
+            sprintf_s(addrString, std::size(addrString), " Line: %d", line.LineNumber);
+            AppendStr(addrString);
         }
+
+        // PC, module base and RVA are always emitted, symbols or not.
+        if (hModule != nullptr) {
+            sprintf_s(addrString, std::size(addrString), " [0x%016llX base 0x%016llX rva 0x%llX]",
+                      (unsigned long long)stack.AddrPC.Offset, (unsigned long long)(uintptr_t)hModule,
+                      (unsigned long long)(stack.AddrPC.Offset - (uintptr_t)hModule));
+        } else {
+            sprintf_s(addrString, std::size(addrString), " [0x%016llX]", (unsigned long long)stack.AddrPC.Offset);
+        }
+        AppendStr(addrString);
+
+        WRITE_VAR_LINE_M(" in ", module);
     }
     PrintCommon();
     Context::GetRawInstance()->GetLogger()->flush();
     spdlog::shutdown();
 #endif
+}
+
+/**
+ * @brief Writes a minidump next to the log file so the crash can be opened in a debugger after the fact.
+ *
+ * @param ex Exception pointers handed to the unhandled exception filter.
+ * @param outPath Receives the path written to, or is left empty if the dump could not be produced.
+ * @return true if a dump file was written.
+ */
+static bool WriteMiniDump(PEXCEPTION_POINTERS ex, std::string& outPath) {
+#ifndef _M_ARM64
+    std::string dumpPath =
+        Context::GetPathRelativeToAppDirectory("logs/" + Context::GetRawInstance()->GetName() + "-crash.dmp");
+
+    std::error_code ec;
+    std::filesystem::create_directories(std::filesystem::path(dumpPath).parent_path(), ec);
+
+    HANDLE file =
+        CreateFileA(dumpPath.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    MINIDUMP_EXCEPTION_INFORMATION info;
+    info.ThreadId = GetCurrentThreadId();
+    info.ExceptionPointers = ex;
+    info.ClientPointers = FALSE;
+
+    // MiniDumpWithIndirectlyReferencedMemory pulls in memory referenced by the stacks, which is what makes
+    // a wild-pointer crash inspectable rather than just showing the frames that led to it.
+    const MINIDUMP_TYPE type = (MINIDUMP_TYPE)(MiniDumpWithIndirectlyReferencedMemory | MiniDumpScanMemory |
+                                               MiniDumpWithThreadInfo | MiniDumpWithUnloadedModules);
+
+    BOOL written = MiniDumpWriteDump(GetCurrentProcess(), GetCurrentProcessId(), file, type, &info, nullptr, nullptr);
+    CloseHandle(file);
+
+    if (written) {
+        outPath = dumpPath;
+        return true;
+    }
+#endif
+    return false;
 }
 
 extern "C" LONG WINAPI seh_filter(PEXCEPTION_POINTERS ex) {
@@ -402,6 +488,43 @@ extern "C" LONG WINAPI seh_filter(PEXCEPTION_POINTERS ex) {
     snprintf(exceptionString, std::size(exceptionString), "0x%x", ex->ExceptionRecord->ExceptionCode);
 
     WRITE_VAR_LINE(crashHandler, "Exception: ", exceptionString);
+
+    // For an access violation the exception record carries the operation and the address that faulted,
+    // which is otherwise only inferable by guessing which register the faulting instruction dereferenced.
+    if (ex->ExceptionRecord->ExceptionCode == EXCEPTION_ACCESS_VIOLATION &&
+        ex->ExceptionRecord->NumberParameters >= 2) {
+        const char* operation;
+        switch (ex->ExceptionRecord->ExceptionInformation[0]) {
+            case 0:
+                operation = "read from";
+                break;
+            case 1:
+                operation = "write to";
+                break;
+            case 8:
+                operation = "execute at";
+                break;
+            default:
+                operation = "access of";
+                break;
+        }
+
+        char faultString[80];
+        snprintf(faultString, std::size(faultString), "Invalid %s 0x%016llX", operation,
+                 (unsigned long long)ex->ExceptionRecord->ExceptionInformation[1]);
+        crashHandler->AppendLine(faultString);
+    }
+
+    // Written before the stack walk: DbgHelp loads symbol data and allocates while walking, so a dump taken
+    // afterwards reflects a process state the crash did not actually occur in. The path is appended to the
+    // report here too, because PrintStack flushes the buffer and shuts down spdlog before it returns.
+    std::string dumpPath;
+    if (WriteMiniDump(ex, dumpPath)) {
+        WRITE_VAR_LINE(crashHandler, "Minidump: ", dumpPath.c_str());
+    } else {
+        crashHandler->AppendLine("Minidump: <failed to write>");
+    }
+
     crashHandler->PrintStack(ex->ContextRecord);
     MessageBoxA(nullptr,
                 (Context::GetRawInstance()->GetName() +


### PR DESCRIPTION
Windows crash reports print blank frames with null addresses, even with a matching PDB sitting next to the executable, and the one symbol that did resolve was typically a misleading nearest-export match rather than a real frame. Several bugs combined: `SymInitialize` was given `"debug"` as a search path (resolved against the cwd, not the executable's directory) with `SYMOPT_IGNORE_IMAGEDIR` suppressing the fallback, so the PDB never loaded; `SymFromAddr`'s return value was ignored, so a zeroed `SYMBOL_INFO` got printed as a frame; `SYMOPT_LOAD_LINES` was never set, so line numbers could never have worked; and `STACKFRAME64` was left zeroed on x64, working only by way of `StackWalk64`'s undocumented fallback to the `CONTEXT` record. This fixes all four, adds module base and RVA to every frame so tracebacks stay resolvable offline under ASLR, reports the operation and faulting address for access violations, and writes a minidump to `logs/<AppName>-crash.dmp` before the stack walk (DbgHelp allocates while walking and would otherwise pollute the captured state). No behavior change on Linux; ARM64 paths remain stubbed as before.
