### PR TITLE
Migrate libultraship to SDL3

### DIFF
--- a/.github/workflows/apt-deps.txt
+++ b/.github/workflows/apt-deps.txt
@@ -1,1 +1,1 @@
-libsdl2-dev libpng-dev libglew-dev libzip-dev zipcmp zipmerge ziptool ninja-build nlohmann-json3-dev libtinyxml2-dev libspdlog-dev tcc libtcc-dev
+libpng-dev libglew-dev libzip-dev zipcmp zipmerge ziptool ninja-build nlohmann-json3-dev libtinyxml2-dev libspdlog-dev tcc libtcc-dev libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev libxkbcommon-dev

--- a/.github/workflows/brew-deps.txt
+++ b/.github/workflows/brew-deps.txt
@@ -1,1 +1,1 @@
-sdl2 libpng glew ninja libzip nlohmann-json tinyxml2 spdlog
+sdl3 libpng glew ninja libzip nlohmann-json tinyxml2 spdlog

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -77,12 +77,11 @@ jobs:
     - name: Install latest SDL
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        wget https://www.libsdl.org/release/SDL2-2.24.1.tar.gz
-        tar -xzf SDL2-2.24.1.tar.gz
-        cd SDL2-2.24.1
-        ./configure
-        make -j 10
-        sudo make install
+        wget https://github.com/libsdl-org/SDL/releases/download/release-3.4.12/SDL3-3.4.12.tar.gz
+        tar -xzf SDL3-3.4.12.tar.gz
+        cmake -S SDL3-3.4.12 -B SDL3-3.4.12/build -GNinja -DCMAKE_BUILD_TYPE=Release
+        cmake --build SDL3-3.4.12/build --parallel 10
+        sudo cmake --install SDL3-3.4.12/build --prefix /usr/local
     - name: Install latest tinyxml2
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"

--- a/.github/workflows/test-validation.yml
+++ b/.github/workflows/test-validation.yml
@@ -24,12 +24,11 @@ jobs:
     - name: Install latest SDL
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        wget https://www.libsdl.org/release/SDL2-2.24.1.tar.gz
-        tar -xzf SDL2-2.24.1.tar.gz
-        cd SDL2-2.24.1
-        ./configure
-        make -j $(nproc)
-        sudo make install
+        wget https://github.com/libsdl-org/SDL/releases/download/release-3.4.12/SDL3-3.4.12.tar.gz
+        tar -xzf SDL3-3.4.12.tar.gz
+        cmake -S SDL3-3.4.12 -B SDL3-3.4.12/build -GNinja -DCMAKE_BUILD_TYPE=Release
+        cmake --build SDL3-3.4.12/build --parallel $(nproc)
+        sudo cmake --install SDL3-3.4.12/build --prefix /usr/local
     - name: Install latest tinyxml2
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"

--- a/.github/workflows/tidy-format-validation.yml
+++ b/.github/workflows/tidy-format-validation.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -52,7 +52,7 @@ jobs:
           mkdir clang-tidy-result
       - name: Analyze
         run: |
-          git diff -U0 "${{ github.event.pull_request.base.sha }}"...HEAD -- 'src' 'include' ':!include/libultraship/color.h' ':!include/ship/utils/color.h' ':!include/libultraship/libultra/*' ':!src/libultraship/libultra/*' ':!src/fast/*' ':!include/fast/*' ':!src/ship/utils/AppleFolderManager.mm' | clang-tidy-diff -p1 -path build -regex='.*\.(cpp|cc|cxx|mm)$' -export-fixes clang-tidy-result/fixes.yml
+          git diff -U0 HEAD^ -- 'src' 'include' ':!include/libultraship/color.h' ':!include/ship/utils/color.h' ':!include/libultraship/libultra/*' ':!src/libultraship/libultra/*' ':!src/fast/*' ':!include/fast/*' ':!src/ship/utils/AppleFolderManager.mm' | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
       - name: Save PR metadata
         run: |
           echo ${{ github.event.number }} > clang-tidy-result/pr-id.txt

--- a/.github/workflows/tidy-format-validation.yml
+++ b/.github/workflows/tidy-format-validation.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -25,12 +25,11 @@ jobs:
       - name: Install latest SDL
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-          wget https://www.libsdl.org/release/SDL2-2.24.1.tar.gz
-          tar -xzf SDL2-2.24.1.tar.gz
-          cd SDL2-2.24.1
-          ./configure
-          make -j 10
-          sudo make install
+          wget https://github.com/libsdl-org/SDL/releases/download/release-3.4.12/SDL3-3.4.12.tar.gz
+          tar -xzf SDL3-3.4.12.tar.gz
+          cmake -S SDL3-3.4.12 -B SDL3-3.4.12/build -GNinja -DCMAKE_BUILD_TYPE=Release
+          cmake --build SDL3-3.4.12/build --parallel 10
+          sudo cmake --install SDL3-3.4.12/build --prefix /usr/local
       - name: Install latest tinyxml2
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
@@ -53,7 +52,7 @@ jobs:
           mkdir clang-tidy-result
       - name: Analyze
         run: |
-          git diff -U0 HEAD^ -- 'src' 'include' ':!include/libultraship/color.h' ':!include/ship/utils/color.h' ':!include/libultraship/libultra/*' ':!src/libultraship/libultra/*' ':!src/fast/*' ':!include/fast/*' ':!src/ship/utils/AppleFolderManager.mm' | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+          git diff -U0 "${{ github.event.pull_request.base.sha }}"...HEAD -- 'src' 'include' ':!include/libultraship/color.h' ':!include/ship/utils/color.h' ':!include/libultraship/libultra/*' ':!src/libultraship/libultra/*' ':!src/fast/*' ':!include/fast/*' ':!src/ship/utils/AppleFolderManager.mm' | clang-tidy-diff -p1 -path build -regex='.*\.(cpp|cc|cxx|mm)$' -export-fixes clang-tidy-result/fixes.yml
       - name: Save PR metadata
         run: |
           echo ${{ github.event.number }} > clang-tidy-result/pr-id.txt

--- a/.github/workflows/tidy-format-validation.yml
+++ b/.github/workflows/tidy-format-validation.yml
@@ -52,7 +52,7 @@ jobs:
           mkdir clang-tidy-result
       - name: Analyze
         run: |
-          git diff -U0 HEAD^ -- 'src' 'include' ':!include/libultraship/color.h' ':!include/ship/utils/color.h' ':!include/libultraship/libultra/*' ':!src/libultraship/libultra/*' ':!src/fast/*' ':!include/fast/*' ':!src/ship/utils/AppleFolderManager.mm' | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+          git diff -U0 HEAD^ -- 'src' 'include' ':!include/libultraship/color.h' ':!include/ship/utils/color.h' ':!include/libultraship/libultra/*' ':!src/libultraship/libultra/*' ':!src/fast/*' ':!include/fast/*' ':!src/ship/utils/AppleFolderManager.mm' ':!include/ship/port/mobile/MobileImpl.h' | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
       - name: Save PR metadata
         run: |
           echo ${{ github.event.number }} > clang-tidy-result/pr-id.txt

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ LUS makes use of the following third party libraries and resources:
 - [Fast3D](https://github.com/Kenix3/libultraship/blob/main/src/fast/LICENSE.txt) (MIT) render display lists.
 - [prism-processor](https://github.com/KiritoDv/prism-processor/blob/main/LICENSE) (MIT) shader preprocessor.
 - [ImGui](https://github.com/ocornut/imgui/blob/master/LICENSE.txt) (MIT) display UI.
-  - [SDL2](https://github.com/libsdl-org/SDL/blob/main/LICENSE.txt) (zlib) windowing and input backend.
+  - [SDL3](https://github.com/libsdl-org/SDL/blob/main/LICENSE.txt) (zlib) windowing and input backend.
   - [glew](https://github.com/nigels-com/glew/blob/master/LICENSE.txt) (modified BSD-3-Clause and MIT) OpenGL extension loading backend (Windows/macOS).
   - [metal-cpp](https://github.com/briaguya-ai/single-header-metal-cpp/blob/macOS13_iOS16/LICENSE) (Apache 2.0) Apple Metal rendering backend (macOS/iOS).
 - [StormLib](https://github.com/ladislav-zezula/StormLib/blob/master/LICENSE) (MIT) create and read `.mpq` compatible archive files.
@@ -107,7 +107,7 @@ LUS makes use of the following third party libraries and resources:
 - [stb](https://github.com/nothings/stb/blob/master/LICENSE) (MIT) image conversion.
 - [thread-pool](https://github.com/bshoshany/thread-pool/blob/master/LICENSE.txt) (MIT) thread pool for the resource manager.
 - [tinyxml2](https://github.com/leethomason/tinyxml2/blob/master/LICENSE.txt) (zlib) parse XML files for resource loaders.
-- [sdl2](https://github.com/libsdl-org/SDL/blob/main/LICENSE.txt) (zlib) window manager, controllers, and audio player.
+- [SDL3](https://github.com/libsdl-org/SDL/blob/main/LICENSE.txt) (zlib) window manager, controllers, and audio player.
 - [glob_match](https://github.com/torvalds/linux/blob/d1bd5fa07667fcc3e38996ec42aef98761f23039/lib/glob.c) (Dual MIT/GPL) Glob pattern matching.
 - [libgfxd](https://github.com/glankk/libgfxd/blob/master/LICENSE) (MIT) display list disassembler.
 - [libtcc](https://repo.or.cz/tinycc.git/blob/HEAD:/COPYING) (LGPL-2.1) C compiler used for the script system.

--- a/cmake/dependencies/android.cmake
+++ b/cmake/dependencies/android.cmake
@@ -1,16 +1,17 @@
 include(FetchContent)
 
-#=================== SDL2 ===================
-find_package(SDL2 QUIET)
-if (NOT ${SDL2_FOUND})
+#=================== SDL3 ===================
+find_package(SDL3 QUIET)
+if (NOT ${SDL3_FOUND})
     FetchContent_Declare(
-        SDL2
-    GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-    GIT_TAG release-2.32.10
+        SDL3
+        GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
+        GIT_TAG release-3.4.12
+        OVERRIDE_FIND_PACKAGE
     )
-    message("SDL2 not found. Downloading now...")
-    FetchContent_MakeAvailable(SDL2)
-    message("SDL2 downloaded to " ${FETCHCONTENT_BASE_DIR}/sdl2-src)
+    message("SDL3 not found. Downloading now...")
+    FetchContent_MakeAvailable(SDL3)
+    message("SDL3 downloaded to " ${FETCHCONTENT_BASE_DIR}/sdl3-src)
 endif()
 
 #=================== nlohmann-json ===================
@@ -70,4 +71,4 @@ if (NOT ${libzip_FOUND})
     list(APPEND ADDITIONAL_LIB_INCLUDES ${libzip_SOURCE_DIR}/lib ${libzip_BINARY_DIR})
 endif()
 
-target_link_libraries(ImGui PUBLIC SDL2::SDL2)
+target_link_libraries(ImGui PUBLIC SDL3::SDL3)

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -30,10 +30,10 @@ target_sources(ImGui
 target_sources(ImGui
     PRIVATE
     ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
-    ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl2.cpp
+    ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl3.cpp
 )
 
-target_include_directories(ImGui PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends PRIVATE ${SDL2_INCLUDE_DIRS})
+target_include_directories(ImGui PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends)
 
 # ========= StormLib =============
 if(INCLUDE_MPQ_SUPPORT)

--- a/cmake/dependencies/ios.cmake
+++ b/cmake/dependencies/ios.cmake
@@ -1,15 +1,17 @@
 include(FetchContent)
 
-#=================== SDL2 ===================
-find_package(SDL2 QUIET)
-if (NOT ${SDL2_FOUND})
+#=================== SDL3 ===================
+find_package(SDL3 QUIET)
+if (NOT ${SDL3_FOUND})
+    set(SDL_SHARED OFF CACHE BOOL "" FORCE)
+    set(SDL_STATIC ON CACHE BOOL "" FORCE)
     FetchContent_Declare(
-        SDL2
+        SDL3
         GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-        GIT_TAG release-2.32.10
+        GIT_TAG release-3.4.12
         OVERRIDE_FIND_PACKAGE
     )
-    FetchContent_MakeAvailable(SDL2)
+    FetchContent_MakeAvailable(SDL3)
 endif()
 
 #=================== nlohmann-json ===================
@@ -87,4 +89,4 @@ target_sources(ImGui
 target_include_directories(ImGui PRIVATE ${metalcpp_SOURCE_DIR})
 target_compile_definitions(ImGui PUBLIC IMGUI_IMPL_METAL_CPP)
 
-target_link_libraries(ImGui PUBLIC SDL2::SDL2-static SDL2::SDL2main)
+target_link_libraries(ImGui PUBLIC SDL3::SDL3)

--- a/cmake/dependencies/linux.cmake
+++ b/cmake/dependencies/linux.cmake
@@ -1,16 +1,5 @@
 #=================== ImGui ===================
-find_package(SDL3 QUIET CONFIG COMPONENTS SDL3)
-if(NOT SDL3_FOUND)
-    include(FetchContent)
-    FetchContent_Declare(
-        SDL3
-        GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-        GIT_TAG release-3.4.12
-        OVERRIDE_FIND_PACKAGE
-    )
-    message("SDL3 not found. Downloading now...")
-    FetchContent_MakeAvailable(SDL3)
-endif()
+find_package(SDL3 REQUIRED CONFIG COMPONENTS SDL3)
 target_link_libraries(ImGui PUBLIC SDL3::SDL3)
 
 if (USE_OPENGLES)

--- a/cmake/dependencies/linux.cmake
+++ b/cmake/dependencies/linux.cmake
@@ -1,6 +1,17 @@
 #=================== ImGui ===================
-find_package(SDL2 REQUIRED)
-target_link_libraries(ImGui PUBLIC SDL2::SDL2)
+find_package(SDL3 QUIET CONFIG COMPONENTS SDL3)
+if(NOT SDL3_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+        SDL3
+        GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
+        GIT_TAG release-3.4.12
+        OVERRIDE_FIND_PACKAGE
+    )
+    message("SDL3 not found. Downloading now...")
+    FetchContent_MakeAvailable(SDL3)
+endif()
+target_link_libraries(ImGui PUBLIC SDL3::SDL3)
 
 if (USE_OPENGLES)
     target_link_libraries(ImGui PUBLIC ${OPENGL_GLESv2_LIBRARY})

--- a/cmake/dependencies/mac.cmake
+++ b/cmake/dependencies/mac.cmake
@@ -32,8 +32,8 @@ target_sources(ImGui
 target_include_directories(ImGui PRIVATE ${metalcpp_SOURCE_DIR})
 target_compile_definitions(ImGui PUBLIC IMGUI_IMPL_METAL_CPP)
 
-find_package(SDL2 REQUIRED)
-target_link_libraries(ImGui PUBLIC SDL2::SDL2)
+find_package(SDL3 REQUIRED CONFIG COMPONENTS SDL3)
+target_link_libraries(ImGui PUBLIC SDL3::SDL3)
 
 find_package(GLEW REQUIRED)
 target_link_libraries(ImGui PUBLIC ${OPENGL_opengl_LIBRARY} GLEW::GLEW)

--- a/cmake/dependencies/openbsd.cmake
+++ b/cmake/dependencies/openbsd.cmake
@@ -1,15 +1,13 @@
 #=================== ImGui ===================
 
-find_package(SDL2 REQUIRED)
+find_package(SDL3 REQUIRED CONFIG COMPONENTS SDL3)
 
-# XXX sdl2-config.cmake doesn't include /usr/X11R6/include but sdl2-config does
-# ideally this could be fixed from sdl2 port
-# set(SDL2_INCLUDE_DIRS "${SDL2_INCLUDE_DIRS};/usr/X11R6/include")
+# The OpenBSD SDL package does not propagate /usr/X11R6/include.
 # note this is a central place to bundle such hacks for libultraship consumers
 # otherwise each game may need its own fix as we are not in the same scope
 include_directories("/usr/X11R6/include")
 
-target_link_libraries(ImGui PUBLIC SDL2::SDL2)
+target_link_libraries(ImGui PUBLIC SDL3::SDL3)
 
 if (USE_OPENGLES)
     # XXX copy linux.cmake but maybe this actually need gles3_LIBRARY

--- a/cmake/dependencies/patches/imgui-fixes-and-config.patch
+++ b/cmake/dependencies/patches/imgui-fixes-and-config.patch
@@ -63,15 +63,15 @@ Date: Sat, 17 May 2025 04:42:41 -0400
 Subject: [PATCH 2/3] gamepad fix
 
 ---
- backends/imgui_impl_sdl2.cpp | 3 ---
+ backends/imgui_impl_sdl3.cpp | 3 ---
  1 file changed, 3 deletions(-)
 
-diff --git a/backends/imgui_impl_sdl2.cpp b/backends/imgui_impl_sdl2.cpp
+diff --git a/backends/imgui_impl_sdl3.cpp b/backends/imgui_impl_sdl3.cpp
 index f3a31c5c3c5e..2e6a1ad9d1f1 100644
---- a/backends/imgui_impl_sdl2.cpp
-+++ b/backends/imgui_impl_sdl2.cpp
-@@ -845,9 +845,6 @@ static void ImGui_ImplSDL2_UpdateGamepads()
-         bd->WantUpdateGamepadsList = false;
+--- a/backends/imgui_impl_sdl3.cpp
++++ b/backends/imgui_impl_sdl3.cpp
+@@ -809,9 +809,6 @@ static void ImGui_ImplSDL3_UpdateGamepads()
+         SDL_free(sdl_gamepads);
      }
  
 -    // FIXME: Technically feeding gamepad shouldn't depend on this now that they are regular inputs.

--- a/cmake/dependencies/windows-vcpkg.cmake
+++ b/cmake/dependencies/windows-vcpkg.cmake
@@ -13,5 +13,5 @@ elseif ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "arm64")
 endif()
 
 	vcpkg_bootstrap()
-	vcpkg_install_packages(zlib bzip2 sdl2 glew libzip nlohmann-json tinyxml2 spdlog)    
+	vcpkg_install_packages(zlib bzip2 sdl3 glew libzip nlohmann-json tinyxml2 spdlog)
 endif()

--- a/cmake/dependencies/windows.cmake
+++ b/cmake/dependencies/windows.cmake
@@ -5,8 +5,8 @@ target_sources(ImGui
 	${imgui_SOURCE_DIR}/backends/imgui_impl_win32.cpp
 )
 
-find_package(SDL2 CONFIG REQUIRED)
-target_link_libraries(ImGui PUBLIC SDL2::SDL2 SDL2::SDL2main)
+find_package(SDL3 CONFIG REQUIRED COMPONENTS SDL3)
+target_link_libraries(ImGui PUBLIC SDL3::SDL3)
 
 find_package(GLEW REQUIRED)
 target_link_libraries(ImGui PUBLIC opengl32 GLEW::GLEW)

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ LUS makes use of the following third party libraries and resources:
 - [Fast3D](https://github.com/Kenix3/libultraship/blob/main/src/fast/LICENSE.txt) (MIT) render display lists.
 - [prism-processor](https://github.com/KiritoDv/prism-processor/blob/main/LICENSE) (MIT) shader preprocessor.
 - [ImGui](https://github.com/ocornut/imgui/blob/master/LICENSE.txt) (MIT) display UI.
-  - [SDL2](https://github.com/libsdl-org/SDL/blob/main/LICENSE.txt) (zlib) windowing and input backend.
+  - [SDL3](https://github.com/libsdl-org/SDL/blob/main/LICENSE.txt) (zlib) windowing and input backend.
   - [glew](https://github.com/nigels-com/glew/blob/master/LICENSE.txt) (modified BSD-3-Clause and MIT) OpenGL extension loading backend (Windows/macOS).
   - [metal-cpp](https://github.com/briaguya-ai/single-header-metal-cpp/blob/macOS13_iOS16/LICENSE) (Apache 2.0) Apple Metal rendering backend (macOS/iOS).
 - [StormLib](https://github.com/ladislav-zezula/StormLib/blob/master/LICENSE) (MIT) create and read `.mpq` compatible archive files.
@@ -122,7 +122,7 @@ LUS makes use of the following third party libraries and resources:
 - [stb](https://github.com/nothings/stb/blob/master/LICENSE) (MIT) image conversion.
 - [thread-pool](https://github.com/bshoshany/thread-pool/blob/master/LICENSE.txt) (MIT) thread pool for the resource manager.
 - [tinyxml2](https://github.com/leethomason/tinyxml2/blob/master/LICENSE.txt) (zlib) parse XML files for resource loaders.
-- [sdl2](https://github.com/libsdl-org/SDL/blob/main/LICENSE.txt) (zlib) window manager, controllers, and audio player.
+- [SDL3](https://github.com/libsdl-org/SDL/blob/main/LICENSE.txt) (zlib) window manager, controllers, and audio player.
 - [glob_match](https://github.com/torvalds/linux/blob/d1bd5fa07667fcc3e38996ec42aef98761f23039/lib/glob.c) (Dual MIT/GPL) Glob pattern matching.
 - [libgfxd](https://github.com/glankk/libgfxd/blob/master/LICENSE) (MIT) display list disassembler.
 - [libtcc](https://repo.or.cz/tinycc.git/blob/HEAD:/COPYING) (LGPL-2.1) C compiler used for the script system.

--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include "ship/window/gui/Gui.h"
 #include "fast/WindowEvent.h"
 #include "fast/resource/type/Texture.h"

--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -77,10 +77,8 @@ class Fast3dGui : public Ship::Gui {
     /**
      * @brief Forwards a platform window event to the active ImGui backend.
      *
-     * Only Fast3D backends (gfx_sdl,
-     * gfx_dxgi) construct and dispatch WindowEvents.
-     * Callers retrieve the Gui via Window::GetGui() and
-     * dynamic_cast to Fast3dGui.
+     * Only Fast3D backends (gfx_sdl, gfx_dxgi) construct and dispatch WindowEvents.
+     * Callers retrieve the Gui via Window::GetGui() and dynamic_cast to Fast3dGui.
      * @param event Platform event (SDL or Win32) wrapped in a Fast::WindowEvent.
      */
     void HandleWindowEvents(Fast::WindowEvent event);

--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -77,9 +77,10 @@ class Fast3dGui : public Ship::Gui {
     /**
      * @brief Forwards a platform window event to the active ImGui backend.
      *
-     * Only Fast3D backends (gfx_sdl, gfx_dxgi) construct and dispatch WindowEvents.
-     * Callers retrieve the Gui via
-     * Window::GetGui() and dynamic_cast to Fast3dGui.
+     * Only Fast3D backends (gfx_sdl,
+     * gfx_dxgi) construct and dispatch WindowEvents.
+     * Callers retrieve the Gui via Window::GetGui() and
+     * dynamic_cast to Fast3dGui.
      * @param event Platform event (SDL or Win32) wrapped in a Fast::WindowEvent.
      */
     void HandleWindowEvents(Fast::WindowEvent event);

--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -12,7 +12,7 @@ class ResourceManager;
 } // namespace Ship
 
 // Fixes issue #926: HandleWindowEvents is only ever called from Fast3D backend code
-// (gfx_sdl2.cpp, gfx_dxgi.cpp) and must not be a virtual method on Ship::Gui.
+// (gfx_sdl.cpp, gfx_dxgi.cpp) and must not be a virtual method on Ship::Gui.
 // The WindowEvent type has been moved to the Fast namespace so that ship code does
 // not depend on any Fast3D or platform-specific types.
 
@@ -77,8 +77,9 @@ class Fast3dGui : public Ship::Gui {
     /**
      * @brief Forwards a platform window event to the active ImGui backend.
      *
-     * Only Fast3D backends (gfx_sdl2, gfx_dxgi) construct and dispatch WindowEvents.
-     * Callers retrieve the Gui via Window::GetGui() and dynamic_cast to Fast3dGui.
+     * Only Fast3D backends (gfx_sdl, gfx_dxgi) construct and dispatch WindowEvents.
+     * Callers retrieve the Gui via
+     * Window::GetGui() and dynamic_cast to Fast3dGui.
      * @param event Platform event (SDL or Win32) wrapped in a Fast::WindowEvent.
      */
     void HandleWindowEvents(Fast::WindowEvent event);

--- a/include/fast/WindowEvent.h
+++ b/include/fast/WindowEvent.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // Fixes issue #926: ship/window/gui/Gui.h previously defined WindowEvent in the Ship namespace,
-// but this type is only ever constructed and consumed by Fast3D backend code (gfx_sdl2.cpp,
+// but this type is only ever constructed and consumed by Fast3D backend code (gfx_sdl.cpp,
 // gfx_dxgi.cpp) and processed by Fast3dGui::HandleWindowEvents. Moving it to the Fast namespace
 // enforces the correct include hierarchy: fast can include fast, ship cannot include fast.
 
@@ -10,9 +10,9 @@ namespace Fast {
 /**
  * @brief Platform-agnostic wrapper around a window system event.
  *
- * Constructed by the Fast3D backends (gfx_sdl2, gfx_dxgi) and passed to
- * Fast3dGui::HandleWindowEvents() so that the ImGui backend can process input
- * events without the ship layer depending on any Fast3D or platform-specific type.
+ * Constructed by the Fast3D backends (gfx_sdl, gfx_dxgi) and passed to
+ * Fast3dGui::HandleWindowEvents() so that the
+ * ImGui backend can process input events without the ship layer depending on any Fast3D or platform-specific type.
  */
 typedef union {
     struct {

--- a/include/fast/WindowEvent.h
+++ b/include/fast/WindowEvent.h
@@ -10,9 +10,11 @@ namespace Fast {
 /**
  * @brief Platform-agnostic wrapper around a window system event.
  *
- * Constructed by the Fast3D backends (gfx_sdl, gfx_dxgi) and passed to
- * Fast3dGui::HandleWindowEvents() so that the
- * ImGui backend can process input events without the ship layer depending on any Fast3D or platform-specific type.
+ * Constructed by the Fast3D backends (gfx_sdl,
+ * gfx_dxgi) and passed to
+ * Fast3dGui::HandleWindowEvents() so that the ImGui backend can process input
+ * events
+ * without the ship layer depending on any Fast3D or platform-specific type.
  */
 typedef union {
     struct {

--- a/include/fast/WindowEvent.h
+++ b/include/fast/WindowEvent.h
@@ -10,11 +10,9 @@ namespace Fast {
 /**
  * @brief Platform-agnostic wrapper around a window system event.
  *
- * Constructed by the Fast3D backends (gfx_sdl,
- * gfx_dxgi) and passed to
+ * Constructed by the Fast3D backends (gfx_sdl, gfx_dxgi) and passed to
  * Fast3dGui::HandleWindowEvents() so that the ImGui backend can process input
- * events
- * without the ship layer depending on any Fast3D or platform-specific type.
+ * events without the ship layer depending on any Fast3D or platform-specific type.
  */
 typedef union {
     struct {

--- a/include/fast/backends/gfx_metal.h
+++ b/include/fast/backends/gfx_metal.h
@@ -11,7 +11,7 @@
 #include "gfx_rendering_api.h"
 #include "../interpreter.h"
 
-#include <imgui_impl_sdl2.h>
+#include <imgui_impl_sdl3.h>
 #include <simd/simd.h>
 
 namespace Ship {

--- a/include/fast/backends/gfx_opengl.h
+++ b/include/fast/backends/gfx_opengl.h
@@ -11,24 +11,24 @@ class ResourceManager;
 } // namespace Ship
 
 #ifdef _MSC_VER
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 // #define GL_GLEXT_PROTOTYPES 1
 #include <GL/glew.h>
 #elif FOR_WINDOWS
 #include <GL/glew.h>
-#include "SDL.h"
+#include <SDL3/SDL.h>
 #define GL_GLEXT_PROTOTYPES 1
-#include "SDL_opengl.h"
+#include <SDL3/SDL_opengl.h>
 #elif __APPLE__
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <GL/glew.h>
 #elif USE_OPENGLES
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <GLES3/gl3.h>
 #else
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #define GL_GLEXT_PROTOTYPES 1
-#include <SDL2/SDL_opengl.h>
+#include <SDL3/SDL_opengl.h>
 #endif
 namespace Fast {
 /**

--- a/include/fast/backends/gfx_opengl.h
+++ b/include/fast/backends/gfx_opengl.h
@@ -11,15 +11,18 @@ class ResourceManager;
 } // namespace Ship
 
 #ifdef _MSC_VER
+#define FAST_GFX_OPENGL_USE_GLEW
 #include <SDL3/SDL.h>
 // #define GL_GLEXT_PROTOTYPES 1
 #include <GL/glew.h>
 #elif FOR_WINDOWS
+#define FAST_GFX_OPENGL_USE_GLEW
 #include <GL/glew.h>
 #include <SDL3/SDL.h>
 #define GL_GLEXT_PROTOTYPES 1
 #include <SDL3/SDL_opengl.h>
 #elif __APPLE__
+#define FAST_GFX_OPENGL_USE_GLEW
 #include <SDL3/SDL.h>
 #include <GL/glew.h>
 #elif USE_OPENGLES

--- a/include/fast/backends/gfx_sdl.h
+++ b/include/fast/backends/gfx_sdl.h
@@ -13,7 +13,7 @@ namespace Fast {
 class Fast3dGui;
 
 /**
- * @brief SDL2 implementation of the Fast3D window/input backend.
+ * @brief SDL implementation of the Fast3D window/input backend.
  *
  * Handles window creation, input polling, fullscreen transitions, framerate
  * pacing, and callback forwarding to the renderer/runtime.
@@ -74,10 +74,10 @@ class GfxWindowBackendSDL2 final : public GfxWindowBackend {
     void OnMouseButtonUp(int btn) const;
     void SyncFramerateWithTime() const;
 
-    SDL_Window* mWnd;
+    SDL_Window* mWnd = nullptr;
     SDL_Rect mCursorClip;
-    SDL_GLContext mCtx;
-    SDL_Renderer* mRenderer;
+    SDL_GLContext mCtx = nullptr;
+    SDL_Renderer* mRenderer = nullptr;
     int mSdlToLusTable[512];
     float mMouseWheelX = 0.0f;
     float mMouseWheelY = 0.0f;

--- a/include/fast/backends/gfx_sdl.h
+++ b/include/fast/backends/gfx_sdl.h
@@ -75,7 +75,6 @@ class GfxWindowBackendSDL2 final : public GfxWindowBackend {
     void SyncFramerateWithTime() const;
 
     SDL_Window* mWnd = nullptr;
-    SDL_Rect mCursorClip;
     SDL_GLContext mCtx = nullptr;
     SDL_Renderer* mRenderer = nullptr;
     int mSdlToLusTable[512];

--- a/include/fast/backends/gfx_sdl.h
+++ b/include/fast/backends/gfx_sdl.h
@@ -18,14 +18,14 @@ class Fast3dGui;
  * Handles window creation, input polling, fullscreen transitions, framerate
  * pacing, and callback forwarding to the renderer/runtime.
  */
-class GfxWindowBackendSDL2 final : public GfxWindowBackend {
+class GfxWindowBackendSDL final : public GfxWindowBackend {
   public:
     /** @brief Constructs the backend with optional shared engine dependencies. */
-    GfxWindowBackendSDL2(std::shared_ptr<Ship::Config> config = nullptr,
-                         std::shared_ptr<Ship::FileDrop> fileDrop = nullptr,
-                         std::shared_ptr<Ship::ConsoleVariable> consoleVariable = nullptr,
-                         std::shared_ptr<Fast::Fast3dGui> fast3dGui = nullptr);
-    ~GfxWindowBackendSDL2() override;
+    GfxWindowBackendSDL(std::shared_ptr<Ship::Config> config = nullptr,
+                        std::shared_ptr<Ship::FileDrop> fileDrop = nullptr,
+                        std::shared_ptr<Ship::ConsoleVariable> consoleVariable = nullptr,
+                        std::shared_ptr<Fast::Fast3dGui> fast3dGui = nullptr);
+    ~GfxWindowBackendSDL() override;
 
     /** @name GfxWindowBackend implementation */
     /** @{ */

--- a/include/fast/backends/gfx_sdl.h
+++ b/include/fast/backends/gfx_sdl.h
@@ -75,6 +75,7 @@ class GfxWindowBackendSDL final : public GfxWindowBackend {
     void SyncFramerateWithTime() const;
 
     SDL_Window* mWnd = nullptr;
+    SDL_Rect mCursorClip{};
     SDL_GLContext mCtx = nullptr;
     SDL_Renderer* mRenderer = nullptr;
     int mSdlToLusTable[512];

--- a/include/libultraship/controller/controldevice/controller/mapping/ControllerDefaultMappings.h
+++ b/include/libultraship/controller/controldevice/controller/mapping/ControllerDefaultMappings.h
@@ -32,14 +32,13 @@ class ControllerDefaultMappings : public Ship::ControllerDefaultMappings {
             defaultKeyboardKeyToButtonMappings,
         std::unordered_map<Ship::StickIndex, std::vector<std::pair<Ship::Direction, Ship::KbScancode>>>
             defaultKeyboardKeyToAxisDirectionMappings,
-        std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>
-            defaultSDLButtonToButtonMappings,
-        std::unordered_map<Ship::StickIndex, std::vector<std::pair<Ship::Direction, SDL_GameControllerButton>>>
+        std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>> defaultSDLButtonToButtonMappings,
+        std::unordered_map<Ship::StickIndex, std::vector<std::pair<Ship::Direction, SDL_GamepadButton>>>
             defaultSDLButtonToAxisDirectionMappings,
-        std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>
+        std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>
             defaultSDLAxisDirectionToButtonMappings,
         std::unordered_map<Ship::StickIndex,
-                           std::vector<std::pair<Ship::Direction, std::pair<SDL_GameControllerAxis, int32_t>>>>
+                           std::vector<std::pair<Ship::Direction, std::pair<SDL_GamepadAxis, int32_t>>>>
             defaultSDLAxisDirectionToAxisDirectionMappings);
 
     /**
@@ -64,15 +63,15 @@ class ControllerDefaultMappings : public Ship::ControllerDefaultMappings {
      * @param defaultSDLButtonToButtonMappings Map from button bitmask to SDL gamepad buttons.
      */
     void SetDefaultSDLButtonToButtonMappings(
-        std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>
-            defaultSDLButtonToButtonMappings) override;
+        std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>> defaultSDLButtonToButtonMappings)
+        override;
 
     /**
      * @brief Applies the given SDL-axis-to-button mapping table as the default.
      * @param defaultSDLAxisDirectionToButtonMappings Map from button bitmask to (SDL axis, direction) pairs.
      */
     void SetDefaultSDLAxisDirectionToButtonMappings(
-        std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>
+        std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>
             defaultSDLAxisDirectionToButtonMappings) override;
 };
 } // namespace LUS

--- a/include/ship/audio/AudioPlayer.h
+++ b/include/ship/audio/AudioPlayer.h
@@ -25,7 +25,7 @@ struct AudioSettings {
  * AudioPlayer owns the audio device lifecycle (DoInit / DoClose) and the optional
  * SoundMatrixDecoder that converts stereo input to 5.1 surround. Concrete
  * subclasses implement DoInit(), DoClose(), and DoPlay() for each supported platform
- * (SDL2, CoreAudio, WASAPI, or a null no-op).
+ * (SDL3, CoreAudio, WASAPI, or a null no-op).
  *
  * Obtain the active instance from Context::GetAudio() → Audio::GetAudioPlayer().
  */

--- a/include/ship/audio/SDLAudioPlayer.h
+++ b/include/ship/audio/SDLAudioPlayer.h
@@ -1,15 +1,13 @@
 #pragma once
 #include "AudioPlayer.h"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 namespace Ship {
 /**
- * @brief AudioPlayer implementation backed by SDL2's audio subsystem.
+ * @brief AudioPlayer implementation backed by SDL3's audio subsystem.
  *
- * SDLAudioPlayer uses `SDL_OpenAudioDevice` to open a platform audio output, then
- * pushes interleaved PCM samples in DoPlay(). It supports both stereo and 6-channel
- * (5.1) output depending on the AudioChannelsSetting configured in AudioPlayer.
- *
+ * SDLAudioPlayer opens the platform output with `SDL_OpenAudioDeviceStream` and queues PCM in DoPlay().
+ * It supports stereo and 6-channel output according to the configured AudioChannelsSetting.
  * This backend is available on all platforms that Ship supports.
  */
 class SDLAudioPlayer final : public AudioPlayer {
@@ -49,7 +47,7 @@ class SDLAudioPlayer final : public AudioPlayer {
     void DoPlay(const uint8_t* buf, size_t len) override;
 
   private:
-    SDL_AudioDeviceID mDevice = 0; ///< Handle to the opened SDL audio device.
-    int32_t mNumChannels = 2;      ///< Number of output channels (2 for stereo, 6 for 5.1).
+    SDL_AudioStream* mStream = nullptr; ///< Stream bound to the opened SDL audio device.
+    int32_t mNumChannels = 2;           ///< Number of output channels (2 for stereo, 6 for 5.1).
 };
 } // namespace Ship

--- a/include/ship/controller/controldevice/controller/mapping/ControllerDefaultMappings.h
+++ b/include/ship/controller/controldevice/controller/mapping/ControllerDefaultMappings.h
@@ -4,7 +4,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include "ControllerAxisDirectionMapping.h"
 
 #ifndef CONTROLLERBUTTONS_T
@@ -37,13 +37,12 @@ class ControllerDefaultMappings {
         std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<KbScancode>> defaultKeyboardKeyToButtonMappings,
         std::unordered_map<StickIndex, std::vector<std::pair<Direction, KbScancode>>>
             defaultKeyboardKeyToAxisDirectionMappings,
-        std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>
-            defaultSDLButtonToButtonMappings,
-        std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GameControllerButton>>>
+        std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>> defaultSDLButtonToButtonMappings,
+        std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GamepadButton>>>
             defaultSDLButtonToAxisDirectionMappings,
-        std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>
+        std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>
             defaultSDLAxisDirectionToButtonMappings,
-        std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GameControllerAxis, int32_t>>>>
+        std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GamepadAxis, int32_t>>>>
             defaultSDLAxisDirectionToAxisDirectionMappings);
 
     /** @brief Constructs a ControllerDefaultMappings with empty default tables. */
@@ -67,28 +66,28 @@ class ControllerDefaultMappings {
      * @brief Returns the default SDL-button-to-button mappings.
      * @return Map of button bitmask to set of SDL gamepad buttons.
      */
-    std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>
+    std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>>
     GetDefaultSDLButtonToButtonMappings();
 
     /**
      * @brief Returns the default SDL-button-to-axis-direction mappings.
      * @return Map of stick index to direction/SDL-button pairs.
      */
-    std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GameControllerButton>>>
+    std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GamepadButton>>>
     GetDefaultSDLButtonToAxisDirectionMappings();
 
     /**
      * @brief Returns the default SDL-axis-direction-to-button mappings.
      * @return Map of button bitmask to axis/threshold pairs.
      */
-    std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>
+    std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>
     GetDefaultSDLAxisDirectionToButtonMappings();
 
     /**
      * @brief Returns the default SDL-axis-direction-to-axis-direction mappings.
      * @return Map of stick index to direction/(axis, threshold) pairs.
      */
-    std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GameControllerAxis, int32_t>>>>
+    std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GamepadAxis, int32_t>>>>
     GetDefaultSDLAxisDirectionToAxisDirectionMappings();
 
   protected:
@@ -111,16 +110,16 @@ class ControllerDefaultMappings {
      * @brief Replaces the default SDL-button-to-button mappings.
      * @param defaultSDLButtonToButtonMappings The new mappings.
      */
-    virtual void SetDefaultSDLButtonToButtonMappings(
-        std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>
-            defaultSDLButtonToButtonMappings);
+    virtual void
+    SetDefaultSDLButtonToButtonMappings(std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>>
+                                            defaultSDLButtonToButtonMappings);
 
     /**
      * @brief Replaces the default SDL-button-to-axis-direction mappings.
      * @param defaultSDLButtonToAxisDirectionMappings The new mappings.
      */
     virtual void SetDefaultSDLButtonToAxisDirectionMappings(
-        std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GameControllerButton>>>
+        std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GamepadButton>>>
             defaultSDLButtonToAxisDirectionMappings);
 
     /**
@@ -128,7 +127,7 @@ class ControllerDefaultMappings {
      * @param defaultSDLAxisDirectionToButtonMappings The new mappings.
      */
     virtual void SetDefaultSDLAxisDirectionToButtonMappings(
-        std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>
+        std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>
             defaultSDLAxisDirectionToButtonMappings);
 
     /**
@@ -136,20 +135,19 @@ class ControllerDefaultMappings {
      * @param defaultSDLAxisDirectionToAxisDirectionMappings The new mappings.
      */
     virtual void SetDefaultSDLAxisDirectionToAxisDirectionMappings(
-        std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GameControllerAxis, int32_t>>>>
+        std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GamepadAxis, int32_t>>>>
             defaultSDLAxisDirectionToAxisDirectionMappings);
 
   private:
     std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<KbScancode>> mDefaultKeyboardKeyToButtonMappings;
     std::unordered_map<StickIndex, std::vector<std::pair<Direction, KbScancode>>>
         mDefaultKeyboardKeyToAxisDirectionMappings;
-    std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>
-        mDefaultSDLButtonToButtonMappings;
-    std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GameControllerButton>>>
+    std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>> mDefaultSDLButtonToButtonMappings;
+    std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GamepadButton>>>
         mDefaultSDLButtonToAxisDirectionMappings;
-    std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>
+    std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>
         mDefaultSDLAxisDirectionToButtonMappings;
-    std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GameControllerAxis, int32_t>>>>
+    std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GamepadAxis, int32_t>>>>
         mDefaultSDLAxisDirectionToAxisDirectionMappings;
 };
 } // namespace Ship

--- a/include/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h
+++ b/include/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h
@@ -45,14 +45,10 @@ class RumbleMappingFactory {
                                   std::shared_ptr<ControlDeck> controlDeck);
 
     /**
-     * @brief Creates default SDL rumble mappings for a specific physical device type.
-     * @param physicalDeviceType
-     * Type of physical device receiving the mapping.
+     * @param physicalDeviceType Type of physical device receiving the mapping.
      * @param portIndex Controller port index (0-based).
-     *
      * @param consoleVariable    ConsoleVariable for persisting mappings.
-     * @param controlDeck        ControlDeck
-     * for physical device access.
+     * @param controlDeck        ControlDeck for physical device access.
      * @return A default SDL rumble mapping for SDL gamepads, or an empty vector for other device types.
      */
     static std::vector<std::shared_ptr<ControllerRumbleMapping>>

--- a/include/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h
+++ b/include/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h
@@ -46,11 +46,12 @@ class RumbleMappingFactory {
 
     /**
      * @brief Creates default SDL rumble mappings for a specific physical device type.
-     * @param physicalDeviceType SDL gamepad type.
-     * @param portIndex          Controller port index (0-based).
+     * @param physicalDeviceType Type of physical device receiving the mapping.
+     * @param portIndex Controller port
+     * index (0-based).
      * @param consoleVariable    ConsoleVariable for persisting mappings.
      * @param controlDeck        ControlDeck for physical device access.
-     * @return Vector of rumble mappings suitable for the device type.
+     * @return A default SDL rumble mapping for SDL gamepads, or an empty vector for other device types.
      */
     static std::vector<std::shared_ptr<ControllerRumbleMapping>>
     CreateDefaultSDLRumbleMappings(PhysicalDeviceType physicalDeviceType, uint8_t portIndex,

--- a/include/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h
+++ b/include/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h
@@ -46,7 +46,7 @@ class RumbleMappingFactory {
 
     /**
      * @brief Creates default SDL rumble mappings for a specific physical device type.
-     * @param portIndex Controller port index (0-based).
+     * @param physicalDeviceType Type of physical device receiving the mapping.
      * @param portIndex Controller port index (0-based).
      * @param consoleVariable    ConsoleVariable for persisting mappings.
      * @param controlDeck        ControlDeck for physical device access.

--- a/include/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h
+++ b/include/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h
@@ -46,11 +46,13 @@ class RumbleMappingFactory {
 
     /**
      * @brief Creates default SDL rumble mappings for a specific physical device type.
-     * @param physicalDeviceType Type of physical device receiving the mapping.
-     * @param portIndex Controller port
-     * index (0-based).
+     * @param physicalDeviceType
+     * Type of physical device receiving the mapping.
+     * @param portIndex Controller port index (0-based).
+     *
      * @param consoleVariable    ConsoleVariable for persisting mappings.
-     * @param controlDeck        ControlDeck for physical device access.
+     * @param controlDeck        ControlDeck
+     * for physical device access.
      * @return A default SDL rumble mapping for SDL gamepads, or an empty vector for other device types.
      */
     static std::vector<std::shared_ptr<ControllerRumbleMapping>>

--- a/include/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h
+++ b/include/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h
@@ -45,7 +45,8 @@ class RumbleMappingFactory {
                                   std::shared_ptr<ControlDeck> controlDeck);
 
     /**
-     * @param physicalDeviceType Type of physical device receiving the mapping.
+     * @brief Creates default SDL rumble mappings for a specific physical device type.
+     * @param portIndex Controller port index (0-based).
      * @param portIndex Controller port index (0-based).
      * @param consoleVariable    ConsoleVariable for persisting mappings.
      * @param controlDeck        ControlDeck for physical device access.

--- a/include/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h
+++ b/include/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h
@@ -46,8 +46,8 @@ class RumbleMappingFactory {
 
     /**
      * @brief Creates default SDL rumble mappings for a specific physical device type.
-     * @param physicalDeviceType The type of physical device (e.g., SDL2 gamepad, Nintendo controller).
-     * @param portIndex          The controller port index (0-based).
+     * @param physicalDeviceType SDL gamepad type.
+     * @param portIndex          Controller port index (0-based).
      * @param consoleVariable    ConsoleVariable for persisting mappings.
      * @param controlDeck        ControlDeck for physical device access.
      * @return Vector of rumble mappings suitable for the device type.

--- a/include/ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAnyMapping.h
+++ b/include/ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAnyMapping.h
@@ -42,7 +42,7 @@ class SDLAxisDirectionToAnyMapping : virtual public ControllerInputMapping {
     bool AxisIsStick();
 
   protected:
-    SDL_GameControllerAxis mControllerAxis;
+    SDL_GamepadAxis mControllerAxis;
     AxisDirection mAxisDirection;
 };
 } // namespace Ship

--- a/include/ship/controller/controldevice/controller/mapping/sdl/SDLButtonToAnyMapping.h
+++ b/include/ship/controller/controldevice/controller/mapping/sdl/SDLButtonToAnyMapping.h
@@ -30,7 +30,7 @@ class SDLButtonToAnyMapping : virtual public ControllerInputMapping {
     std::string GetPhysicalDeviceName() override;
 
   protected:
-    SDL_GameControllerButton mControllerButton;
+    SDL_GamepadButton mControllerButton;
 
   private:
     std::string GetGenericButtonName();

--- a/include/ship/controller/controldevice/controller/mapping/sdl/SDLMapping.h
+++ b/include/ship/controller/controldevice/controller/mapping/sdl/SDLMapping.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 namespace Ship {
 

--- a/include/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.h
+++ b/include/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.h
@@ -4,17 +4,15 @@
 #include <unordered_set>
 #include <vector>
 #include <string>
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 namespace Ship {
 
 /**
- * @brief Tracks connected SDL game controllers and manages per-port ignore lists.
+ * @brief Tracks connected SDL gamepads and manages per-port ignore lists.
  *
- * ConnectedPhysicalDeviceManager maintains a live map of SDL game controllers that
- * are currently connected to the system. It also supports per-port ignore lists so
- * that specific controllers can be excluded from a given controller port's input
- * processing.
+ * Maintains a live map of connected SDL gamepads. Per-port ignore lists allow a
+ * controller to be excluded from a specific port.
  */
 class ConnectedPhysicalDeviceManager {
   public:
@@ -28,9 +26,9 @@ class ConnectedPhysicalDeviceManager {
      * Gamepads on the port's ignore list are excluded from the result.
      *
      * @param portIndex Zero-based controller port index.
-     * @return Map of SDL joystick instance ID to SDL_GameController pointer.
+     * @return Map of SDL joystick instance ID to SDL_Gamepad pointer.
      */
-    std::unordered_map<int32_t, SDL_GameController*> GetConnectedSDLGamepadsForPort(uint8_t portIndex);
+    std::unordered_map<int32_t, SDL_Gamepad*> GetConnectedSDLGamepadsForPort(uint8_t portIndex);
 
     /**
      * @brief Returns the display names of all connected SDL gamepads.
@@ -68,22 +66,24 @@ class ConnectedPhysicalDeviceManager {
     void UnignoreInstanceIdForPort(uint8_t portIndex, int32_t instanceId);
 
     /**
-     * @brief Handles an SDL device-added event by opening the new controller.
-     * @param sdlDeviceIndex SDL device index from the SDL_CONTROLLERDEVICEADDED event.
+     * @brief Handles a gamepad-added event by refreshing the connected set.
+     * @param instanceId Event joystick instance ID.
      */
-    void HandlePhysicalDeviceConnect(int32_t sdlDeviceIndex);
+    void HandlePhysicalDeviceConnect(int32_t instanceId);
 
     /**
-     * @brief Handles an SDL device-removed event by closing the controller.
-     * @param sdlJoystickInstanceId SDL joystick instance ID from the SDL_CONTROLLERDEVICEREMOVED event.
+     * @brief Handles a gamepad-removed event by refreshing the connected set.
+     * @param instanceId Event joystick instance ID.
      */
-    void HandlePhysicalDeviceDisconnect(int32_t sdlJoystickInstanceId);
+    void HandlePhysicalDeviceDisconnect(int32_t instanceId);
 
     /** @brief Re-scans all connected SDL gamepads and rebuilds the internal maps. */
     void RefreshConnectedSDLGamepads();
 
   private:
-    std::unordered_map<int32_t, SDL_GameController*> mConnectedSDLGamepads;
+    void CloseConnectedSDLGamepads();
+
+    std::unordered_map<int32_t, SDL_Gamepad*> mConnectedSDLGamepads;
     std::unordered_map<int32_t, std::string> mConnectedSDLGamepadNames;
     std::unordered_map<uint8_t, std::unordered_set<int32_t>> mIgnoredInstanceIds;
 };

--- a/include/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.h
+++ b/include/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.h
@@ -77,7 +77,7 @@ class ConnectedPhysicalDeviceManager {
      */
     void HandlePhysicalDeviceDisconnect(int32_t instanceId);
 
-    /** @brief Re-scans all connected SDL gamepads and rebuilds the internal maps. */
+    /** @brief Re-scans SDL gamepads, preserving handles for devices that remain connected. */
     void RefreshConnectedSDLGamepads();
 
   private:

--- a/include/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.h
+++ b/include/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.h
@@ -9,12 +9,12 @@ class ControlDeck;
 class Window;
 
 /**
- * @brief Hidden GuiWindow that listens for SDL controller add/remove events.
+ * @brief Hidden GuiWindow that listens for SDL controller add/remove/remap events.
  *
  * SDLAddRemoveDeviceEventHandler is registered as a GuiWindow solely so it
  * participates in the update loop. It does not draw any UI; instead its
- * UpdateElement() polls SDL events and forwards device connection/disconnection
- * notifications to the ConnectedPhysicalDeviceManager.
+ * UpdateElement() polls SDL events and forwards device and mapping changes to
+ * the ConnectedPhysicalDeviceManager.
  */
 class SDLAddRemoveDeviceEventHandler : public GuiWindow {
   public:

--- a/include/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.h
+++ b/include/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.h
@@ -9,11 +9,11 @@ class ControlDeck;
 class Window;
 
 /**
- * @brief Hidden GuiWindow that listens for SDL controller add/remove/remap events.
+ * @brief Hidden GuiWindow that listens for SDL controller add/remove events.
  *
  * SDLAddRemoveDeviceEventHandler is registered as a GuiWindow solely so it
  * participates in the update loop. It does not draw any UI; instead its
- * UpdateElement() polls SDL events and forwards device and mapping changes to
+ * UpdateElement() polls SDL events and forwards device changes to
  * the ConnectedPhysicalDeviceManager.
  */
 class SDLAddRemoveDeviceEventHandler : public GuiWindow {

--- a/include/ship/debug/CrashHandler.h
+++ b/include/ship/debug/CrashHandler.h
@@ -11,7 +11,7 @@
 #include <dlfcn.h>  // for dladdr
 #include <execinfo.h>
 #include <unistd.h>
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #endif
 
 #if _WIN32

--- a/include/ship/port/mobile/MobileImpl.h
+++ b/include/ship/port/mobile/MobileImpl.h
@@ -1,14 +1,11 @@
 #pragma once
 
-#include <cstdint>
-#include <string>
-
-#include <imgui.h>
+struct SDL_Window;
 
 namespace Ship {
 
 class Mobile {
   public:
-    static void ImGuiProcessEvent(bool wantsTextInput);
+    static void ImGuiProcessEvent(SDL_Window* window, bool wantsTextInput);
 };
 }; // namespace Ship

--- a/include/ship/utils/macUtils.h
+++ b/include/ship/utils/macUtils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/ship/window/FileDrop.h
+++ b/include/ship/window/FileDrop.h
@@ -36,7 +36,7 @@ class FileDrop : public Component {
      * @brief Records a file path as having been dropped onto the window.
      * @param path Path of the dropped file (ownership is not taken).
      */
-    void SetDroppedFile(char* path);
+    void SetDroppedFile(const char* path);
 
     /** @brief Clears the current dropped-file state. */
     void ClearDroppedFile();

--- a/include/ship/window/gui/Gui.h
+++ b/include/ship/window/gui/Gui.h
@@ -200,8 +200,9 @@ class Gui : public Component {
      *  The base implementation is a no-op. */
     virtual void ImGuiBackendNewFrame();
 
-    /** @brief Calls ImGui_ImplSDL2_NewFrame() or the platform equivalent.
-     *  The base implementation is a no-op. */
+    /** @brief Calls ImGui_ImplSDL3_NewFrame() or the platform equivalent.
+     *  The base implementation is a no-op.
+     */
     virtual void ImGuiWMNewFrame();
 
     /** @brief Initialises the platform/window-manager ImGui backend.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -204,8 +204,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL "iOS")
             XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
         )
 
-        if(TARGET SDL2)
-            set_target_properties(SDL2 PROPERTIES
+        if(TARGET SDL3-static)
+            set_target_properties(SDL3-static PROPERTIES
                 XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
                 XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
             )

--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -14,13 +14,13 @@
 #include "ship/resource/File.h"
 
 #ifdef __APPLE__
-#include <SDL_hints.h>
-#include <SDL_video.h>
+#include <SDL3/SDL_hints.h>
+#include <SDL3/SDL_video.h>
 #include <imgui_impl_metal.h>
-#include <imgui_impl_sdl2.h>
+#include <imgui_impl_sdl3.h>
 #else
-#include <SDL2/SDL_hints.h>
-#include <SDL2/SDL_video.h>
+#include <SDL3/SDL_hints.h>
+#include <SDL3/SDL_video.h>
 #endif
 
 #if defined(__ANDROID__) || defined(__IOS__)
@@ -29,7 +29,7 @@
 
 #ifdef ENABLE_OPENGL
 #include <imgui_impl_opengl3.h>
-#include <imgui_impl_sdl2.h>
+#include <imgui_impl_sdl3.h>
 #endif
 
 #if defined(ENABLE_DX11) || defined(ENABLE_DX12)
@@ -91,12 +91,16 @@ void Fast3dGui::HandleWindowEvents(Fast::WindowEvent event) {
 
     switch (window->GetWindowBackend()) {
         case WindowBackend::FAST3D_SDL_OPENGL:
-        case WindowBackend::FAST3D_SDL_METAL:
-            ImGui_ImplSDL2_ProcessEvent(static_cast<const SDL_Event*>(event.Sdl.Event));
+        case WindowBackend::FAST3D_SDL_METAL: {
+            ImGui_ImplSDL3_ProcessEvent(static_cast<const SDL_Event*>(event.Sdl.Event));
 #if defined(__ANDROID__) || defined(__IOS__)
-            Ship::Mobile::ImGuiProcessEvent(ImGui::GetIO().WantTextInput);
+            SDL_Window* sdlWindow = window->GetWindowBackend() == WindowBackend::FAST3D_SDL_OPENGL
+                                        ? static_cast<SDL_Window*>(mImpl.Opengl.Window)
+                                        : static_cast<SDL_Window*>(mImpl.Metal.Window);
+            Ship::Mobile::ImGuiProcessEvent(sdlWindow, ImGui::GetIO().WantTextInput);
 #endif
             break;
+        }
 #ifdef ENABLE_DX11
         case WindowBackend::FAST3D_DXGI_DX11:
             ImGui_ImplWin32_WndProcHandler(static_cast<HWND>(event.Win32.Handle), event.Win32.Msg, event.Win32.Param1,
@@ -118,7 +122,7 @@ void Fast3dGui::ImGuiWMInit() {
             if (mConsoleVariables->GetInteger(CVAR_ALLOW_BACKGROUND_INPUTS, 1)) {
                 SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
             }
-            ImGui_ImplSDL2_InitForOpenGL(static_cast<SDL_Window*>(mImpl.Opengl.Window), mImpl.Opengl.Context);
+            ImGui_ImplSDL3_InitForOpenGL(static_cast<SDL_Window*>(mImpl.Opengl.Window), mImpl.Opengl.Context);
             break;
 #if __APPLE__
         case WindowBackend::FAST3D_SDL_METAL:
@@ -126,7 +130,7 @@ void Fast3dGui::ImGuiWMInit() {
             if (mConsoleVariables->GetInteger(CVAR_ALLOW_BACKGROUND_INPUTS, 1)) {
                 SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
             }
-            ImGui_ImplSDL2_InitForMetal(static_cast<SDL_Window*>(mImpl.Metal.Window));
+            ImGui_ImplSDL3_InitForMetal(static_cast<SDL_Window*>(mImpl.Metal.Window));
             break;
 #endif
 #if defined(ENABLE_DX11) || defined(ENABLE_DX12)
@@ -138,7 +142,7 @@ void Fast3dGui::ImGuiWMInit() {
             break;
     }
 
-    // Initial gamepad bind once the SDL2 backend exists (no-op for DX/Metal).
+    // Initial gamepad bind once the SDL3 backend exists (no-op for DX/Metal).
     RefreshImGuiGamepads();
 }
 
@@ -147,12 +151,12 @@ void Fast3dGui::ImGuiWMShutdown() {
     switch (window->GetWindowBackend()) {
 #ifdef ENABLE_OPENGL
         case WindowBackend::FAST3D_SDL_OPENGL:
-            ImGui_ImplSDL2_Shutdown();
+            ImGui_ImplSDL3_Shutdown();
             break;
 #endif
 #if __APPLE__
         case WindowBackend::FAST3D_SDL_METAL:
-            ImGui_ImplSDL2_Shutdown();
+            ImGui_ImplSDL3_Shutdown();
             break;
 #endif
 #if defined(ENABLE_DX11) || defined(ENABLE_DX12)
@@ -254,7 +258,7 @@ void Fast3dGui::ImGuiWMNewFrame() {
     switch (window->GetWindowBackend()) {
         case WindowBackend::FAST3D_SDL_OPENGL:
         case WindowBackend::FAST3D_SDL_METAL:
-            ImGui_ImplSDL2_NewFrame();
+            ImGui_ImplSDL3_NewFrame();
             break;
 #ifdef ENABLE_DX11
         case WindowBackend::FAST3D_DXGI_DX11:
@@ -266,7 +270,7 @@ void Fast3dGui::ImGuiWMNewFrame() {
     }
 }
 
-// Bind ImGui's SDL2 gamepad backend to the controller(s) the
+// Bind ImGui's SDL3 gamepad backend to the controller(s) the
 // ControlDeck has already opened
 void Fast3dGui::RefreshImGuiGamepads() {
     auto window = mWindow;
@@ -275,7 +279,7 @@ void Fast3dGui::RefreshImGuiGamepads() {
         return;
     }
 
-    ImGui_ImplSDL2_SetGamepadMode(ImGui_ImplSDL2_GamepadMode_AutoAll, nullptr, 0);
+    ImGui_ImplSDL3_SetGamepadMode(ImGui_ImplSDL3_GamepadMode_AutoAll, nullptr, 0);
 }
 
 void Fast3dGui::ImGuiRenderDrawData(ImDrawData* data) {

--- a/src/fast/Fast3dWindow.cpp
+++ b/src/fast/Fast3dWindow.cpp
@@ -176,8 +176,8 @@ void Fast3dWindow::InitWindowManager() {
 #ifdef ENABLE_OPENGL
         case WindowBackend::FAST3D_SDL_OPENGL:
             mWindowManagerApi =
-                new GfxWindowBackendSDL2(GetConfig(), GetContext()->GetChildren().GetFirst<Ship::FileDrop>(),
-                                         GetConsoleVariables(), std::dynamic_pointer_cast<Fast::Fast3dGui>(GetGui()));
+                new GfxWindowBackendSDL(GetConfig(), GetContext()->GetChildren().GetFirst<Ship::FileDrop>(),
+                                        GetConsoleVariables(), std::dynamic_pointer_cast<Fast::Fast3dGui>(GetGui()));
             mRenderingApi = new GfxRenderingAPIOGL(GetConsoleVariables(),
                                                    GetContext()->GetChildren().GetFirst<Ship::ResourceManager>());
             break;
@@ -185,8 +185,8 @@ void Fast3dWindow::InitWindowManager() {
 #ifdef __APPLE__
         case WindowBackend::FAST3D_SDL_METAL:
             mWindowManagerApi =
-                new GfxWindowBackendSDL2(GetConfig(), GetContext()->GetChildren().GetFirst<Ship::FileDrop>(),
-                                         GetConsoleVariables(), std::dynamic_pointer_cast<Fast::Fast3dGui>(GetGui()));
+                new GfxWindowBackendSDL(GetConfig(), GetContext()->GetChildren().GetFirst<Ship::FileDrop>(),
+                                        GetConsoleVariables(), std::dynamic_pointer_cast<Fast::Fast3dGui>(GetGui()));
             mRenderingApi = new GfxRenderingAPIMetal(GetConsoleVariables(),
                                                      GetContext()->GetChildren().GetFirst<Ship::ResourceManager>());
             break;

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -27,7 +27,7 @@
 #define MTL_PRIVATE_IMPLEMENTATION
 #include <Metal/Metal.hpp>
 
-#include <SDL_render.h>
+#include <SDL3/SDL_render.h>
 #include <imgui_impl_metal.h>
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/fmt.h>
@@ -79,7 +79,7 @@ bool GfxRenderingAPIMetal::MetalInit(SDL_Renderer* renderer) {
     mRenderer = renderer;
     NS::AutoreleasePool* autorelease_pool = NS::AutoreleasePool::alloc()->init();
 
-    mLayer = (CA::MetalLayer*)SDL_RenderGetMetalLayer(renderer);
+    mLayer = (CA::MetalLayer*)SDL_GetRenderMetalLayer(renderer);
     mLayer->setPixelFormat(MTL::PixelFormatBGRA8Unorm);
 
     mDevice = mLayer->device();
@@ -101,7 +101,7 @@ static void SetupScreenFramebuffer(uint32_t width, uint32_t height);
 
 void GfxRenderingAPIMetal::NewFrame() {
     int width, height;
-    SDL_GetRendererOutputSize(mRenderer, &width, &height);
+    SDL_GetCurrentRenderOutputSize(mRenderer, &width, &height);
     SetupScreenFramebuffer(width, height);
 
     MTL::RenderPassDescriptor* current_render_pass = mFramebuffers[0].mRenderPassDescriptor;
@@ -758,7 +758,7 @@ void GfxRenderingAPIMetal::UpdateFramebufferParameters(int fb_id, uint32_t width
     // see `SetupScreenFramebuffer`.
     if (fb_id == 0) {
         int width, height;
-        SDL_GetRendererOutputSize(mRenderer, &width, &height);
+        SDL_GetCurrentRenderOutputSize(mRenderer, &width, &height);
         mLayer->setDrawableSize({ CGFloat(width), CGFloat(height) });
 
         return;

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -714,7 +714,7 @@ void GfxRenderingAPIOGL::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, size
 }
 
 void GfxRenderingAPIOGL::Init() {
-#if !defined(__linux__) && !defined(__OpenBSD__)
+#ifdef FAST_GFX_OPENGL_USE_GLEW
     glewInit();
 #endif
 

--- a/src/fast/backends/gfx_sdl.cpp
+++ b/src/fast/backends/gfx_sdl.cpp
@@ -208,18 +208,17 @@ const SDL_Scancode scancode_rmapping_nonextended[][2] = { { SDL_SCANCODE_KP_7, S
                                                           { SDL_SCANCODE_KP_PERIOD, SDL_SCANCODE_DELETE },
                                                           { SDL_SCANCODE_KP_MULTIPLY, SDL_SCANCODE_PRINTSCREEN } };
 
-GfxWindowBackendSDL2::GfxWindowBackendSDL2(std::shared_ptr<Ship::Config> config,
-                                           std::shared_ptr<Ship::FileDrop> fileDrop,
-                                           std::shared_ptr<Ship::ConsoleVariable> consoleVariable,
-                                           std::shared_ptr<Fast::Fast3dGui> fast3dGui)
+GfxWindowBackendSDL::GfxWindowBackendSDL(std::shared_ptr<Ship::Config> config, std::shared_ptr<Ship::FileDrop> fileDrop,
+                                         std::shared_ptr<Ship::ConsoleVariable> consoleVariable,
+                                         std::shared_ptr<Fast::Fast3dGui> fast3dGui)
     : mConsoleVariable(std::move(consoleVariable)), mConfig(std::move(config)), mFileDrop(std::move(fileDrop)),
       mFast3dGui(std::move(fast3dGui)) {
 }
 
-GfxWindowBackendSDL2::~GfxWindowBackendSDL2() {
+GfxWindowBackendSDL::~GfxWindowBackendSDL() {
 }
 
-void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
+void GfxWindowBackendSDL::SetFullscreenImpl(bool on, bool call_callback) {
     if (mFullScreen == on) {
         return;
     }
@@ -243,15 +242,14 @@ void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
                                                      desktopMode->refresh_rate, true, &fullscreenMode)) {
                 SPDLOG_ERROR("Failed to find an exclusive fullscreen mode.");
                 SPDLOG_ERROR(SDL_GetError());
-                return;
+            } else {
+                mode = &fullscreenMode;
             }
-            mode = &fullscreenMode;
         }
 
         if (!SDL_SetWindowFullscreenMode(mWnd, mode)) {
             SPDLOG_ERROR("Failed to set the fullscreen display mode.");
             SPDLOG_ERROR(SDL_GetError());
-            return;
         }
     }
 
@@ -288,7 +286,7 @@ void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
     }
 }
 
-void GfxWindowBackendSDL2::GetActiveWindowRefreshRate(uint32_t* refresh_rate) {
+void GfxWindowBackendSDL::GetActiveWindowRefreshRate(uint32_t* refresh_rate) {
     SDL_DisplayID display_in_use = SDL_GetDisplayForWindow(mWnd);
 
     const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(display_in_use);
@@ -304,7 +302,7 @@ static HANDLE mTimer;
 #define FRAME_INTERVAL_US_NUMERATOR 1000000
 #define FRAME_INTERVAL_US_DENOMINATOR (mTargetFps)
 
-void GfxWindowBackendSDL2::Close() {
+void GfxWindowBackendSDL::Close() {
     mIsRunning = false;
 }
 
@@ -316,8 +314,7 @@ static LRESULT CALLBACK gfx_sdl_wnd_proc(HWND h_wnd, UINT message, WPARAM w_para
             // system window procedure instead.
             return DefWindowProc(h_wnd, message, w_param, l_param);
         case WM_ENDSESSION: {
-            GfxWindowBackendSDL2* self =
-                reinterpret_cast<GfxWindowBackendSDL2*>(GetWindowLongPtr(h_wnd, GWLP_USERDATA));
+            GfxWindowBackendSDL* self = reinterpret_cast<GfxWindowBackendSDL*>(GetWindowLongPtr(h_wnd, GWLP_USERDATA));
             // Apparently SDL2 does not handle this
             if (w_param == TRUE) {
                 self->Close();
@@ -332,8 +329,8 @@ static LRESULT CALLBACK gfx_sdl_wnd_proc(HWND h_wnd, UINT message, WPARAM w_para
 };
 #endif
 
-void GfxWindowBackendSDL2::Init(const char* gameName, const char* gfxApiName, bool startFullScreen, uint32_t width,
-                                uint32_t height, int32_t posX, int32_t posY) {
+void GfxWindowBackendSDL::Init(const char* gameName, const char* gfxApiName, bool startFullScreen, uint32_t width,
+                               uint32_t height, int32_t posX, int32_t posY) {
     mWindowWidth = width;
     mWindowHeight = height;
 
@@ -474,15 +471,15 @@ void GfxWindowBackendSDL2::Init(const char* gameName, const char* gfxApiName, bo
     }
 }
 
-void GfxWindowBackendSDL2::SetFullscreenChangedCallback(void (*onFullscreenChanged)(bool is_now_fullscreen)) {
+void GfxWindowBackendSDL::SetFullscreenChangedCallback(void (*onFullscreenChanged)(bool is_now_fullscreen)) {
     mOnFullscreenChanged = onFullscreenChanged;
 }
 
-void GfxWindowBackendSDL2::SetFullscreen(bool enable) {
+void GfxWindowBackendSDL::SetFullscreen(bool enable) {
     SetFullscreenImpl(enable, true);
 }
 
-void GfxWindowBackendSDL2::SetCursorVisibility(bool visible) {
+void GfxWindowBackendSDL::SetCursorVisibility(bool visible) {
     if (visible) {
         SDL_ShowCursor();
     } else {
@@ -490,11 +487,11 @@ void GfxWindowBackendSDL2::SetCursorVisibility(bool visible) {
     }
 }
 
-void GfxWindowBackendSDL2::SetMousePos(int32_t x, int32_t y) {
+void GfxWindowBackendSDL::SetMousePos(int32_t x, int32_t y) {
     SDL_WarpMouseInWindow(mWnd, static_cast<float>(x), static_cast<float>(y));
 }
 
-void GfxWindowBackendSDL2::GetMousePos(int32_t* x, int32_t* y) {
+void GfxWindowBackendSDL::GetMousePos(int32_t* x, int32_t* y) {
     float mouseX = 0.0f;
     float mouseY = 0.0f;
     SDL_GetMouseState(&mouseX, &mouseY);
@@ -502,7 +499,7 @@ void GfxWindowBackendSDL2::GetMousePos(int32_t* x, int32_t* y) {
     *y = static_cast<int32_t>(mouseY);
 }
 
-void GfxWindowBackendSDL2::GetMouseDelta(int32_t* x, int32_t* y) {
+void GfxWindowBackendSDL::GetMouseDelta(int32_t* x, int32_t* y) {
     float deltaX = 0.0f;
     float deltaY = 0.0f;
     SDL_GetRelativeMouseState(&deltaX, &deltaY);
@@ -510,38 +507,38 @@ void GfxWindowBackendSDL2::GetMouseDelta(int32_t* x, int32_t* y) {
     *y = static_cast<int32_t>(deltaY);
 }
 
-void GfxWindowBackendSDL2::GetMouseWheel(float* x, float* y) {
+void GfxWindowBackendSDL::GetMouseWheel(float* x, float* y) {
     *x = mMouseWheelX;
     *y = mMouseWheelY;
     mMouseWheelX = 0.0f;
     mMouseWheelY = 0.0f;
 }
 
-bool GfxWindowBackendSDL2::GetMouseState(uint32_t btn) {
+bool GfxWindowBackendSDL::GetMouseState(uint32_t btn) {
     return SDL_GetMouseState(nullptr, nullptr) & (1 << btn);
 }
 
-void GfxWindowBackendSDL2::SetMouseCapture(bool capture) {
+void GfxWindowBackendSDL::SetMouseCapture(bool capture) {
     SDL_SetWindowRelativeMouseMode(mWnd, capture);
 }
 
-bool GfxWindowBackendSDL2::IsMouseCaptured() {
+bool GfxWindowBackendSDL::IsMouseCaptured() {
     return SDL_GetWindowRelativeMouseMode(mWnd);
 }
 
-void GfxWindowBackendSDL2::SetKeyboardCallbacks(bool (*onKeyDown)(int scancode), bool (*onKeyUp)(int scancode),
-                                                void (*onAllKeysUp)()) {
+void GfxWindowBackendSDL::SetKeyboardCallbacks(bool (*onKeyDown)(int scancode), bool (*onKeyUp)(int scancode),
+                                               void (*onAllKeysUp)()) {
     mOnKeyDown = onKeyDown;
     mOnKeyUp = onKeyUp;
     mOnAllKeysUp = onAllKeysUp;
 }
 
-void GfxWindowBackendSDL2::SetMouseCallbacks(bool (*onMouseButtonDown)(int btn), bool (*onMouseButtonUp)(int btn)) {
+void GfxWindowBackendSDL::SetMouseCallbacks(bool (*onMouseButtonDown)(int btn), bool (*onMouseButtonUp)(int btn)) {
     mOnMouseButtonDown = onMouseButtonDown;
     mOnMouseButtonUp = onMouseButtonUp;
 }
 
-void GfxWindowBackendSDL2::GetDimensions(uint32_t* width, uint32_t* height, int32_t* posX, int32_t* posY) {
+void GfxWindowBackendSDL::GetDimensions(uint32_t* width, uint32_t* height, int32_t* posX, int32_t* posY) {
 #ifdef __APPLE__
     SDL_GetWindowSize(mWnd, static_cast<int*>((void*)width), static_cast<int*>((void*)height));
 #else
@@ -550,7 +547,7 @@ void GfxWindowBackendSDL2::GetDimensions(uint32_t* width, uint32_t* height, int3
     SDL_GetWindowPosition(mWnd, static_cast<int*>(posX), static_cast<int*>(posY));
 }
 
-void GfxWindowBackendSDL2::SetDimensions(uint32_t width, uint32_t height, int32_t posX, int32_t posY) {
+void GfxWindowBackendSDL::SetDimensions(uint32_t width, uint32_t height, int32_t posX, int32_t posY) {
     mWindowWidth = width;
     mWindowHeight = height;
     if (mWnd) {
@@ -559,7 +556,7 @@ void GfxWindowBackendSDL2::SetDimensions(uint32_t width, uint32_t height, int32_
     }
 }
 
-Ship::WindowRect GfxWindowBackendSDL2::GetPrimaryMonitorRect() {
+Ship::WindowRect GfxWindowBackendSDL::GetPrimaryMonitorRect() {
     SDL_DisplayID display_in_use = mWnd ? SDL_GetDisplayForWindow(mWnd) : SDL_GetPrimaryDisplay();
     if (display_in_use == 0) {
         SPDLOG_WARN("Can't detect on which monitor we are. Probably out of display area? ({})", SDL_GetError());
@@ -573,14 +570,14 @@ Ship::WindowRect GfxWindowBackendSDL2::GetPrimaryMonitorRect() {
     return { 0, 0, 0, 0 };
 }
 
-int GfxWindowBackendSDL2::TranslateScancode(int scancode) const {
+int GfxWindowBackendSDL::TranslateScancode(int scancode) const {
     if (scancode < 512) {
         return mSdlToLusTable[scancode];
     }
     return 0;
 }
 
-int GfxWindowBackendSDL2::UntranslateScancode(int translatedScancode) const {
+int GfxWindowBackendSDL::UntranslateScancode(int translatedScancode) const {
     for (int i = 0; i < 512; i++) {
         if (mSdlToLusTable[i] == translatedScancode) {
             return i;
@@ -590,21 +587,21 @@ int GfxWindowBackendSDL2::UntranslateScancode(int translatedScancode) const {
     return 0;
 }
 
-void GfxWindowBackendSDL2::OnKeydown(int scancode) const {
+void GfxWindowBackendSDL::OnKeydown(int scancode) const {
     int key = TranslateScancode(scancode);
     if (mOnKeyDown != nullptr) {
         mOnKeyDown(key);
     }
 }
 
-void GfxWindowBackendSDL2::OnKeyup(int scancode) const {
+void GfxWindowBackendSDL::OnKeyup(int scancode) const {
     int key = TranslateScancode(scancode);
     if (mOnKeyUp != nullptr) {
         mOnKeyUp(key);
     }
 }
 
-void GfxWindowBackendSDL2::OnMouseButtonDown(int btn) const {
+void GfxWindowBackendSDL::OnMouseButtonDown(int btn) const {
     if (!(btn >= 0 && btn < 5)) {
         return;
     }
@@ -613,19 +610,19 @@ void GfxWindowBackendSDL2::OnMouseButtonDown(int btn) const {
     }
 }
 
-void GfxWindowBackendSDL2::OnMouseButtonUp(int btn) const {
+void GfxWindowBackendSDL::OnMouseButtonUp(int btn) const {
     if (mOnMouseButtonUp != nullptr) {
         mOnMouseButtonUp(btn);
     }
 }
 
-void GfxWindowBackendSDL2::HandleSingleEvent(SDL_Event& event) {
+void GfxWindowBackendSDL::HandleSingleEvent(SDL_Event& event) {
     Fast::WindowEvent event_impl;
     event_impl.Sdl = { &event };
     if (mFast3dGui) {
         mFast3dGui->HandleWindowEvents(event_impl);
     } else {
-        SPDLOG_ERROR("gfx_sdl2: Gui is not a Fast3dGui; cannot dispatch window event");
+        SPDLOG_ERROR("gfx_sdl: Gui is not a Fast3dGui; cannot dispatch window event");
     }
     switch (event.type) {
 #ifndef TARGET_WEB
@@ -670,13 +667,13 @@ void GfxWindowBackendSDL2::HandleSingleEvent(SDL_Event& event) {
     }
 }
 
-void GfxWindowBackendSDL2::HandleEvents() {
+void GfxWindowBackendSDL::HandleEvents() {
     SDL_Event event;
     SDL_PumpEvents();
     while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_FIRST, SDL_EVENT_GAMEPAD_ADDED - 1) > 0) {
         HandleSingleEvent(event);
     }
-    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_GAMEPAD_REMAPPED + 1, SDL_EVENT_LAST) > 0) {
+    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_GAMEPAD_REMOVED + 1, SDL_EVENT_LAST) > 0) {
         HandleSingleEvent(event);
     }
 
@@ -692,7 +689,7 @@ void GfxWindowBackendSDL2::HandleEvents() {
 #endif
 }
 
-bool GfxWindowBackendSDL2::IsFrameReady() {
+bool GfxWindowBackendSDL::IsFrameReady() {
     return true;
 }
 
@@ -701,7 +698,7 @@ static uint64_t qpc_to_100ns(uint64_t qpc) {
     return qpc / qpc_freq * _100NANOSECONDS_IN_SECOND + qpc % qpc_freq * _100NANOSECONDS_IN_SECOND / qpc_freq;
 }
 
-void GfxWindowBackendSDL2::SyncFramerateWithTime() const {
+void GfxWindowBackendSDL::SyncFramerateWithTime() const {
     uint64_t t = qpc_to_100ns(SDL_GetPerformanceCounter());
 
     const int64_t next = previous_time + 10 * FRAME_INTERVAL_US_NUMERATOR / FRAME_INTERVAL_US_DENOMINATOR;
@@ -744,7 +741,7 @@ void GfxWindowBackendSDL2::SyncFramerateWithTime() const {
     previous_time = t;
 }
 
-void GfxWindowBackendSDL2::SwapBuffersBegin() {
+void GfxWindowBackendSDL::SwapBuffersBegin() {
     bool nextVsyncEnabled = mConsoleVariable->GetInteger(CVAR_VSYNC_ENABLED, 1);
 
     if (mVsyncEnabled != nextVsyncEnabled) {
@@ -757,38 +754,38 @@ void GfxWindowBackendSDL2::SwapBuffersBegin() {
     SDL_GL_SwapWindow(mWnd);
 }
 
-void GfxWindowBackendSDL2::SwapBuffersEnd() {
+void GfxWindowBackendSDL::SwapBuffersEnd() {
 }
 
-double GfxWindowBackendSDL2::GetTime() {
+double GfxWindowBackendSDL::GetTime() {
     return 0.0;
 }
 
-int GfxWindowBackendSDL2::GetTargetFps() {
+int GfxWindowBackendSDL::GetTargetFps() {
     return mTargetFps;
 }
 
-void GfxWindowBackendSDL2::SetTargetFps(int fps) {
+void GfxWindowBackendSDL::SetTargetFps(int fps) {
     mTargetFps = fps;
 }
 
-void GfxWindowBackendSDL2::SetMaxFrameLatency(int latency) {
+void GfxWindowBackendSDL::SetMaxFrameLatency(int latency) {
     // Not supported by SDL :(
 }
 
-const char* GfxWindowBackendSDL2::GetKeyName(int scancode) {
+const char* GfxWindowBackendSDL::GetKeyName(int scancode) {
     return SDL_GetScancodeName((SDL_Scancode)UntranslateScancode(scancode));
 }
 
-bool GfxWindowBackendSDL2::CanDisableVsync() {
+bool GfxWindowBackendSDL::CanDisableVsync() {
     return true;
 }
 
-bool GfxWindowBackendSDL2::IsRunning() {
+bool GfxWindowBackendSDL::IsRunning() {
     return mIsRunning;
 }
 
-void GfxWindowBackendSDL2::Destroy() {
+void GfxWindowBackendSDL::Destroy() {
     if (mCtx != nullptr) {
         SDL_GL_DestroyContext(mCtx);
         mCtx = nullptr;
@@ -804,7 +801,7 @@ void GfxWindowBackendSDL2::Destroy() {
     SDL_Quit();
 }
 
-bool GfxWindowBackendSDL2::IsFullscreen() {
+bool GfxWindowBackendSDL::IsFullscreen() {
     return mFullScreen;
 }
 } // namespace Fast

--- a/src/fast/backends/gfx_sdl.cpp
+++ b/src/fast/backends/gfx_sdl.cpp
@@ -520,6 +520,18 @@ bool GfxWindowBackendSDL::GetMouseState(uint32_t btn) {
 
 void GfxWindowBackendSDL::SetMouseCapture(bool capture) {
     SDL_SetWindowRelativeMouseMode(mWnd, capture);
+    // Keep the cursor fixed while captured. Relative mode alone constrains it to
+    // the window, but does not preserve the centering behavior expected here.
+    const SDL_Rect* cursorClip = nullptr;
+    if (capture) {
+        int width = 0;
+        int height = 0;
+        if (SDL_GetWindowSize(mWnd, &width, &height)) {
+            mCursorClip = { (width / 2) - 1, (height / 2) - 1, 2, 2 };
+            cursorClip = &mCursorClip;
+        }
+    }
+    SDL_SetWindowMouseRect(mWnd, cursorClip);
 }
 
 bool GfxWindowBackendSDL::IsMouseCaptured() {

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -1,4 +1,4 @@
-#include <cmath>
+#include <math.h>
 #include <stdio.h>
 
 #if defined(ENABLE_OPENGL) || defined(__APPLE__)
@@ -293,7 +293,7 @@ void GfxWindowBackendSDL2::GetActiveWindowRefreshRate(uint32_t* refresh_rate) {
 
     const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(display_in_use);
     *refresh_rate =
-        mode != nullptr && mode->refresh_rate > 0.0f ? static_cast<uint32_t>(std::round(mode->refresh_rate)) : 60;
+        mode != nullptr && mode->refresh_rate > 0.0f ? static_cast<uint32_t>(roundf(mode->refresh_rate)) : 60;
 }
 
 static uint64_t previous_time;

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <stdio.h>
 
 #if defined(ENABLE_OPENGL) || defined(__APPLE__)
@@ -291,7 +292,8 @@ void GfxWindowBackendSDL2::GetActiveWindowRefreshRate(uint32_t* refresh_rate) {
     SDL_DisplayID display_in_use = SDL_GetDisplayForWindow(mWnd);
 
     const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(display_in_use);
-    *refresh_rate = mode != nullptr && mode->refresh_rate > 0.0f ? static_cast<uint32_t>(mode->refresh_rate) : 60;
+    *refresh_rate =
+        mode != nullptr && mode->refresh_rate > 0.0f ? static_cast<uint32_t>(std::round(mode->refresh_rate)) : 60;
 }
 
 static uint64_t previous_time;

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -676,7 +676,7 @@ void GfxWindowBackendSDL2::HandleEvents() {
     while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_FIRST, SDL_EVENT_GAMEPAD_ADDED - 1) > 0) {
         HandleSingleEvent(event);
     }
-    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_GAMEPAD_REMOVED + 1, SDL_EVENT_LAST) > 0) {
+    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_GAMEPAD_REMAPPED + 1, SDL_EVENT_LAST) > 0) {
         HandleSingleEvent(event);
     }
 

--- a/src/fast/backends/gfx_sdl2.cpp
+++ b/src/fast/backends/gfx_sdl2.cpp
@@ -20,17 +20,17 @@
 
 #if FOR_WINDOWS
 #include <GL/glew.h>
-#include "SDL.h"
+#include <SDL3/SDL.h>
 #define GL_GLEXT_PROTOTYPES 1
-#include "SDL_opengl.h"
+#include <SDL3/SDL_opengl.h>
 #elif __APPLE__
-#include <SDL.h>
+#include <SDL3/SDL.h>
 #include "fast/backends/gfx_metal.h"
 #include "ship/utils/macUtils.h"
 #else
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #define GL_GLEXT_PROTOTYPES 1
-#include <SDL2/SDL_opengles2.h>
+#include <SDL3/SDL_opengles2.h>
 #endif
 
 #include "ship/window/gui/Gui.h"
@@ -39,7 +39,6 @@
 #ifdef _WIN32
 #include <WTypesbase.h>
 #include <Windows.h>
-#include <SDL_syswm.h>
 #endif
 
 #define GFX_BACKEND_NAME "SDL"
@@ -224,19 +223,34 @@ void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
         return;
     }
 
-    int display_in_use = SDL_GetWindowDisplayIndex(mWnd);
-    if (display_in_use < 0) {
+    SDL_DisplayID display_in_use = SDL_GetDisplayForWindow(mWnd);
+    if (display_in_use == 0) {
         SPDLOG_WARN("Can't detect on which monitor we are. Probably out of display area?");
         SPDLOG_WARN(SDL_GetError());
     }
 
     if (on) {
         // OTRTODO: Get mode from config.
-        SDL_DisplayMode mode;
-        if (SDL_GetDesktopDisplayMode(display_in_use, &mode) >= 0) {
-            SDL_SetWindowDisplayMode(mWnd, &mode);
-        } else {
+        const bool windowedFullscreen = mConsoleVariable->GetInteger(CVAR_SDL_WINDOWED_FULLSCREEN, 0) != 0;
+        SDL_DisplayMode fullscreenMode{};
+        const SDL_DisplayMode* mode = nullptr;
+
+        if (!windowedFullscreen) {
+            const SDL_DisplayMode* desktopMode = SDL_GetDesktopDisplayMode(display_in_use);
+            if (desktopMode == nullptr ||
+                !SDL_GetClosestFullscreenDisplayMode(display_in_use, desktopMode->w, desktopMode->h,
+                                                     desktopMode->refresh_rate, true, &fullscreenMode)) {
+                SPDLOG_ERROR("Failed to find an exclusive fullscreen mode.");
+                SPDLOG_ERROR(SDL_GetError());
+                return;
+            }
+            mode = &fullscreenMode;
+        }
+
+        if (!SDL_SetWindowFullscreenMode(mWnd, mode)) {
+            SPDLOG_ERROR("Failed to set the fullscreen display mode.");
             SPDLOG_ERROR(SDL_GetError());
+            return;
         }
     }
 
@@ -247,10 +261,7 @@ void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
     }
     mFullScreen = on;
 #else
-    if (SDL_SetWindowFullscreen(mWnd, on ? (mConsoleVariable->GetInteger(CVAR_SDL_WINDOWED_FULLSCREEN, 0)
-                                                ? SDL_WINDOW_FULLSCREEN_DESKTOP
-                                                : SDL_WINDOW_FULLSCREEN)
-                                         : 0) >= 0) {
+    if (SDL_SetWindowFullscreen(mWnd, on)) {
         mFullScreen = on;
     } else {
         SPDLOG_ERROR("Failed to switch from or to fullscreen mode.");
@@ -263,7 +274,7 @@ void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
         mWindowHeight = mConfig->GetInt("Window.Height", 480);
         int32_t posX = mConfig->GetInt("Window.PositionX", 100);
         int32_t posY = mConfig->GetInt("Window.PositionY", 100);
-        if (display_in_use < 0) { // Fallback to default if out of bounds
+        if (display_in_use == 0) { // Fallback to default if out of bounds
             posX = 100;
             posY = 100;
         }
@@ -277,11 +288,10 @@ void GfxWindowBackendSDL2::SetFullscreenImpl(bool on, bool call_callback) {
 }
 
 void GfxWindowBackendSDL2::GetActiveWindowRefreshRate(uint32_t* refresh_rate) {
-    int display_in_use = SDL_GetWindowDisplayIndex(mWnd);
+    SDL_DisplayID display_in_use = SDL_GetDisplayForWindow(mWnd);
 
-    SDL_DisplayMode mode;
-    SDL_GetCurrentDisplayMode(display_in_use, &mode);
-    *refresh_rate = mode.refresh_rate != 0 ? mode.refresh_rate : 60;
+    const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(display_in_use);
+    *refresh_rate = mode != nullptr && mode->refresh_rate > 0.0f ? static_cast<uint32_t>(mode->refresh_rate) : 60;
 }
 
 static uint64_t previous_time;
@@ -325,14 +335,12 @@ void GfxWindowBackendSDL2::Init(const char* gameName, const char* gfxApiName, bo
     mWindowWidth = width;
     mWindowHeight = height;
 
-#if SDL_VERSION_ATLEAST(2, 24, 0)
-    /* fix DPI scaling issues on Windows */
-    SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
-#endif
+    if (!SDL_InitSubSystem(SDL_INIT_VIDEO)) {
+        SPDLOG_ERROR("SDL video initialization failed: {}", SDL_GetError());
+        return;
+    }
 
-    SDL_Init(SDL_INIT_VIDEO);
-
-    SDL_EventState(SDL_DROPFILE, SDL_ENABLE);
+    SDL_SetEventEnabled(SDL_EVENT_DROP_FILE, true);
 
 #if defined(__APPLE__)
     bool use_opengl = strcmp(gfxApiName, "OpenGL") == 0;
@@ -377,9 +385,9 @@ void GfxWindowBackendSDL2::Init(const char* gameName, const char* gfxApiName, bo
     int len = snprintf(title, sizeof(title), "%s (%s)", gameName, gfxApiName);
 
 #ifdef __IOS__
-    Uint32 flags = SDL_WINDOW_BORDERLESS | SDL_WINDOW_SHOWN;
+    Uint32 flags = SDL_WINDOW_BORDERLESS;
 #else
-    Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
+    Uint32 flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY;
 #endif
 
     if (use_opengl) {
@@ -388,27 +396,37 @@ void GfxWindowBackendSDL2::Init(const char* gameName, const char* gfxApiName, bo
         flags = flags | SDL_WINDOW_METAL;
     }
 
-    mWnd = SDL_CreateWindow(title, posX, posY, mWindowWidth, mWindowHeight, flags);
+    SDL_PropertiesID windowProperties = SDL_CreateProperties();
+    SDL_SetStringProperty(windowProperties, SDL_PROP_WINDOW_CREATE_TITLE_STRING, title);
+    SDL_SetNumberProperty(windowProperties, SDL_PROP_WINDOW_CREATE_X_NUMBER, posX);
+    SDL_SetNumberProperty(windowProperties, SDL_PROP_WINDOW_CREATE_Y_NUMBER, posY);
+    SDL_SetNumberProperty(windowProperties, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, mWindowWidth);
+    SDL_SetNumberProperty(windowProperties, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, mWindowHeight);
+    SDL_SetNumberProperty(windowProperties, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER, flags);
+    mWnd = SDL_CreateWindowWithProperties(windowProperties);
+    SDL_DestroyProperties(windowProperties);
+    if (mWnd == nullptr) {
+        SPDLOG_ERROR("Error creating SDL window: {}", SDL_GetError());
+        return;
+    }
 #ifdef _WIN32
     // Get Windows window handle and use it to subclass the window procedure.
     // Needed to circumvent SDLs DPI scaling problems under windows (original does only scale *sometimes*).
-    SDL_SysWMinfo wmInfo;
-    SDL_VERSION(&wmInfo.version);
-    SDL_GetWindowWMInfo(mWnd, &wmInfo);
-    HWND hwnd = wmInfo.info.win.window;
+    HWND hwnd = static_cast<HWND>(
+        SDL_GetPointerProperty(SDL_GetWindowProperties(mWnd), SDL_PROP_WINDOW_WIN32_HWND_POINTER, nullptr));
     SDL_WndProc = SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)gfx_sdl_wnd_proc);
     SetWindowLongPtr(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(this));
 #endif
     Fast::GuiWindowInitData window_impl;
 
-    int display_in_use = SDL_GetWindowDisplayIndex(mWnd);
-    if (display_in_use < 0) { // Fallback to default if out of bounds
+    SDL_DisplayID display_in_use = SDL_GetDisplayForWindow(mWnd);
+    if (display_in_use == 0) { // Fallback to default if out of bounds
         posX = 100;
         posY = 100;
     }
 
     if (use_opengl) {
-        SDL_GL_GetDrawableSize(mWnd, &mWindowWidth, &mWindowHeight);
+        SDL_GetWindowSizeInPixels(mWnd, &mWindowWidth, &mWindowHeight);
 
         if (startFullScreen) {
             SetFullscreenImpl(true, false);
@@ -421,21 +439,18 @@ void GfxWindowBackendSDL2::Init(const char* gameName, const char* gfxApiName, bo
 
         window_impl.Opengl = { mWnd, mCtx };
     } else {
-        uint32_t flags = SDL_RENDERER_ACCELERATED;
-        if (mVsyncEnabled) {
-            flags |= SDL_RENDERER_PRESENTVSYNC;
-        }
-        mRenderer = SDL_CreateRenderer(mWnd, -1, flags);
+        mRenderer = SDL_CreateRenderer(mWnd, nullptr);
         if (mRenderer == nullptr) {
             SPDLOG_ERROR("Error creating renderer: {}", SDL_GetError());
             return;
         }
+        SDL_SetRenderVSync(mRenderer, mVsyncEnabled ? 1 : 0);
 
         if (startFullScreen) {
             SetFullscreenImpl(true, false);
         }
 
-        SDL_GetRendererOutputSize(mRenderer, &mWindowWidth, &mWindowHeight);
+        SDL_GetCurrentRenderOutputSize(mRenderer, &mWindowWidth, &mWindowHeight);
         window_impl.Metal = { mWnd, mRenderer };
     }
 
@@ -467,22 +482,30 @@ void GfxWindowBackendSDL2::SetFullscreen(bool enable) {
 
 void GfxWindowBackendSDL2::SetCursorVisibility(bool visible) {
     if (visible) {
-        SDL_ShowCursor(SDL_ENABLE);
+        SDL_ShowCursor();
     } else {
-        SDL_ShowCursor(SDL_DISABLE);
+        SDL_HideCursor();
     }
 }
 
 void GfxWindowBackendSDL2::SetMousePos(int32_t x, int32_t y) {
-    SDL_WarpMouseInWindow(mWnd, x, y);
+    SDL_WarpMouseInWindow(mWnd, static_cast<float>(x), static_cast<float>(y));
 }
 
 void GfxWindowBackendSDL2::GetMousePos(int32_t* x, int32_t* y) {
-    SDL_GetMouseState(x, y);
+    float mouseX = 0.0f;
+    float mouseY = 0.0f;
+    SDL_GetMouseState(&mouseX, &mouseY);
+    *x = static_cast<int32_t>(mouseX);
+    *y = static_cast<int32_t>(mouseY);
 }
 
 void GfxWindowBackendSDL2::GetMouseDelta(int32_t* x, int32_t* y) {
-    SDL_GetRelativeMouseState(x, y);
+    float deltaX = 0.0f;
+    float deltaY = 0.0f;
+    SDL_GetRelativeMouseState(&deltaX, &deltaY);
+    *x = static_cast<int32_t>(deltaX);
+    *y = static_cast<int32_t>(deltaY);
 }
 
 void GfxWindowBackendSDL2::GetMouseWheel(float* x, float* y) {
@@ -497,21 +520,11 @@ bool GfxWindowBackendSDL2::GetMouseState(uint32_t btn) {
 }
 
 void GfxWindowBackendSDL2::SetMouseCapture(bool capture) {
-    SDL_SetRelativeMouseMode(static_cast<SDL_bool>(capture));
-    // TODO: Manually setting a clipping rect here because
-    // https://wiki.libsdl.org/SDL2/SDL_HINT_MOUSE_RELATIVE_MODE_CENTER isn't working as epxected.
-    // Revisit on SDL3
-    auto mouse = SDL_GetWindowMouseRect(mWnd);
-    if (capture) {
-        int w, h;
-        SDL_GetWindowSize(mWnd, &w, &h);
-        mCursorClip = { (w / 2) - 1, (h / 2) - 1, 2, 2 };
-    }
-    SDL_SetWindowMouseRect(mWnd, capture ? &mCursorClip : NULL);
+    SDL_SetWindowRelativeMouseMode(mWnd, capture);
 }
 
 bool GfxWindowBackendSDL2::IsMouseCaptured() {
-    return (SDL_GetRelativeMouseMode() == SDL_TRUE);
+    return SDL_GetWindowRelativeMouseMode(mWnd);
 }
 
 void GfxWindowBackendSDL2::SetKeyboardCallbacks(bool (*onKeyDown)(int scancode), bool (*onKeyUp)(int scancode),
@@ -530,7 +543,7 @@ void GfxWindowBackendSDL2::GetDimensions(uint32_t* width, uint32_t* height, int3
 #ifdef __APPLE__
     SDL_GetWindowSize(mWnd, static_cast<int*>((void*)width), static_cast<int*>((void*)height));
 #else
-    SDL_GL_GetDrawableSize(mWnd, static_cast<int*>((void*)width), static_cast<int*>((void*)height));
+    SDL_GetWindowSizeInPixels(mWnd, static_cast<int*>((void*)width), static_cast<int*>((void*)height));
 #endif
     SDL_GetWindowPosition(mWnd, static_cast<int*>(posX), static_cast<int*>(posY));
 }
@@ -545,14 +558,14 @@ void GfxWindowBackendSDL2::SetDimensions(uint32_t width, uint32_t height, int32_
 }
 
 Ship::WindowRect GfxWindowBackendSDL2::GetPrimaryMonitorRect() {
-    SDL_DisplayMode mode;
-    int display_in_use = mWnd ? SDL_GetWindowDisplayIndex(mWnd) : 0;
-    if (display_in_use < 0) {
+    SDL_DisplayID display_in_use = mWnd ? SDL_GetDisplayForWindow(mWnd) : SDL_GetPrimaryDisplay();
+    if (display_in_use == 0) {
         SPDLOG_WARN("Can't detect on which monitor we are. Probably out of display area? ({})", SDL_GetError());
-        display_in_use = 0;
+        display_in_use = SDL_GetPrimaryDisplay();
     }
-    if (SDL_GetDesktopDisplayMode(display_in_use, &mode) >= 0) {
-        return { 0, 0, mode.w, mode.h };
+    const SDL_DisplayMode* mode = SDL_GetDesktopDisplayMode(display_in_use);
+    if (mode != nullptr) {
+        return { 0, 0, mode->w, mode->h };
     }
     SPDLOG_ERROR("Failed to get SDL Desktop Display Mode: ({})", SDL_GetError());
     return { 0, 0, 0, 0 };
@@ -615,45 +628,41 @@ void GfxWindowBackendSDL2::HandleSingleEvent(SDL_Event& event) {
     switch (event.type) {
 #ifndef TARGET_WEB
         // Scancodes are broken in Emscripten SDL2: https://bugzilla.libsdl.org/show_bug.cgi?id=3259
-        case SDL_KEYDOWN:
-            OnKeydown(event.key.keysym.scancode);
+        case SDL_EVENT_KEY_DOWN:
+            OnKeydown(event.key.scancode);
             break;
-        case SDL_KEYUP:
-            OnKeyup(event.key.keysym.scancode);
+        case SDL_EVENT_KEY_UP:
+            OnKeyup(event.key.scancode);
             break;
-        case SDL_MOUSEBUTTONDOWN:
+        case SDL_EVENT_MOUSE_BUTTON_DOWN:
             OnMouseButtonDown(event.button.button - 1);
             break;
-        case SDL_MOUSEBUTTONUP:
+        case SDL_EVENT_MOUSE_BUTTON_UP:
             OnMouseButtonUp(event.button.button - 1);
             break;
-        case SDL_MOUSEWHEEL:
+        case SDL_EVENT_MOUSE_WHEEL:
             mMouseWheelX = event.wheel.x;
             mMouseWheelY = event.wheel.y;
             break;
 #endif
-        case SDL_WINDOWEVENT:
-            switch (event.window.event) {
-                case SDL_WINDOWEVENT_SIZE_CHANGED:
+        case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
 #ifdef __APPLE__
-                    SDL_GetWindowSize(mWnd, &mWindowWidth, &mWindowHeight);
+            SDL_GetWindowSize(mWnd, &mWindowWidth, &mWindowHeight);
 #else
-                    SDL_GL_GetDrawableSize(mWnd, &mWindowWidth, &mWindowHeight);
+            SDL_GetWindowSizeInPixels(mWnd, &mWindowWidth, &mWindowHeight);
 #endif
-                    break;
-                case SDL_WINDOWEVENT_CLOSE:
-                    if (event.window.windowID == SDL_GetWindowID(mWnd)) {
-                        // We listen specifically for main window close because closing main window
-                        // on macOS does not trigger SDL_Quit.
-                        Close();
-                    }
-                    break;
+            break;
+        case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+            if (event.window.windowID == SDL_GetWindowID(mWnd)) {
+                // We listen specifically for main window close because closing main window
+                // on macOS does not trigger SDL_Quit.
+                Close();
             }
             break;
-        case SDL_DROPFILE:
-            mFileDrop->SetDroppedFile(event.drop.file);
+        case SDL_EVENT_DROP_FILE:
+            mFileDrop->SetDroppedFile(event.drop.data);
             break;
-        case SDL_QUIT:
+        case SDL_EVENT_QUIT:
             Close();
             break;
     }
@@ -662,10 +671,10 @@ void GfxWindowBackendSDL2::HandleSingleEvent(SDL_Event& event) {
 void GfxWindowBackendSDL2::HandleEvents() {
     SDL_Event event;
     SDL_PumpEvents();
-    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_CONTROLLERDEVICEADDED - 1) > 0) {
+    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_FIRST, SDL_EVENT_GAMEPAD_ADDED - 1) > 0) {
         HandleSingleEvent(event);
     }
-    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_CONTROLLERDEVICEREMOVED + 1, SDL_LASTEVENT) > 0) {
+    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_GAMEPAD_REMOVED + 1, SDL_EVENT_LAST) > 0) {
         HandleSingleEvent(event);
     }
 
@@ -739,7 +748,7 @@ void GfxWindowBackendSDL2::SwapBuffersBegin() {
     if (mVsyncEnabled != nextVsyncEnabled) {
         mVsyncEnabled = nextVsyncEnabled;
         SDL_GL_SetSwapInterval(mVsyncEnabled ? 1 : 0);
-        SDL_RenderSetVSync(mRenderer, mVsyncEnabled ? 1 : 0);
+        SDL_SetRenderVSync(mRenderer, mVsyncEnabled ? 1 : 0);
     }
 
     SyncFramerateWithTime();
@@ -778,10 +787,18 @@ bool GfxWindowBackendSDL2::IsRunning() {
 }
 
 void GfxWindowBackendSDL2::Destroy() {
-    // TODO: destroy _any_ resources used by SDL
-    SDL_GL_DeleteContext(mCtx);
-    SDL_DestroyWindow(mWnd);
-    SDL_DestroyRenderer(mRenderer);
+    if (mCtx != nullptr) {
+        SDL_GL_DestroyContext(mCtx);
+        mCtx = nullptr;
+    }
+    if (mRenderer != nullptr) {
+        SDL_DestroyRenderer(mRenderer);
+        mRenderer = nullptr;
+    }
+    if (mWnd != nullptr) {
+        SDL_DestroyWindow(mWnd);
+        mWnd = nullptr;
+    }
     SDL_Quit();
 }
 

--- a/src/libultraship/controller/controldevice/controller/Controller.cpp
+++ b/src/libultraship/controller/controldevice/controller/Controller.cpp
@@ -4,9 +4,9 @@
 #include "ship/core/Context.h"
 #include "ship/config/ConsoleVariable.h"
 #if __APPLE__
-#include <SDL_events.h>
+#include <SDL3/SDL_events.h>
 #else
-#include <SDL2/SDL_events.h>
+#include <SDL3/SDL_events.h>
 #endif
 #include <spdlog/spdlog.h>
 #include "ship/utils/StringHelper.h"

--- a/src/libultraship/controller/controldevice/controller/mapping/ControllerDefaultMappings.cpp
+++ b/src/libultraship/controller/controldevice/controller/mapping/ControllerDefaultMappings.cpp
@@ -6,14 +6,12 @@ ControllerDefaultMappings::ControllerDefaultMappings(
     std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<Ship::KbScancode>> defaultKeyboardKeyToButtonMappings,
     std::unordered_map<Ship::StickIndex, std::vector<std::pair<Ship::Direction, Ship::KbScancode>>>
         defaultKeyboardKeyToAxisDirectionMappings,
-    std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>
-        defaultSDLButtonToButtonMappings,
-    std::unordered_map<Ship::StickIndex, std::vector<std::pair<Ship::Direction, SDL_GameControllerButton>>>
+    std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>> defaultSDLButtonToButtonMappings,
+    std::unordered_map<Ship::StickIndex, std::vector<std::pair<Ship::Direction, SDL_GamepadButton>>>
         defaultSDLButtonToAxisDirectionMappings,
-    std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>
+    std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>
         defaultSDLAxisDirectionToButtonMappings,
-    std::unordered_map<Ship::StickIndex,
-                       std::vector<std::pair<Ship::Direction, std::pair<SDL_GameControllerAxis, int32_t>>>>
+    std::unordered_map<Ship::StickIndex, std::vector<std::pair<Ship::Direction, std::pair<SDL_GamepadAxis, int32_t>>>>
         defaultSDLAxisDirectionToAxisDirectionMappings)
     : Ship::ControllerDefaultMappings(defaultKeyboardKeyToButtonMappings, defaultKeyboardKeyToAxisDirectionMappings,
                                       defaultSDLButtonToButtonMappings, defaultSDLButtonToAxisDirectionMappings,
@@ -28,11 +26,11 @@ ControllerDefaultMappings::ControllerDefaultMappings()
     : ControllerDefaultMappings(
           std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<Ship::KbScancode>>(),
           std::unordered_map<Ship::StickIndex, std::vector<std::pair<Ship::Direction, Ship::KbScancode>>>(),
-          std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>(),
-          std::unordered_map<Ship::StickIndex, std::vector<std::pair<Ship::Direction, SDL_GameControllerButton>>>(),
-          std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>(),
+          std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>>(),
+          std::unordered_map<Ship::StickIndex, std::vector<std::pair<Ship::Direction, SDL_GamepadButton>>>(),
+          std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>(),
           std::unordered_map<Ship::StickIndex,
-                             std::vector<std::pair<Ship::Direction, std::pair<SDL_GameControllerAxis, int32_t>>>>()) {
+                             std::vector<std::pair<Ship::Direction, std::pair<SDL_GamepadAxis, int32_t>>>>()) {
 }
 
 ControllerDefaultMappings::~ControllerDefaultMappings() {
@@ -64,27 +62,26 @@ void ControllerDefaultMappings::SetDefaultKeyboardKeyToButtonMappings(
 }
 
 void ControllerDefaultMappings::SetDefaultSDLButtonToButtonMappings(
-    std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>
-        defaultSDLButtonToButtonMappings) {
+    std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>> defaultSDLButtonToButtonMappings) {
     if (!defaultSDLButtonToButtonMappings.empty()) {
         Ship::ControllerDefaultMappings::SetDefaultSDLButtonToButtonMappings(defaultSDLButtonToButtonMappings);
         return;
     }
 
     Ship::ControllerDefaultMappings::SetDefaultSDLButtonToButtonMappings({
-        { BTN_A, { SDL_CONTROLLER_BUTTON_A } },
-        { BTN_B, { SDL_CONTROLLER_BUTTON_B } },
-        { BTN_L, { SDL_CONTROLLER_BUTTON_LEFTSHOULDER } },
-        { BTN_START, { SDL_CONTROLLER_BUTTON_START } },
-        { BTN_DUP, { SDL_CONTROLLER_BUTTON_DPAD_UP } },
-        { BTN_DDOWN, { SDL_CONTROLLER_BUTTON_DPAD_DOWN } },
-        { BTN_DLEFT, { SDL_CONTROLLER_BUTTON_DPAD_LEFT } },
-        { BTN_DRIGHT, { SDL_CONTROLLER_BUTTON_DPAD_RIGHT } },
+        { BTN_A, { SDL_GAMEPAD_BUTTON_SOUTH } },
+        { BTN_B, { SDL_GAMEPAD_BUTTON_EAST } },
+        { BTN_L, { SDL_GAMEPAD_BUTTON_LEFT_SHOULDER } },
+        { BTN_START, { SDL_GAMEPAD_BUTTON_START } },
+        { BTN_DUP, { SDL_GAMEPAD_BUTTON_DPAD_UP } },
+        { BTN_DDOWN, { SDL_GAMEPAD_BUTTON_DPAD_DOWN } },
+        { BTN_DLEFT, { SDL_GAMEPAD_BUTTON_DPAD_LEFT } },
+        { BTN_DRIGHT, { SDL_GAMEPAD_BUTTON_DPAD_RIGHT } },
     });
 }
 
 void ControllerDefaultMappings::SetDefaultSDLAxisDirectionToButtonMappings(
-    std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>
+    std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>
         defaultSDLAxisDirectionToButtonMappings) {
     if (!defaultSDLAxisDirectionToButtonMappings.empty()) {
         Ship::ControllerDefaultMappings::SetDefaultSDLAxisDirectionToButtonMappings(
@@ -93,12 +90,12 @@ void ControllerDefaultMappings::SetDefaultSDLAxisDirectionToButtonMappings(
     }
 
     Ship::ControllerDefaultMappings::SetDefaultSDLAxisDirectionToButtonMappings({
-        { BTN_R, { { SDL_CONTROLLER_AXIS_TRIGGERRIGHT, 1 } } },
-        { BTN_Z, { { SDL_CONTROLLER_AXIS_TRIGGERLEFT, 1 } } },
-        { BTN_CUP, { { SDL_CONTROLLER_AXIS_RIGHTY, -1 } } },
-        { BTN_CDOWN, { { SDL_CONTROLLER_AXIS_RIGHTY, 1 } } },
-        { BTN_CLEFT, { { SDL_CONTROLLER_AXIS_RIGHTX, -1 } } },
-        { BTN_CRIGHT, { { SDL_CONTROLLER_AXIS_RIGHTX, 1 } } },
+        { BTN_R, { { SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, 1 } } },
+        { BTN_Z, { { SDL_GAMEPAD_AXIS_LEFT_TRIGGER, 1 } } },
+        { BTN_CUP, { { SDL_GAMEPAD_AXIS_RIGHTY, -1 } } },
+        { BTN_CDOWN, { { SDL_GAMEPAD_AXIS_RIGHTY, 1 } } },
+        { BTN_CLEFT, { { SDL_GAMEPAD_AXIS_RIGHTX, -1 } } },
+        { BTN_CRIGHT, { { SDL_GAMEPAD_AXIS_RIGHTX, 1 } } },
     });
 }
 } // namespace LUS

--- a/src/libultraship/libultra/os.cpp
+++ b/src/libultraship/libultra/os.cpp
@@ -1,5 +1,5 @@
 #include "libultraship/libultraship.h"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include <ratio>
 
 // Establish a chrono duration for the N64 46.875MHz clock rate
@@ -19,7 +19,7 @@ int32_t osContInit(OSMesgQueue* mq, uint8_t* controllerBits, OSContStatus* statu
     status->status |= 1;
 
     std::string controllerDb = Ship::Context::LocateFileAcrossAppDirs("gamecontrollerdb.txt");
-    int mappingsAdded = SDL_GameControllerAddMappingsFromFile(controllerDb.c_str());
+    int mappingsAdded = SDL_AddGamepadMappingsFromFile(controllerDb.c_str());
     if (mappingsAdded >= 0) {
         SPDLOG_INFO("Added SDL game controllers from \"{}\" ({})", controllerDb, mappingsAdded);
     } else {
@@ -27,7 +27,7 @@ int32_t osContInit(OSMesgQueue* mq, uint8_t* controllerBits, OSContStatus* statu
     }
 
     SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
-    if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {
+    if (!SDL_InitSubSystem(SDL_INIT_GAMEPAD)) {
         SPDLOG_ERROR("Failed to initialize SDL game controllers ({})", SDL_GetError());
         exit(EXIT_FAILURE);
     }

--- a/src/libultraship/libultra/os_vi.cpp
+++ b/src/libultraship/libultra/os_vi.cpp
@@ -2,7 +2,7 @@
 
 extern "C" {
 
-Uint32 __lusViCallback(Uint32 interval, void* param) {
+Uint32 __lusViCallback(void* userdata, SDL_TimerID timerId, Uint32 interval) {
     __OSEventState* es = &__osEventStateTab[OS_EVENT_VI];
 
     if (es && es->queue) {

--- a/src/ship/audio/SDLAudioPlayer.cpp
+++ b/src/ship/audio/SDLAudioPlayer.cpp
@@ -41,6 +41,8 @@ bool SDLAudioPlayer::DoInit() {
 }
 
 int SDLAudioPlayer::Buffered() {
+    // SDL_GetAudioStreamQueued is the SDL3 replacement for the producer-side queue size used by SDL2.
+    // SDL_GetAudioStreamAvailable reports converted data for callers that read from the stream instead.
     return mStream == nullptr ? 0 : SDL_GetAudioStreamQueued(mStream) / (sizeof(int16_t) * mNumChannels);
 }
 

--- a/src/ship/audio/SDLAudioPlayer.cpp
+++ b/src/ship/audio/SDLAudioPlayer.cpp
@@ -10,18 +10,16 @@ SDLAudioPlayer::~SDLAudioPlayer() {
 }
 
 void SDLAudioPlayer::DoClose() {
-    if (mDevice != 0) {
-        // Pause playback first
-        SDL_PauseAudioDevice(mDevice, 1);
-        // Clear any queued audio to prevent glitches when reopening
-        SDL_ClearQueuedAudio(mDevice);
-        SDL_CloseAudioDevice(mDevice);
-        mDevice = 0;
+    if (mStream != nullptr) {
+        SDL_PauseAudioDevice(SDL_GetAudioStreamDevice(mStream));
+        SDL_ClearAudioStream(mStream);
+        SDL_DestroyAudioStream(mStream);
+        mStream = nullptr;
     }
 }
 
 bool SDLAudioPlayer::DoInit() {
-    if (SDL_Init(SDL_INIT_AUDIO) != 0) {
+    if (!SDL_InitSubSystem(SDL_INIT_AUDIO)) {
         SPDLOG_ERROR("SDL init error: {}", SDL_GetError());
         return false;
     }
@@ -29,34 +27,27 @@ bool SDLAudioPlayer::DoInit() {
     // Always open with the correct number of output channels
     mNumChannels = this->GetNumOutputChannels();
 
-    SDL_AudioSpec want, have;
-    SDL_zero(want);
-    want.freq = this->GetSampleRate();
-    want.format = AUDIO_S16SYS;
-    want.channels = mNumChannels;
-    want.samples = this->GetSampleLength();
-    want.callback = NULL;
-
-    mDevice = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
-    if (mDevice == 0) {
-        SPDLOG_ERROR("SDL_OpenAudio error: {}", SDL_GetError());
+    const SDL_AudioSpec spec = { SDL_AUDIO_S16, mNumChannels, this->GetSampleRate() };
+    mStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, nullptr, nullptr);
+    if (mStream == nullptr) {
+        SPDLOG_ERROR("SDL_OpenAudioDeviceStream error: {}", SDL_GetError());
         return false;
     }
 
     SPDLOG_INFO("SDL Audio initialized: {} channels, {} Hz", mNumChannels, this->GetSampleRate());
 
-    SDL_PauseAudioDevice(mDevice, 0);
+    SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(mStream));
     return true;
 }
 
 int SDLAudioPlayer::Buffered() {
-    return SDL_GetQueuedAudioSize(mDevice) / (sizeof(int16_t) * mNumChannels);
+    return mStream == nullptr ? 0 : SDL_GetAudioStreamQueued(mStream) / (sizeof(int16_t) * mNumChannels);
 }
 
 void SDLAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
     if (Buffered() < 6000) {
         // Don't fill the audio buffer too much in case this happens
-        SDL_QueueAudio(mDevice, buf, len);
+        SDL_PutAudioStreamData(mStream, buf, static_cast<int>(len));
     }
 }
 } // namespace Ship

--- a/src/ship/controller/controldevice/controller/Controller.cpp
+++ b/src/ship/controller/controldevice/controller/Controller.cpp
@@ -4,11 +4,7 @@
 #include <algorithm>
 #include "ship/config/ConsoleVariable.h"
 #include "ship/window/Window.h"
-#if __APPLE__
 #include <SDL3/SDL_events.h>
-#else
-#include <SDL3/SDL_events.h>
-#endif
 #include <spdlog/spdlog.h>
 #include "ship/utils/StringHelper.h"
 

--- a/src/ship/controller/controldevice/controller/Controller.cpp
+++ b/src/ship/controller/controldevice/controller/Controller.cpp
@@ -5,9 +5,9 @@
 #include "ship/config/ConsoleVariable.h"
 #include "ship/window/Window.h"
 #if __APPLE__
-#include <SDL_events.h>
+#include <SDL3/SDL_events.h>
 #else
-#include <SDL2/SDL_events.h>
+#include <SDL3/SDL_events.h>
 #endif
 #include <spdlog/spdlog.h>
 #include "ship/utils/StringHelper.h"

--- a/src/ship/controller/controldevice/controller/mapping/ControllerDefaultMappings.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/ControllerDefaultMappings.cpp
@@ -5,13 +5,12 @@ ControllerDefaultMappings::ControllerDefaultMappings(
     std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<KbScancode>> defaultKeyboardKeyToButtonMappings,
     std::unordered_map<StickIndex, std::vector<std::pair<Direction, KbScancode>>>
         defaultKeyboardKeyToAxisDirectionMappings,
-    std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>
-        defaultSDLButtonToButtonMappings,
-    std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GameControllerButton>>>
+    std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>> defaultSDLButtonToButtonMappings,
+    std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GamepadButton>>>
         defaultSDLButtonToAxisDirectionMappings,
-    std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>
+    std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>
         defaultSDLAxisDirectionToButtonMappings,
-    std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GameControllerAxis, int32_t>>>>
+    std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GamepadAxis, int32_t>>>>
         defaultSDLAxisDirectionToAxisDirectionMappings) {
     SetDefaultKeyboardKeyToButtonMappings(defaultKeyboardKeyToButtonMappings);
     SetDefaultKeyboardKeyToAxisDirectionMappings(defaultKeyboardKeyToAxisDirectionMappings);
@@ -27,11 +26,10 @@ ControllerDefaultMappings::ControllerDefaultMappings()
     : ControllerDefaultMappings(
           std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<KbScancode>>(),
           std::unordered_map<StickIndex, std::vector<std::pair<Direction, KbScancode>>>(),
-          std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>(),
-          std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GameControllerButton>>>(),
-          std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>(),
-          std::unordered_map<StickIndex,
-                             std::vector<std::pair<Direction, std::pair<SDL_GameControllerAxis, int32_t>>>>()) {
+          std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>>(),
+          std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GamepadButton>>>(),
+          std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>(),
+          std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GamepadAxis, int32_t>>>>()) {
 }
 
 ControllerDefaultMappings::~ControllerDefaultMappings() {
@@ -66,24 +64,23 @@ void ControllerDefaultMappings::SetDefaultKeyboardKeyToAxisDirectionMappings(
                                                                { DOWN, KbScancode::LUS_KB_S } };
 }
 
-std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>
+std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>>
 ControllerDefaultMappings::GetDefaultSDLButtonToButtonMappings() {
     return mDefaultSDLButtonToButtonMappings;
 }
 
 void ControllerDefaultMappings::SetDefaultSDLButtonToButtonMappings(
-    std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GameControllerButton>>
-        defaultSDLButtonToButtonMappings) {
+    std::unordered_map<CONTROLLERBUTTONS_T, std::unordered_set<SDL_GamepadButton>> defaultSDLButtonToButtonMappings) {
     mDefaultSDLButtonToButtonMappings = defaultSDLButtonToButtonMappings;
 }
 
-std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GameControllerButton>>>
+std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GamepadButton>>>
 ControllerDefaultMappings::GetDefaultSDLButtonToAxisDirectionMappings() {
     return mDefaultSDLButtonToAxisDirectionMappings;
 }
 
 void ControllerDefaultMappings::SetDefaultSDLButtonToAxisDirectionMappings(
-    std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GameControllerButton>>>
+    std::unordered_map<StickIndex, std::vector<std::pair<Direction, SDL_GamepadButton>>>
         defaultSDLButtonToAxisDirectionMappings) {
     if (!defaultSDLButtonToAxisDirectionMappings.empty()) {
         mDefaultSDLButtonToAxisDirectionMappings = defaultSDLButtonToAxisDirectionMappings;
@@ -91,24 +88,24 @@ void ControllerDefaultMappings::SetDefaultSDLButtonToAxisDirectionMappings(
     }
 }
 
-std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>
+std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>
 ControllerDefaultMappings::GetDefaultSDLAxisDirectionToButtonMappings() {
     return mDefaultSDLAxisDirectionToButtonMappings;
 }
 
 void ControllerDefaultMappings::SetDefaultSDLAxisDirectionToButtonMappings(
-    std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GameControllerAxis, int32_t>>>
+    std::unordered_map<CONTROLLERBUTTONS_T, std::vector<std::pair<SDL_GamepadAxis, int32_t>>>
         defaultSDLAxisDirectionToButtonMappings) {
     mDefaultSDLAxisDirectionToButtonMappings = defaultSDLAxisDirectionToButtonMappings;
 }
 
-std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GameControllerAxis, int32_t>>>>
+std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GamepadAxis, int32_t>>>>
 ControllerDefaultMappings::GetDefaultSDLAxisDirectionToAxisDirectionMappings() {
     return mDefaultSDLAxisDirectionToAxisDirectionMappings;
 }
 
 void ControllerDefaultMappings::SetDefaultSDLAxisDirectionToAxisDirectionMappings(
-    std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GameControllerAxis, int32_t>>>>
+    std::unordered_map<StickIndex, std::vector<std::pair<Direction, std::pair<SDL_GamepadAxis, int32_t>>>>
         defaultSDLAxisDirectionToAxisDirectionMappings) {
     if (!defaultSDLAxisDirectionToAxisDirectionMappings.empty()) {
         mDefaultSDLAxisDirectionToAxisDirectionMappings = defaultSDLAxisDirectionToAxisDirectionMappings;
@@ -116,17 +113,17 @@ void ControllerDefaultMappings::SetDefaultSDLAxisDirectionToAxisDirectionMapping
     }
 
     mDefaultSDLAxisDirectionToAxisDirectionMappings[LEFT_STICK] = {
-        { LEFT, { SDL_CONTROLLER_AXIS_LEFTX, -1 } },
-        { RIGHT, { SDL_CONTROLLER_AXIS_LEFTX, 1 } },
-        { UP, { SDL_CONTROLLER_AXIS_LEFTY, -1 } },
-        { DOWN, { SDL_CONTROLLER_AXIS_LEFTY, 1 } },
+        { LEFT, { SDL_GAMEPAD_AXIS_LEFTX, -1 } },
+        { RIGHT, { SDL_GAMEPAD_AXIS_LEFTX, 1 } },
+        { UP, { SDL_GAMEPAD_AXIS_LEFTY, -1 } },
+        { DOWN, { SDL_GAMEPAD_AXIS_LEFTY, 1 } },
     };
 
     mDefaultSDLAxisDirectionToAxisDirectionMappings[RIGHT_STICK] = {
-        { LEFT, { SDL_CONTROLLER_AXIS_RIGHTX, -1 } },
-        { RIGHT, { SDL_CONTROLLER_AXIS_RIGHTX, 1 } },
-        { UP, { SDL_CONTROLLER_AXIS_RIGHTY, -1 } },
-        { DOWN, { SDL_CONTROLLER_AXIS_RIGHTY, 1 } },
+        { LEFT, { SDL_GAMEPAD_AXIS_RIGHTX, -1 } },
+        { RIGHT, { SDL_GAMEPAD_AXIS_RIGHTX, 1 } },
+        { UP, { SDL_GAMEPAD_AXIS_RIGHTY, -1 } },
+        { DOWN, { SDL_GAMEPAD_AXIS_RIGHTY, 1 } },
     };
 }
 

--- a/src/ship/controller/controldevice/controller/mapping/factories/AxisDirectionMappingFactory.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/factories/AxisDirectionMappingFactory.cpp
@@ -163,8 +163,8 @@ std::shared_ptr<ControllerAxisDirectionMapping> AxisDirectionMappingFactory::Cre
 
     for (auto [instanceId, gamepad] :
          controlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(portIndex)) {
-        for (int32_t button = SDL_CONTROLLER_BUTTON_A; button < SDL_CONTROLLER_BUTTON_MAX; button++) {
-            if (SDL_GameControllerGetButton(gamepad, static_cast<SDL_GameControllerButton>(button))) {
+        for (int32_t button = SDL_GAMEPAD_BUTTON_SOUTH; button < SDL_GAMEPAD_BUTTON_COUNT; button++) {
+            if (SDL_GetGamepadButton(gamepad, static_cast<SDL_GamepadButton>(button))) {
                 mapping = std::make_shared<SDLButtonToAxisDirectionMapping>(portIndex, stickIndex, direction, button,
                                                                             controlDeck, consoleVariable);
                 break;
@@ -175,9 +175,9 @@ std::shared_ptr<ControllerAxisDirectionMapping> AxisDirectionMappingFactory::Cre
             break;
         }
 
-        for (int32_t i = SDL_CONTROLLER_AXIS_LEFTX; i < SDL_CONTROLLER_AXIS_MAX; i++) {
-            const auto axis = static_cast<SDL_GameControllerAxis>(i);
-            const auto axisValue = SDL_GameControllerGetAxis(gamepad, axis) / 32767.0f;
+        for (int32_t i = SDL_GAMEPAD_AXIS_LEFTX; i < SDL_GAMEPAD_AXIS_COUNT; i++) {
+            const auto axis = static_cast<SDL_GamepadAxis>(i);
+            const auto axisValue = SDL_GetGamepadAxis(gamepad, axis) / 32767.0f;
             int32_t axisDirection = 0;
             if (axisValue < -0.7f) {
                 axisDirection = NEGATIVE;

--- a/src/ship/controller/controldevice/controller/mapping/factories/ButtonMappingFactory.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/factories/ButtonMappingFactory.cpp
@@ -131,8 +131,8 @@ ButtonMappingFactory::CreateButtonMappingFromSDLInput(uint8_t portIndex, CONTROL
 
     for (auto [instanceId, gamepad] :
          controlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(portIndex)) {
-        for (int32_t button = SDL_CONTROLLER_BUTTON_A; button < SDL_CONTROLLER_BUTTON_MAX; button++) {
-            if (SDL_GameControllerGetButton(gamepad, static_cast<SDL_GameControllerButton>(button))) {
+        for (int32_t button = SDL_GAMEPAD_BUTTON_SOUTH; button < SDL_GAMEPAD_BUTTON_COUNT; button++) {
+            if (SDL_GetGamepadButton(gamepad, static_cast<SDL_GamepadButton>(button))) {
                 mapping = std::make_shared<SDLButtonToButtonMapping>(portIndex, bitmask, button, controlDeck,
                                                                      consoleVariable);
                 break;
@@ -143,9 +143,9 @@ ButtonMappingFactory::CreateButtonMappingFromSDLInput(uint8_t portIndex, CONTROL
             break;
         }
 
-        for (int32_t i = SDL_CONTROLLER_AXIS_LEFTX; i < SDL_CONTROLLER_AXIS_MAX; i++) {
-            const auto axis = static_cast<SDL_GameControllerAxis>(i);
-            const auto axisValue = SDL_GameControllerGetAxis(gamepad, axis) / 32767.0f;
+        for (int32_t i = SDL_GAMEPAD_AXIS_LEFTX; i < SDL_GAMEPAD_AXIS_COUNT; i++) {
+            const auto axis = static_cast<SDL_GamepadAxis>(i);
+            const auto axisValue = SDL_GetGamepadAxis(gamepad, axis) / 32767.0f;
             int32_t axisDirection = 0;
             if (axisValue < -0.7f) {
                 axisDirection = NEGATIVE;

--- a/src/ship/controller/controldevice/controller/mapping/factories/GyroMappingFactory.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/factories/GyroMappingFactory.cpp
@@ -43,12 +43,12 @@ GyroMappingFactory::CreateGyroMappingFromSDLInput(uint8_t portIndex, std::shared
 
     for (auto [instanceId, gamepad] :
          controlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(portIndex)) {
-        if (!SDL_GameControllerHasSensor(gamepad, SDL_SENSOR_GYRO)) {
+        if (!SDL_GamepadHasSensor(gamepad, SDL_SENSOR_GYRO)) {
             continue;
         }
 
-        for (int32_t button = SDL_CONTROLLER_BUTTON_A; button < SDL_CONTROLLER_BUTTON_MAX; button++) {
-            if (SDL_GameControllerGetButton(gamepad, static_cast<SDL_GameControllerButton>(button))) {
+        for (int32_t button = SDL_GAMEPAD_BUTTON_SOUTH; button < SDL_GAMEPAD_BUTTON_COUNT; button++) {
+            if (SDL_GetGamepadButton(gamepad, static_cast<SDL_GamepadButton>(button))) {
                 mapping =
                     std::make_shared<SDLGyroMapping>(portIndex, 1.0f, 0.0f, 0.0f, 0.0f, controlDeck, consoleVariable);
                 mapping->Recalibrate();
@@ -60,9 +60,9 @@ GyroMappingFactory::CreateGyroMappingFromSDLInput(uint8_t portIndex, std::shared
             break;
         }
 
-        for (int32_t i = SDL_CONTROLLER_AXIS_LEFTX; i < SDL_CONTROLLER_AXIS_MAX; i++) {
-            const auto axis = static_cast<SDL_GameControllerAxis>(i);
-            const auto axisValue = SDL_GameControllerGetAxis(gamepad, axis) / 32767.0f;
+        for (int32_t i = SDL_GAMEPAD_AXIS_LEFTX; i < SDL_GAMEPAD_AXIS_COUNT; i++) {
+            const auto axis = static_cast<SDL_GamepadAxis>(i);
+            const auto axisValue = SDL_GetGamepadAxis(gamepad, axis) / 32767.0f;
             int32_t axisDirection = 0;
             if (axisValue < -0.7f) {
                 axisDirection = NEGATIVE;

--- a/src/ship/controller/controldevice/controller/mapping/factories/LEDMappingFactory.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/factories/LEDMappingFactory.cpp
@@ -39,12 +39,12 @@ LEDMappingFactory::CreateLEDMappingFromSDLInput(uint8_t portIndex, std::shared_p
 
     for (auto [instanceId, gamepad] :
          controlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(portIndex)) {
-        if (!SDL_GameControllerHasLED(gamepad)) {
+        if (!SDL_GetBooleanProperty(SDL_GetGamepadProperties(gamepad), SDL_PROP_GAMEPAD_CAP_RGB_LED_BOOLEAN, false)) {
             continue;
         }
 
-        for (int32_t button = SDL_CONTROLLER_BUTTON_A; button < SDL_CONTROLLER_BUTTON_MAX; button++) {
-            if (SDL_GameControllerGetButton(gamepad, static_cast<SDL_GameControllerButton>(button))) {
+        for (int32_t button = SDL_GAMEPAD_BUTTON_SOUTH; button < SDL_GAMEPAD_BUTTON_COUNT; button++) {
+            if (SDL_GetGamepadButton(gamepad, static_cast<SDL_GamepadButton>(button))) {
                 mapping = std::make_shared<SDLLEDMapping>(portIndex, 0, Color_RGB8({ 0, 0, 0 }), controlDeck,
                                                           consoleVariable);
                 break;
@@ -55,9 +55,9 @@ LEDMappingFactory::CreateLEDMappingFromSDLInput(uint8_t portIndex, std::shared_p
             break;
         }
 
-        for (int32_t i = SDL_CONTROLLER_AXIS_LEFTX; i < SDL_CONTROLLER_AXIS_MAX; i++) {
-            const auto axis = static_cast<SDL_GameControllerAxis>(i);
-            const auto axisValue = SDL_GameControllerGetAxis(gamepad, axis) / 32767.0f;
+        for (int32_t i = SDL_GAMEPAD_AXIS_LEFTX; i < SDL_GAMEPAD_AXIS_COUNT; i++) {
+            const auto axis = static_cast<SDL_GamepadAxis>(i);
+            const auto axisValue = SDL_GetGamepadAxis(gamepad, axis) / 32767.0f;
             int32_t axisDirection = 0;
             if (axisValue < -0.7f) {
                 axisDirection = NEGATIVE;

--- a/src/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.cpp
@@ -37,6 +37,10 @@ std::vector<std::shared_ptr<ControllerRumbleMapping>>
 RumbleMappingFactory::CreateDefaultSDLRumbleMappings(PhysicalDeviceType physicalDeviceType, uint8_t portIndex,
                                                      std::shared_ptr<ConsoleVariable> consoleVariable,
                                                      std::shared_ptr<ControlDeck> controlDeck) {
+    if (physicalDeviceType != PhysicalDeviceType::SDLGamepad) {
+        return {};
+    }
+
     std::vector<std::shared_ptr<ControllerRumbleMapping>> mappings = { std::make_shared<SDLRumbleMapping>(
         portIndex, DEFAULT_LOW_FREQUENCY_RUMBLE_PERCENTAGE, DEFAULT_HIGH_FREQUENCY_RUMBLE_PERCENTAGE, controlDeck,
         consoleVariable) };

--- a/src/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.cpp
@@ -50,12 +50,12 @@ std::shared_ptr<ControllerRumbleMapping> RumbleMappingFactory::CreateRumbleMappi
 
     for (auto [instanceId, gamepad] :
          controlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(portIndex)) {
-        if (!SDL_GameControllerHasRumble(gamepad)) {
+        if (!SDL_GetBooleanProperty(SDL_GetGamepadProperties(gamepad), SDL_PROP_GAMEPAD_CAP_RUMBLE_BOOLEAN, false)) {
             continue;
         }
 
-        for (int32_t button = SDL_CONTROLLER_BUTTON_A; button < SDL_CONTROLLER_BUTTON_MAX; button++) {
-            if (SDL_GameControllerGetButton(gamepad, static_cast<SDL_GameControllerButton>(button))) {
+        for (int32_t button = SDL_GAMEPAD_BUTTON_SOUTH; button < SDL_GAMEPAD_BUTTON_COUNT; button++) {
+            if (SDL_GetGamepadButton(gamepad, static_cast<SDL_GamepadButton>(button))) {
                 mapping = std::make_shared<SDLRumbleMapping>(portIndex, DEFAULT_LOW_FREQUENCY_RUMBLE_PERCENTAGE,
                                                              DEFAULT_HIGH_FREQUENCY_RUMBLE_PERCENTAGE, controlDeck,
                                                              consoleVariable);
@@ -67,9 +67,9 @@ std::shared_ptr<ControllerRumbleMapping> RumbleMappingFactory::CreateRumbleMappi
             break;
         }
 
-        for (int32_t i = SDL_CONTROLLER_AXIS_LEFTX; i < SDL_CONTROLLER_AXIS_MAX; i++) {
-            const auto axis = static_cast<SDL_GameControllerAxis>(i);
-            const auto axisValue = SDL_GameControllerGetAxis(gamepad, axis) / 32767.0f;
+        for (int32_t i = SDL_GAMEPAD_AXIS_LEFTX; i < SDL_GAMEPAD_AXIS_COUNT; i++) {
+            const auto axis = static_cast<SDL_GamepadAxis>(i);
+            const auto axisValue = SDL_GetGamepadAxis(gamepad, axis) / 32767.0f;
             int32_t axisDirection = 0;
             if (axisValue < -0.7f) {
                 axisDirection = NEGATIVE;

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAnyMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAnyMapping.cpp
@@ -6,7 +6,7 @@
 namespace Ship {
 SDLAxisDirectionToAnyMapping::SDLAxisDirectionToAnyMapping(int32_t sdlControllerAxis, int32_t axisDirection)
     : ControllerInputMapping(PhysicalDeviceType::SDLGamepad) {
-    mControllerAxis = static_cast<SDL_GameControllerAxis>(sdlControllerAxis);
+    mControllerAxis = static_cast<SDL_GamepadAxis>(sdlControllerAxis);
     mAxisDirection = static_cast<AxisDirection>(axisDirection);
 }
 
@@ -15,22 +15,22 @@ SDLAxisDirectionToAnyMapping::~SDLAxisDirectionToAnyMapping() {
 
 std::string SDLAxisDirectionToAnyMapping::GetPhysicalInputName() {
     switch (mControllerAxis) {
-        case SDL_CONTROLLER_AXIS_LEFTX:
+        case SDL_GAMEPAD_AXIS_LEFTX:
             return StringHelper::Sprintf("Left Stick %s",
                                          mAxisDirection == NEGATIVE ? ICON_FA_ARROW_LEFT : ICON_FA_ARROW_RIGHT);
-        case SDL_CONTROLLER_AXIS_LEFTY:
+        case SDL_GAMEPAD_AXIS_LEFTY:
             return StringHelper::Sprintf("Left Stick %s",
                                          mAxisDirection == NEGATIVE ? ICON_FA_ARROW_UP : ICON_FA_ARROW_DOWN);
-        case SDL_CONTROLLER_AXIS_RIGHTX:
+        case SDL_GAMEPAD_AXIS_RIGHTX:
             return StringHelper::Sprintf("Right Stick %s",
                                          mAxisDirection == NEGATIVE ? ICON_FA_ARROW_LEFT : ICON_FA_ARROW_RIGHT);
-        case SDL_CONTROLLER_AXIS_RIGHTY:
+        case SDL_GAMEPAD_AXIS_RIGHTY:
             return StringHelper::Sprintf("Right Stick %s",
                                          mAxisDirection == NEGATIVE ? ICON_FA_ARROW_UP : ICON_FA_ARROW_DOWN);
-        case SDL_CONTROLLER_AXIS_TRIGGERLEFT:
+        case SDL_GAMEPAD_AXIS_LEFT_TRIGGER:
             return "LT";
             break;
-        case SDL_CONTROLLER_AXIS_TRIGGERRIGHT:
+        case SDL_GAMEPAD_AXIS_RIGHT_TRIGGER:
             return "RT";
             break;
         default:
@@ -46,11 +46,11 @@ std::string SDLAxisDirectionToAnyMapping::GetPhysicalDeviceName() {
 }
 
 bool SDLAxisDirectionToAnyMapping::AxisIsTrigger() {
-    return mControllerAxis == SDL_CONTROLLER_AXIS_TRIGGERLEFT || mControllerAxis == SDL_CONTROLLER_AXIS_TRIGGERRIGHT;
+    return mControllerAxis == SDL_GAMEPAD_AXIS_LEFT_TRIGGER || mControllerAxis == SDL_GAMEPAD_AXIS_RIGHT_TRIGGER;
 }
 
 bool SDLAxisDirectionToAnyMapping::AxisIsStick() {
-    return mControllerAxis == SDL_CONTROLLER_AXIS_LEFTX || mControllerAxis == SDL_CONTROLLER_AXIS_LEFTY ||
-           mControllerAxis == SDL_CONTROLLER_AXIS_RIGHTX || mControllerAxis == SDL_CONTROLLER_AXIS_RIGHTY;
+    return mControllerAxis == SDL_GAMEPAD_AXIS_LEFTX || mControllerAxis == SDL_GAMEPAD_AXIS_LEFTY ||
+           mControllerAxis == SDL_GAMEPAD_AXIS_RIGHTX || mControllerAxis == SDL_GAMEPAD_AXIS_RIGHTY;
 }
 } // namespace Ship

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAxisDirectionMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToAxisDirectionMapping.cpp
@@ -27,7 +27,7 @@ float SDLAxisDirectionToAxisDirectionMapping::GetNormalizedAxisDirectionValue() 
     std::vector<float> normalizedValues = {};
     for (const auto& [instanceId, gamepad] :
          mControlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(mPortIndex)) {
-        const auto axisValue = SDL_GameControllerGetAxis(gamepad, mControllerAxis);
+        const auto axisValue = SDL_GetGamepadAxis(gamepad, mControllerAxis);
 
         if ((mAxisDirection == POSITIVE && axisValue < 0) || (mAxisDirection == NEGATIVE && axisValue > 0)) {
             normalizedValues.push_back(0.0f);

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToButtonMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToButtonMapping.cpp
@@ -31,7 +31,7 @@ void SDLAxisDirectionToButtonMapping::UpdatePad(CONTROLLERBUTTONS_T& padButtons)
 
     for (const auto& [instanceId, gamepad] :
          mControlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(mPortIndex)) {
-        const auto axisValue = SDL_GameControllerGetAxis(gamepad, mControllerAxis);
+        const auto axisValue = SDL_GetGamepadAxis(gamepad, mControllerAxis);
 
         auto axisMinValue = SDL_JOYSTICK_AXIS_MAX * (axisThresholdPercentage / 100.0f);
         if ((mAxisDirection == POSITIVE && axisValue > axisMinValue) ||

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLButtonToAnyMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLButtonToAnyMapping.cpp
@@ -6,7 +6,7 @@
 namespace Ship {
 SDLButtonToAnyMapping::SDLButtonToAnyMapping(int32_t sdlControllerButton)
     : ControllerInputMapping(PhysicalDeviceType::SDLGamepad) {
-    mControllerButton = static_cast<SDL_GameControllerButton>(sdlControllerButton);
+    mControllerButton = static_cast<SDL_GamepadButton>(sdlControllerButton);
 }
 
 SDLButtonToAnyMapping::~SDLButtonToAnyMapping() {
@@ -14,46 +14,46 @@ SDLButtonToAnyMapping::~SDLButtonToAnyMapping() {
 
 std::string SDLButtonToAnyMapping::GetPhysicalInputName() {
     switch (mControllerButton) {
-        case SDL_CONTROLLER_BUTTON_A:
+        case SDL_GAMEPAD_BUTTON_SOUTH:
             return "A";
-        case SDL_CONTROLLER_BUTTON_B:
+        case SDL_GAMEPAD_BUTTON_EAST:
             return "B";
-        case SDL_CONTROLLER_BUTTON_X:
+        case SDL_GAMEPAD_BUTTON_WEST:
             return "X";
-        case SDL_CONTROLLER_BUTTON_Y:
+        case SDL_GAMEPAD_BUTTON_NORTH:
             return "Y";
-        case SDL_CONTROLLER_BUTTON_BACK:
+        case SDL_GAMEPAD_BUTTON_BACK:
             return "View";
-        case SDL_CONTROLLER_BUTTON_GUIDE:
+        case SDL_GAMEPAD_BUTTON_GUIDE:
             return "Xbox";
-        case SDL_CONTROLLER_BUTTON_START:
+        case SDL_GAMEPAD_BUTTON_START:
             return StringHelper::Sprintf("%s", ICON_FA_BARS);
-        case SDL_CONTROLLER_BUTTON_LEFTSTICK:
+        case SDL_GAMEPAD_BUTTON_LEFT_STICK:
             return "LS";
-        case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
+        case SDL_GAMEPAD_BUTTON_RIGHT_STICK:
             return "RS";
-        case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
+        case SDL_GAMEPAD_BUTTON_LEFT_SHOULDER:
             return "LB";
-        case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
+        case SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER:
             return "RB";
-        case SDL_CONTROLLER_BUTTON_DPAD_UP:
+        case SDL_GAMEPAD_BUTTON_DPAD_UP:
             return StringHelper::Sprintf("D-Pad %s", ICON_FA_ARROW_UP);
-        case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+        case SDL_GAMEPAD_BUTTON_DPAD_DOWN:
             return StringHelper::Sprintf("D-Pad %s", ICON_FA_ARROW_DOWN);
-        case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+        case SDL_GAMEPAD_BUTTON_DPAD_LEFT:
             return StringHelper::Sprintf("D-Pad %s", ICON_FA_ARROW_LEFT);
-        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+        case SDL_GAMEPAD_BUTTON_DPAD_RIGHT:
             return StringHelper::Sprintf("D-Pad %s", ICON_FA_ARROW_RIGHT);
-        case SDL_CONTROLLER_BUTTON_MISC1:
+        case SDL_GAMEPAD_BUTTON_MISC1:
             return "Share"; /* Xbox Series X share button, PS5 microphone button, Nintendo Switch Pro capture button,
                                Amazon Luna microphone button */
-        case SDL_CONTROLLER_BUTTON_PADDLE1:
+        case SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1:
             return "P1";
-        case SDL_CONTROLLER_BUTTON_PADDLE2:
+        case SDL_GAMEPAD_BUTTON_LEFT_PADDLE1:
             return "P2";
-        case SDL_CONTROLLER_BUTTON_PADDLE3:
+        case SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2:
             return "P3";
-        case SDL_CONTROLLER_BUTTON_PADDLE4:
+        case SDL_GAMEPAD_BUTTON_LEFT_PADDLE2:
             return "P4";
         default:
             break;

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLButtonToAxisDirectionMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLButtonToAxisDirectionMapping.cpp
@@ -26,7 +26,7 @@ float SDLButtonToAxisDirectionMapping::GetNormalizedAxisDirectionValue() {
 
     for (const auto& [instanceId, gamepad] :
          mControlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(mPortIndex)) {
-        if (SDL_GameControllerGetButton(gamepad, mControllerButton)) {
+        if (SDL_GetGamepadButton(gamepad, mControllerButton)) {
             return MAX_AXIS_RANGE;
         }
     }

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLButtonToButtonMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLButtonToButtonMapping.cpp
@@ -23,7 +23,7 @@ void SDLButtonToButtonMapping::UpdatePad(CONTROLLERBUTTONS_T& padButtons) {
 
     for (const auto& [instanceId, gamepad] :
          mControlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(mPortIndex)) {
-        if (SDL_GameControllerGetButton(gamepad, mControllerButton)) {
+        if (SDL_GetGamepadButton(gamepad, mControllerButton)) {
             padButtons |= mBitmask;
             return;
         }

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLGyroMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLGyroMapping.cpp
@@ -20,14 +20,14 @@ SDLGyroMapping::SDLGyroMapping(uint8_t portIndex, float sensitivity, float neutr
 void SDLGyroMapping::Recalibrate() {
     for (const auto& [instanceId, gamepad] :
          mControlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(mPortIndex)) {
-        if (!SDL_GameControllerHasSensor(gamepad, SDL_SENSOR_GYRO)) {
+        if (!SDL_GamepadHasSensor(gamepad, SDL_SENSOR_GYRO)) {
             continue;
         }
 
         // just use gyro on the first gyro supported device we find
         float gyroData[3];
-        SDL_GameControllerSetSensorEnabled(gamepad, SDL_SENSOR_GYRO, SDL_TRUE);
-        SDL_GameControllerGetSensorData(gamepad, SDL_SENSOR_GYRO, gyroData, 3);
+        SDL_SetGamepadSensorEnabled(gamepad, SDL_SENSOR_GYRO, true);
+        SDL_GetGamepadSensorData(gamepad, SDL_SENSOR_GYRO, gyroData, 3);
 
         mNeutralPitch = gyroData[0];
         mNeutralYaw = gyroData[1];
@@ -50,14 +50,14 @@ void SDLGyroMapping::UpdatePad(float& x, float& y) {
 
     for (const auto& [instanceId, gamepad] :
          mControlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(mPortIndex)) {
-        if (!SDL_GameControllerHasSensor(gamepad, SDL_SENSOR_GYRO)) {
+        if (!SDL_GamepadHasSensor(gamepad, SDL_SENSOR_GYRO)) {
             continue;
         }
 
         // just use gyro on the first gyro supported device we find
         float gyroData[3];
-        SDL_GameControllerSetSensorEnabled(gamepad, SDL_SENSOR_GYRO, SDL_TRUE);
-        SDL_GameControllerGetSensorData(gamepad, SDL_SENSOR_GYRO, gyroData, 3);
+        SDL_SetGamepadSensorEnabled(gamepad, SDL_SENSOR_GYRO, true);
+        SDL_GetGamepadSensorData(gamepad, SDL_SENSOR_GYRO, gyroData, 3);
 
         x = (gyroData[0] - mNeutralPitch) * mSensitivity;
         y = (gyroData[1] - mNeutralYaw) * mSensitivity;

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLLEDMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLLEDMapping.cpp
@@ -23,11 +23,11 @@ void SDLLEDMapping::SetLEDColor(Color_RGB8 color) {
 
     for (const auto& [instanceId, gamepad] :
          mControlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(mPortIndex)) {
-        if (!SDL_GameControllerHasLED(gamepad)) {
+        if (!SDL_GetBooleanProperty(SDL_GetGamepadProperties(gamepad), SDL_PROP_GAMEPAD_CAP_RGB_LED_BOOLEAN, false)) {
             continue;
         }
 
-        SDL_JoystickSetLED(SDL_GameControllerGetJoystick(gamepad), color.r, color.g, color.b);
+        SDL_SetGamepadLED(gamepad, color.r, color.g, color.b);
     }
 }
 

--- a/src/ship/controller/controldevice/controller/mapping/sdl/SDLRumbleMapping.cpp
+++ b/src/ship/controller/controldevice/controller/mapping/sdl/SDLRumbleMapping.cpp
@@ -20,14 +20,14 @@ SDLRumbleMapping::SDLRumbleMapping(uint8_t portIndex, uint8_t lowFrequencyIntens
 void SDLRumbleMapping::StartRumble() {
     for (const auto& [instanceId, gamepad] :
          mControlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(mPortIndex)) {
-        SDL_GameControllerRumble(gamepad, mLowFrequencyIntensity, mHighFrequencyIntensity, 0);
+        SDL_RumbleGamepad(gamepad, mLowFrequencyIntensity, mHighFrequencyIntensity, 0);
     }
 }
 
 void SDLRumbleMapping::StopRumble() {
     for (const auto& [instanceId, gamepad] :
          mControlDeck->GetConnectedPhysicalDeviceManager()->GetConnectedSDLGamepadsForPort(mPortIndex)) {
-        SDL_GameControllerRumble(gamepad, 0, 0, 0);
+        SDL_RumbleGamepad(gamepad, 0, 0, 0);
     }
 }
 

--- a/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
+++ b/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
@@ -57,11 +57,10 @@ void ConnectedPhysicalDeviceManager::CloseConnectedSDLGamepads() {
         }
     }
     mConnectedSDLGamepads.clear();
+    mConnectedSDLGamepadNames.clear();
 }
 
 void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
-    CloseConnectedSDLGamepads();
-    mConnectedSDLGamepadNames.clear();
     static SDL_GUID sZeroGuid;
 
     int32_t joystickCount = 0;
@@ -70,8 +69,26 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
         return;
     }
 
+    std::unordered_set<SDL_JoystickID> connectedInstanceIds(joysticks, joysticks + joystickCount);
+
+    for (auto gamepadIt = mConnectedSDLGamepads.begin(); gamepadIt != mConnectedSDLGamepads.end();) {
+        const SDL_JoystickID instanceId = gamepadIt->first;
+        if (connectedInstanceIds.contains(instanceId)) {
+            ++gamepadIt;
+            continue;
+        }
+
+        SDL_CloseGamepad(gamepadIt->second);
+        gamepadIt = mConnectedSDLGamepads.erase(gamepadIt);
+        mConnectedSDLGamepadNames.erase(instanceId);
+    }
+
     for (int32_t i = 0; i < joystickCount; i++) {
         const SDL_JoystickID instanceId = joysticks[i];
+
+        if (mConnectedSDLGamepads.contains(instanceId)) {
+            continue;
+        }
 
         SDL_GUID deviceGUID = SDL_GetJoystickGUIDForID(instanceId);
         if (SDL_memcmp(&deviceGUID, &sZeroGuid, sizeof(deviceGUID)) == 0) {
@@ -97,13 +114,6 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
             continue;
         }
 
-        const SDL_JoystickID openedInstanceId = SDL_GetJoystickID(SDL_GetGamepadJoystick(gamepad));
-        if (openedInstanceId == 0) {
-            SPDLOG_ERROR("SDL_GetJoystickID error (GUID: {}): {}", deviceGuidCStr, SDL_GetError());
-            SDL_CloseGamepad(gamepad);
-            continue;
-        }
-
         std::string gamepadName;
         auto name = SDL_GetGamepadName(gamepad);
         if (name == nullptr) {
@@ -113,11 +123,11 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
             gamepadName = name;
         }
 
-        mConnectedSDLGamepads[openedInstanceId] = gamepad;
-        mConnectedSDLGamepadNames[openedInstanceId] = gamepadName;
+        mConnectedSDLGamepads[instanceId] = gamepad;
+        mConnectedSDLGamepadNames[instanceId] = gamepadName;
 
         for (uint8_t port = 1; port < 4; port++) {
-            mIgnoredInstanceIds[port].insert(openedInstanceId);
+            mIgnoredInstanceIds[port].insert(instanceId);
         }
     }
 

--- a/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
+++ b/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
@@ -6,11 +6,12 @@ ConnectedPhysicalDeviceManager::ConnectedPhysicalDeviceManager() {
 }
 
 ConnectedPhysicalDeviceManager::~ConnectedPhysicalDeviceManager() {
+    CloseConnectedSDLGamepads();
 }
 
-std::unordered_map<int32_t, SDL_GameController*>
+std::unordered_map<int32_t, SDL_Gamepad*>
 ConnectedPhysicalDeviceManager::GetConnectedSDLGamepadsForPort(uint8_t portIndex) {
-    std::unordered_map<int32_t, SDL_GameController*> result;
+    std::unordered_map<int32_t, SDL_Gamepad*> result;
 
     for (const auto& [instanceId, gamepad] : mConnectedSDLGamepads) {
         if (!PortIsIgnoringInstanceId(portIndex, instanceId)) {
@@ -41,34 +42,48 @@ void ConnectedPhysicalDeviceManager::UnignoreInstanceIdForPort(uint8_t portIndex
     mIgnoredInstanceIds[portIndex].erase(instanceId);
 }
 
-void ConnectedPhysicalDeviceManager::HandlePhysicalDeviceConnect(int32_t sdlDeviceIndex) {
+void ConnectedPhysicalDeviceManager::HandlePhysicalDeviceConnect(int32_t) {
     RefreshConnectedSDLGamepads();
 }
 
-void ConnectedPhysicalDeviceManager::HandlePhysicalDeviceDisconnect(int32_t sdlJoystickInstanceId) {
+void ConnectedPhysicalDeviceManager::HandlePhysicalDeviceDisconnect(int32_t) {
     RefreshConnectedSDLGamepads();
+}
+
+void ConnectedPhysicalDeviceManager::CloseConnectedSDLGamepads() {
+    if ((SDL_WasInit(SDL_INIT_GAMEPAD) & SDL_INIT_GAMEPAD) != 0) {
+        for (const auto& [instanceId, gamepad] : mConnectedSDLGamepads) {
+            SDL_CloseGamepad(gamepad);
+        }
+    }
+    mConnectedSDLGamepads.clear();
 }
 
 void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
-    mConnectedSDLGamepads.clear();
+    CloseConnectedSDLGamepads();
     mConnectedSDLGamepadNames.clear();
-    static SDL_JoystickGUID sZeroGuid;
+    static SDL_GUID sZeroGuid;
 
-    for (int32_t i = 0; i < SDL_NumJoysticks(); i++) {
+    int32_t joystickCount = 0;
+    SDL_JoystickID* joysticks = SDL_GetJoysticks(&joystickCount);
+    if (joysticks == nullptr) {
+        return;
+    }
 
-        SDL_JoystickGUID deviceGUID = SDL_JoystickGetDeviceGUID(i);
+    for (int32_t i = 0; i < joystickCount; i++) {
+        const SDL_JoystickID instanceId = joysticks[i];
+
+        SDL_GUID deviceGUID = SDL_GetJoystickGUIDForID(instanceId);
         if (SDL_memcmp(&deviceGUID, &sZeroGuid, sizeof(deviceGUID)) == 0) {
-            SPDLOG_WARN(
-                "Calling SDL JoystickGetDeviceGUID with index ({:d}) returned zero GUID. This is likely due to an "
-                "invalid index. Refer to https://wiki.libsdl.org/SDL2/SDL_JoystickGetDeviceGUID for more information.",
-                i);
+            SPDLOG_WARN("SDL_GetJoystickGUIDForID returned a zero GUID for joystick instance {:d}; skipping it.",
+                        instanceId);
             continue;
         }
 
         char deviceGuidCStr[33] = "";
-        SDL_JoystickGetGUIDString(deviceGUID, deviceGuidCStr, sizeof(deviceGuidCStr));
+        SDL_GUIDToString(deviceGUID, deviceGuidCStr, sizeof(deviceGuidCStr));
 
-        if (!SDL_IsGameController(i)) {
+        if (!SDL_IsGamepad(instanceId)) {
             SPDLOG_WARN("SDL Joystick (GUID: {}) not recognized as gamepad."
                         "This is likely due to a missing mapping string in gamecontrollerdb.txt."
                         "Refer to https://github.com/mdqinc/SDL_GameControllerDB for more information.",
@@ -76,33 +91,36 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
             continue;
         }
 
-        auto gamepad = SDL_GameControllerOpen(i);
+        auto gamepad = SDL_OpenGamepad(instanceId);
         if (gamepad == nullptr) {
-            SPDLOG_ERROR("SDL GameControllerOpen error (GUID: {}): {}", deviceGuidCStr, SDL_GetError());
+            SPDLOG_ERROR("SDL_OpenGamepad error (GUID: {}): {}", deviceGuidCStr, SDL_GetError());
             continue;
         }
 
-        auto instanceId = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(gamepad));
-        if (instanceId < 0) {
-            SPDLOG_ERROR("SDL JoystickInstanceID error (GUID: {}): {}", deviceGuidCStr, SDL_GetError());
+        const SDL_JoystickID openedInstanceId = SDL_GetJoystickID(SDL_GetGamepadJoystick(gamepad));
+        if (openedInstanceId == 0) {
+            SPDLOG_ERROR("SDL_GetJoystickID error (GUID: {}): {}", deviceGuidCStr, SDL_GetError());
+            SDL_CloseGamepad(gamepad);
             continue;
         }
 
         std::string gamepadName;
-        auto name = SDL_GameControllerName(gamepad);
+        auto name = SDL_GetGamepadName(gamepad);
         if (name == nullptr) {
             gamepadName = deviceGuidCStr;
-            SPDLOG_WARN("SDL_GameControllerName returned null. Setting name to GUID \"{}\" instead.", gamepadName);
+            SPDLOG_WARN("SDL_GetGamepadName returned null. Setting name to GUID \"{}\" instead.", gamepadName);
         } else {
             gamepadName = name;
         }
 
-        mConnectedSDLGamepads[instanceId] = gamepad;
-        mConnectedSDLGamepadNames[instanceId] = gamepadName;
+        mConnectedSDLGamepads[openedInstanceId] = gamepad;
+        mConnectedSDLGamepadNames[openedInstanceId] = gamepadName;
 
         for (uint8_t port = 1; port < 4; port++) {
-            mIgnoredInstanceIds[port].insert(instanceId);
+            mIgnoredInstanceIds[port].insert(openedInstanceId);
         }
     }
+
+    SDL_free(joysticks);
 }
 } // namespace Ship

--- a/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
+++ b/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
@@ -73,7 +73,7 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
 
     for (auto gamepadIt = mConnectedSDLGamepads.begin(); gamepadIt != mConnectedSDLGamepads.end();) {
         const SDL_JoystickID instanceId = gamepadIt->first;
-        if (connectedInstanceIds.contains(instanceId)) {
+        if (connectedInstanceIds.contains(instanceId) && SDL_IsGamepad(instanceId)) {
             ++gamepadIt;
             continue;
         }
@@ -85,10 +85,6 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
 
     for (int32_t i = 0; i < joystickCount; i++) {
         const SDL_JoystickID instanceId = joysticks[i];
-
-        if (mConnectedSDLGamepads.contains(instanceId)) {
-            continue;
-        }
 
         SDL_GUID deviceGUID = SDL_GetJoystickGUIDForID(instanceId);
         if (SDL_memcmp(&deviceGUID, &sZeroGuid, sizeof(deviceGUID)) == 0) {
@@ -108,10 +104,17 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
             continue;
         }
 
-        auto gamepad = SDL_OpenGamepad(instanceId);
-        if (gamepad == nullptr) {
-            SPDLOG_ERROR("SDL_OpenGamepad error (GUID: {}): {}", deviceGuidCStr, SDL_GetError());
-            continue;
+        SDL_Gamepad* gamepad = nullptr;
+        const auto existingGamepad = mConnectedSDLGamepads.find(instanceId);
+        if (existingGamepad != mConnectedSDLGamepads.end()) {
+            gamepad = existingGamepad->second;
+        } else {
+            gamepad = SDL_OpenGamepad(instanceId);
+            if (gamepad == nullptr) {
+                SPDLOG_ERROR("SDL_OpenGamepad error (GUID: {}): {}", deviceGuidCStr, SDL_GetError());
+                continue;
+            }
+            mConnectedSDLGamepads[instanceId] = gamepad;
         }
 
         std::string gamepadName;
@@ -123,7 +126,6 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
             gamepadName = name;
         }
 
-        mConnectedSDLGamepads[instanceId] = gamepad;
         mConnectedSDLGamepadNames[instanceId] = gamepadName;
 
         for (uint8_t port = 1; port < 4; port++) {

--- a/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
+++ b/src/ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.cpp
@@ -73,7 +73,7 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
 
     for (auto gamepadIt = mConnectedSDLGamepads.begin(); gamepadIt != mConnectedSDLGamepads.end();) {
         const SDL_JoystickID instanceId = gamepadIt->first;
-        if (connectedInstanceIds.contains(instanceId) && SDL_IsGamepad(instanceId)) {
+        if (connectedInstanceIds.contains(instanceId)) {
             ++gamepadIt;
             continue;
         }
@@ -85,6 +85,10 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
 
     for (int32_t i = 0; i < joystickCount; i++) {
         const SDL_JoystickID instanceId = joysticks[i];
+
+        if (mConnectedSDLGamepads.contains(instanceId)) {
+            continue;
+        }
 
         SDL_GUID deviceGUID = SDL_GetJoystickGUIDForID(instanceId);
         if (SDL_memcmp(&deviceGUID, &sZeroGuid, sizeof(deviceGUID)) == 0) {
@@ -104,17 +108,10 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
             continue;
         }
 
-        SDL_Gamepad* gamepad = nullptr;
-        const auto existingGamepad = mConnectedSDLGamepads.find(instanceId);
-        if (existingGamepad != mConnectedSDLGamepads.end()) {
-            gamepad = existingGamepad->second;
-        } else {
-            gamepad = SDL_OpenGamepad(instanceId);
-            if (gamepad == nullptr) {
-                SPDLOG_ERROR("SDL_OpenGamepad error (GUID: {}): {}", deviceGuidCStr, SDL_GetError());
-                continue;
-            }
-            mConnectedSDLGamepads[instanceId] = gamepad;
+        auto gamepad = SDL_OpenGamepad(instanceId);
+        if (gamepad == nullptr) {
+            SPDLOG_ERROR("SDL_OpenGamepad error (GUID: {}): {}", deviceGuidCStr, SDL_GetError());
+            continue;
         }
 
         std::string gamepadName;
@@ -126,6 +123,7 @@ void ConnectedPhysicalDeviceManager::RefreshConnectedSDLGamepads() {
             gamepadName = name;
         }
 
+        mConnectedSDLGamepads[instanceId] = gamepad;
         mConnectedSDLGamepadNames[instanceId] = gamepadName;
 
         for (uint8_t port = 1; port < 4; port++) {

--- a/src/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.cpp
+++ b/src/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.cpp
@@ -40,8 +40,15 @@ void SDLAddRemoveDeviceEventHandler::UpdateElement() {
         }
     }
 
-    // The connected controller set changed, so re-point the ImGui gamepad
-    // backend at it (keeps menu navigation working across hotplug).
+    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_GAMEPAD_REMAPPED, SDL_EVENT_GAMEPAD_REMAPPED) > 0) {
+        if (mControlDeck) {
+            mControlDeck->GetConnectedPhysicalDeviceManager()->RefreshConnectedSDLGamepads();
+            changed = true;
+        }
+    }
+
+    // The connected controller set or mapping changed, so re-point the ImGui
+    // gamepad backend at it (keeps menu navigation working across hotplug).
     if (changed) {
         auto window = GetWindow();
         if (window != nullptr && window->GetGui() != nullptr) {

--- a/src/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.cpp
+++ b/src/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.cpp
@@ -1,5 +1,5 @@
 #include "ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.h"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 #include "ship/controller/controldeck/ControlDeck.h"
 #include "ship/window/Window.h"
 #include "ship/window/gui/Gui.h"
@@ -26,20 +26,16 @@ void SDLAddRemoveDeviceEventHandler::UpdateElement() {
     SDL_PumpEvents();
     SDL_Event event;
     bool changed = false;
-    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_CONTROLLERDEVICEADDED, SDL_CONTROLLERDEVICEADDED) > 0) {
-        // from https://wiki.libsdl.org/SDL2/SDL_ControllerDeviceEvent: which - the joystick device index for
-        // the SDL_CONTROLLERDEVICEADDED event
+    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_GAMEPAD_ADDED, SDL_EVENT_GAMEPAD_ADDED) > 0) {
         if (mControlDeck) {
-            mControlDeck->GetConnectedPhysicalDeviceManager()->HandlePhysicalDeviceConnect(event.cdevice.which);
+            mControlDeck->GetConnectedPhysicalDeviceManager()->HandlePhysicalDeviceConnect(event.gdevice.which);
             changed = true;
         }
     }
 
-    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_CONTROLLERDEVICEREMOVED, SDL_CONTROLLERDEVICEREMOVED) > 0) {
-        // from https://wiki.libsdl.org/SDL2/SDL_ControllerDeviceEvent: which - the [...] instance id for the
-        // SDL_CONTROLLERDEVICEREMOVED [...] event
+    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_GAMEPAD_REMOVED, SDL_EVENT_GAMEPAD_REMOVED) > 0) {
         if (mControlDeck) {
-            mControlDeck->GetConnectedPhysicalDeviceManager()->HandlePhysicalDeviceDisconnect(event.cdevice.which);
+            mControlDeck->GetConnectedPhysicalDeviceManager()->HandlePhysicalDeviceDisconnect(event.gdevice.which);
             changed = true;
         }
     }

--- a/src/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.cpp
+++ b/src/ship/controller/physicaldevice/SDLAddRemoveDeviceEventHandler.cpp
@@ -40,15 +40,8 @@ void SDLAddRemoveDeviceEventHandler::UpdateElement() {
         }
     }
 
-    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_GAMEPAD_REMAPPED, SDL_EVENT_GAMEPAD_REMAPPED) > 0) {
-        if (mControlDeck) {
-            mControlDeck->GetConnectedPhysicalDeviceManager()->RefreshConnectedSDLGamepads();
-            changed = true;
-        }
-    }
-
-    // The connected controller set or mapping changed, so re-point the ImGui
-    // gamepad backend at it (keeps menu navigation working across hotplug).
+    // The connected controller set changed, so re-point the ImGui gamepad
+    // backend at it (keeps menu navigation working across hotplug).
     if (changed) {
         auto window = GetWindow();
         if (window != nullptr && window->GetGui() != nullptr) {

--- a/src/ship/core/Context.cpp
+++ b/src/ship/core/Context.cpp
@@ -254,7 +254,7 @@ const std::string& Context::GetShortName() const {
 
 std::string Context::GetAppBundlePath() {
 #if defined(__ANDROID__)
-    const char* externaldir = SDL_AndroidGetExternalStoragePath();
+    const char* externaldir = SDL_GetAndroidExternalStoragePath();
     if (externaldir != NULL) {
         return externaldir;
     }
@@ -317,7 +317,7 @@ std::string Context::GetAppBundlePath() {
 
 std::string Context::GetAppDirectoryPath(const std::string& appName) {
 #if defined(__ANDROID__)
-    const char* externaldir = SDL_AndroidGetExternalStoragePath();
+    const char* externaldir = SDL_GetAndroidExternalStoragePath();
     if (externaldir != NULL) {
         return externaldir;
     }

--- a/src/ship/port/mobile/MobileImpl.cpp
+++ b/src/ship/port/mobile/MobileImpl.cpp
@@ -1,12 +1,12 @@
 #if defined(__ANDROID__) || defined(__IOS__)
 #include "ship/port/mobile/MobileImpl.h"
-#include <SDL2/SDL.h>
+#include <SDL3/SDL.h>
 
 #include <imgui_internal.h>
 
 static bool isShowingVirtualKeyboard = true;
 
-void Ship::Mobile::ImGuiProcessEvent(bool wantsTextInput) {
+void Ship::Mobile::ImGuiProcessEvent(SDL_Window* window, bool wantsTextInput) {
     ImGuiInputTextState* state = ImGui::GetInputTextState(ImGui::GetActiveID());
 
     if (wantsTextInput) {
@@ -14,12 +14,12 @@ void Ship::Mobile::ImGuiProcessEvent(bool wantsTextInput) {
             state->ClearText();
 
             isShowingVirtualKeyboard = true;
-            SDL_StartTextInput();
+            SDL_StartTextInput(window);
         }
     } else {
         if (isShowingVirtualKeyboard) {
             isShowingVirtualKeyboard = false;
-            SDL_StopTextInput();
+            SDL_StopTextInput(window);
         }
     }
 }

--- a/src/ship/utils/macUtils.mm
+++ b/src/ship/utils/macUtils.mm
@@ -1,15 +1,13 @@
 // macUtils.mm
 #ifdef __APPLE__
 #import "ship/utils/macUtils.h"
-#import <SDL_syswm.h>
 #import <Cocoa/Cocoa.h>
 
 //Just a simple function to toggle the native macOS fullscreen.
 void toggleNativeMacOSFullscreen(SDL_Window *window) {
-    SDL_SysWMinfo wmInfo;
-    SDL_VERSION(&wmInfo.version);
-    if (SDL_GetWindowWMInfo(window, &wmInfo)) {
-        NSWindow *nswindow = wmInfo.info.cocoa.window;
+    NSWindow *nswindow = (__bridge NSWindow *)SDL_GetPointerProperty(
+        SDL_GetWindowProperties(window), SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, nullptr);
+    if (nswindow != nil) {
         [nswindow toggleFullScreen:nil];
     }
 }
@@ -17,10 +15,9 @@ void toggleNativeMacOSFullscreen(SDL_Window *window) {
 //Just a simple function to check if we are in native macOS fullscreen mode. Needed to avoid the game from crashing
 //when going from native to SDL fullscreening modes or getting other forms of breakage.
 bool isNativeMacOSFullscreenActive(SDL_Window *window) {
-    SDL_SysWMinfo wmInfo;
-    SDL_VERSION(&wmInfo.version);
-    if (SDL_GetWindowWMInfo(window, &wmInfo)) {
-        NSWindow *nswindow = wmInfo.info.cocoa.window;
+    NSWindow *nswindow = (__bridge NSWindow *)SDL_GetPointerProperty(
+        SDL_GetWindowProperties(window), SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, nullptr);
+    if (nswindow != nil) {
         return (([nswindow styleMask] & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen);
     }
     return false;

--- a/src/ship/window/FileDrop.cpp
+++ b/src/ship/window/FileDrop.cpp
@@ -26,7 +26,7 @@ FileDrop::~FileDrop() {
     }
 }
 
-void FileDrop::SetDroppedFile(char* path) {
+void FileDrop::SetDroppedFile(const char* path) {
     if (mPath != nullptr) {
         SPDLOG_WARN("Overwriting dropped file: {} with {}", mPath, path);
         free(mPath);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(libultraship_tests
     resource_type_tests.cpp
     archive_self_tests.cpp
     connected_physical_device_manager_tests.cpp
+    gfx_sdl_window_tests.cpp
 )
 
 if(ENABLE_SCRIPTING)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(libultraship_tests
     path_diskfile_tests.cpp
     resource_type_tests.cpp
     archive_self_tests.cpp
+    connected_physical_device_manager_tests.cpp
 )
 
 if(ENABLE_SCRIPTING)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(libultraship_tests
     archive_self_tests.cpp
     connected_physical_device_manager_tests.cpp
     gfx_sdl_window_tests.cpp
+    rumble_mapping_factory_tests.cpp
 )
 
 if(ENABLE_SCRIPTING)

--- a/tests/connected_physical_device_manager_tests.cpp
+++ b/tests/connected_physical_device_manager_tests.cpp
@@ -1,7 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <string>
-
 #include "ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.h"
 
 namespace Ship {
@@ -14,17 +12,17 @@ class ConnectedPhysicalDeviceManagerTest : public testing::Test {
 
         SDL_VirtualJoystickDesc desc;
         SDL_INIT_INTERFACE(&desc);
-        desc.type = SDL_JOYSTICK_TYPE_UNKNOWN;
+        desc.type = SDL_JOYSTICK_TYPE_GAMEPAD;
         desc.vendor_id = 0x1209;
         desc.product_id = 0x0001;
         desc.naxes = 2;
         desc.nbuttons = 1;
+        desc.button_mask = 1 << SDL_GAMEPAD_BUTTON_SOUTH;
+        desc.axis_mask = (1 << SDL_GAMEPAD_AXIS_LEFTX) | (1 << SDL_GAMEPAD_AXIS_LEFTY);
         desc.name = "LUS virtual gamepad";
 
         mInstanceId = SDL_AttachVirtualJoystick(&desc);
         ASSERT_NE(mInstanceId, 0u) << SDL_GetError();
-        ASSERT_TRUE(SetMapping("LUS virtual gamepad")) << SDL_GetError();
-        ASSERT_TRUE(SDL_IsGamepad(mInstanceId));
     }
 
     void TearDown() override {
@@ -35,16 +33,9 @@ class ConnectedPhysicalDeviceManagerTest : public testing::Test {
     }
 
     SDL_JoystickID mInstanceId = 0;
-
-    bool SetMapping(const char* name) const {
-        char guid[33] = "";
-        SDL_GUIDToString(SDL_GetJoystickGUIDForID(mInstanceId), guid, sizeof(guid));
-        const std::string mapping = std::string(guid) + "," + name + ",a:b0,leftx:a0,lefty:a1,";
-        return SDL_SetGamepadMapping(mInstanceId, mapping.c_str());
-    }
 };
 
-TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshPreservesHandleAndUpdatesNameForConnectedGamepad) {
+TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshPreservesHandleForConnectedGamepad) {
     ConnectedPhysicalDeviceManager manager;
 
     manager.RefreshConnectedSDLGamepads();
@@ -53,43 +44,16 @@ TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshPreservesHandleAndUpdatesNameF
     SDL_Gamepad* const firstHandle = firstScan.at(mInstanceId);
     ASSERT_NE(firstHandle, nullptr);
 
-    ASSERT_TRUE(SetMapping("Remapped LUS virtual gamepad")) << SDL_GetError();
     manager.RefreshConnectedSDLGamepads();
     const auto secondScan = manager.GetConnectedSDLGamepadsForPort(0);
     ASSERT_TRUE(secondScan.contains(mInstanceId));
     EXPECT_EQ(secondScan.at(mInstanceId), firstHandle);
-    EXPECT_EQ(manager.GetConnectedSDLGamepadNames().at(mInstanceId), "Remapped LUS virtual gamepad");
-}
-
-TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshClosesHandleWhenGamepadMappingIsRemoved) {
-    ConnectedPhysicalDeviceManager manager;
-
-    manager.RefreshConnectedSDLGamepads();
-    ASSERT_TRUE(manager.GetConnectedSDLGamepadsForPort(0).contains(mInstanceId));
-    ASSERT_NE(SDL_GetGamepadFromID(mInstanceId), nullptr);
-
-    ASSERT_TRUE(SDL_ReloadGamepadMappings()) << SDL_GetError();
-    ASSERT_FALSE(SDL_IsGamepad(mInstanceId));
-    manager.RefreshConnectedSDLGamepads();
-
-    EXPECT_FALSE(manager.GetConnectedSDLGamepadsForPort(0).contains(mInstanceId));
-    EXPECT_FALSE(manager.GetConnectedSDLGamepadNames().contains(mInstanceId));
-    EXPECT_EQ(SDL_GetGamepadFromID(mInstanceId), nullptr);
-}
-
-TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshClosesHandleWhenJoystickIsDetached) {
-    ConnectedPhysicalDeviceManager manager;
-
-    manager.RefreshConnectedSDLGamepads();
-    ASSERT_TRUE(manager.GetConnectedSDLGamepadsForPort(0).contains(mInstanceId));
-    ASSERT_NE(SDL_GetGamepadFromID(mInstanceId), nullptr);
 
     const SDL_JoystickID detachedInstanceId = mInstanceId;
     ASSERT_TRUE(SDL_DetachVirtualJoystick(detachedInstanceId));
     mInstanceId = 0;
     manager.RefreshConnectedSDLGamepads();
     EXPECT_FALSE(manager.GetConnectedSDLGamepadsForPort(0).contains(detachedInstanceId));
-    EXPECT_EQ(SDL_GetGamepadFromID(detachedInstanceId), nullptr);
 }
 
 } // namespace

--- a/tests/connected_physical_device_manager_tests.cpp
+++ b/tests/connected_physical_device_manager_tests.cpp
@@ -54,6 +54,7 @@ TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshPreservesHandleForConnectedGam
     mInstanceId = 0;
     manager.RefreshConnectedSDLGamepads();
     EXPECT_FALSE(manager.GetConnectedSDLGamepadsForPort(0).contains(detachedInstanceId));
+    EXPECT_EQ(SDL_GetGamepadFromID(detachedInstanceId), nullptr);
 }
 
 } // namespace

--- a/tests/connected_physical_device_manager_tests.cpp
+++ b/tests/connected_physical_device_manager_tests.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include "ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.h"
 
 namespace Ship {
@@ -12,17 +14,17 @@ class ConnectedPhysicalDeviceManagerTest : public testing::Test {
 
         SDL_VirtualJoystickDesc desc;
         SDL_INIT_INTERFACE(&desc);
-        desc.type = SDL_JOYSTICK_TYPE_GAMEPAD;
+        desc.type = SDL_JOYSTICK_TYPE_UNKNOWN;
         desc.vendor_id = 0x1209;
         desc.product_id = 0x0001;
         desc.naxes = 2;
         desc.nbuttons = 1;
-        desc.button_mask = 1 << SDL_GAMEPAD_BUTTON_SOUTH;
-        desc.axis_mask = (1 << SDL_GAMEPAD_AXIS_LEFTX) | (1 << SDL_GAMEPAD_AXIS_LEFTY);
         desc.name = "LUS virtual gamepad";
 
         mInstanceId = SDL_AttachVirtualJoystick(&desc);
         ASSERT_NE(mInstanceId, 0u) << SDL_GetError();
+        ASSERT_TRUE(SetMapping("LUS virtual gamepad")) << SDL_GetError();
+        ASSERT_TRUE(SDL_IsGamepad(mInstanceId));
     }
 
     void TearDown() override {
@@ -33,9 +35,16 @@ class ConnectedPhysicalDeviceManagerTest : public testing::Test {
     }
 
     SDL_JoystickID mInstanceId = 0;
+
+    bool SetMapping(const char* name) const {
+        char guid[33] = "";
+        SDL_GUIDToString(SDL_GetJoystickGUIDForID(mInstanceId), guid, sizeof(guid));
+        const std::string mapping = std::string(guid) + "," + name + ",a:b0,leftx:a0,lefty:a1,";
+        return SDL_SetGamepadMapping(mInstanceId, mapping.c_str());
+    }
 };
 
-TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshPreservesHandleForConnectedGamepad) {
+TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshPreservesHandleAndUpdatesNameForConnectedGamepad) {
     ConnectedPhysicalDeviceManager manager;
 
     manager.RefreshConnectedSDLGamepads();
@@ -44,16 +53,27 @@ TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshPreservesHandleForConnectedGam
     SDL_Gamepad* const firstHandle = firstScan.at(mInstanceId);
     ASSERT_NE(firstHandle, nullptr);
 
+    ASSERT_TRUE(SetMapping("Remapped LUS virtual gamepad")) << SDL_GetError();
     manager.RefreshConnectedSDLGamepads();
     const auto secondScan = manager.GetConnectedSDLGamepadsForPort(0);
     ASSERT_TRUE(secondScan.contains(mInstanceId));
     EXPECT_EQ(secondScan.at(mInstanceId), firstHandle);
+    EXPECT_EQ(manager.GetConnectedSDLGamepadNames().at(mInstanceId), "Remapped LUS virtual gamepad");
+}
+
+TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshClosesHandleWhenJoystickIsDetached) {
+    ConnectedPhysicalDeviceManager manager;
+
+    manager.RefreshConnectedSDLGamepads();
+    ASSERT_TRUE(manager.GetConnectedSDLGamepadsForPort(0).contains(mInstanceId));
+    ASSERT_NE(SDL_GetGamepadFromID(mInstanceId), nullptr);
 
     const SDL_JoystickID detachedInstanceId = mInstanceId;
     ASSERT_TRUE(SDL_DetachVirtualJoystick(detachedInstanceId));
     mInstanceId = 0;
     manager.RefreshConnectedSDLGamepads();
     EXPECT_FALSE(manager.GetConnectedSDLGamepadsForPort(0).contains(detachedInstanceId));
+    EXPECT_EQ(SDL_GetGamepadFromID(detachedInstanceId), nullptr);
 }
 
 } // namespace

--- a/tests/connected_physical_device_manager_tests.cpp
+++ b/tests/connected_physical_device_manager_tests.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+
+#include "ship/controller/physicaldevice/ConnectedPhysicalDeviceManager.h"
+
+namespace Ship {
+namespace {
+
+class ConnectedPhysicalDeviceManagerTest : public testing::Test {
+  protected:
+    void SetUp() override {
+        ASSERT_TRUE(SDL_InitSubSystem(SDL_INIT_GAMEPAD));
+
+        SDL_VirtualJoystickDesc desc;
+        SDL_INIT_INTERFACE(&desc);
+        desc.type = SDL_JOYSTICK_TYPE_GAMEPAD;
+        desc.vendor_id = 0x1209;
+        desc.product_id = 0x0001;
+        desc.naxes = 2;
+        desc.nbuttons = 1;
+        desc.button_mask = 1 << SDL_GAMEPAD_BUTTON_SOUTH;
+        desc.axis_mask = (1 << SDL_GAMEPAD_AXIS_LEFTX) | (1 << SDL_GAMEPAD_AXIS_LEFTY);
+        desc.name = "LUS virtual gamepad";
+
+        mInstanceId = SDL_AttachVirtualJoystick(&desc);
+        ASSERT_NE(mInstanceId, 0u) << SDL_GetError();
+    }
+
+    void TearDown() override {
+        if (mInstanceId != 0) {
+            SDL_DetachVirtualJoystick(mInstanceId);
+        }
+        SDL_QuitSubSystem(SDL_INIT_GAMEPAD);
+    }
+
+    SDL_JoystickID mInstanceId = 0;
+};
+
+TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshPreservesHandleForConnectedGamepad) {
+    ConnectedPhysicalDeviceManager manager;
+
+    manager.RefreshConnectedSDLGamepads();
+    const auto firstScan = manager.GetConnectedSDLGamepadsForPort(0);
+    ASSERT_TRUE(firstScan.contains(mInstanceId));
+    SDL_Gamepad* const firstHandle = firstScan.at(mInstanceId);
+    ASSERT_NE(firstHandle, nullptr);
+
+    manager.RefreshConnectedSDLGamepads();
+    const auto secondScan = manager.GetConnectedSDLGamepadsForPort(0);
+    ASSERT_TRUE(secondScan.contains(mInstanceId));
+    EXPECT_EQ(secondScan.at(mInstanceId), firstHandle);
+
+    const SDL_JoystickID detachedInstanceId = mInstanceId;
+    ASSERT_TRUE(SDL_DetachVirtualJoystick(detachedInstanceId));
+    mInstanceId = 0;
+    manager.RefreshConnectedSDLGamepads();
+    EXPECT_FALSE(manager.GetConnectedSDLGamepadsForPort(0).contains(detachedInstanceId));
+}
+
+} // namespace
+} // namespace Ship

--- a/tests/connected_physical_device_manager_tests.cpp
+++ b/tests/connected_physical_device_manager_tests.cpp
@@ -61,6 +61,22 @@ TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshPreservesHandleAndUpdatesNameF
     EXPECT_EQ(manager.GetConnectedSDLGamepadNames().at(mInstanceId), "Remapped LUS virtual gamepad");
 }
 
+TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshClosesHandleWhenGamepadMappingIsRemoved) {
+    ConnectedPhysicalDeviceManager manager;
+
+    manager.RefreshConnectedSDLGamepads();
+    ASSERT_TRUE(manager.GetConnectedSDLGamepadsForPort(0).contains(mInstanceId));
+    ASSERT_NE(SDL_GetGamepadFromID(mInstanceId), nullptr);
+
+    ASSERT_TRUE(SDL_ReloadGamepadMappings()) << SDL_GetError();
+    ASSERT_FALSE(SDL_IsGamepad(mInstanceId));
+    manager.RefreshConnectedSDLGamepads();
+
+    EXPECT_FALSE(manager.GetConnectedSDLGamepadsForPort(0).contains(mInstanceId));
+    EXPECT_FALSE(manager.GetConnectedSDLGamepadNames().contains(mInstanceId));
+    EXPECT_EQ(SDL_GetGamepadFromID(mInstanceId), nullptr);
+}
+
 TEST_F(ConnectedPhysicalDeviceManagerTest, RefreshClosesHandleWhenJoystickIsDetached) {
     ConnectedPhysicalDeviceManager manager;
 

--- a/tests/gfx_sdl_window_tests.cpp
+++ b/tests/gfx_sdl_window_tests.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include <SDL3/SDL.h>
+
+#include "fast/backends/gfx_sdl.h"
+
+#if defined(ENABLE_OPENGL) && !defined(__APPLE__)
+
+namespace Fast {
+namespace {
+
+class GfxWindowBackendSDLTest : public testing::Test {
+  protected:
+    void SetUp() override {
+        ASSERT_TRUE(SDL_InitSubSystem(SDL_INIT_EVENTS));
+        SDL_FlushEvents(SDL_EVENT_FIRST, SDL_EVENT_LAST);
+    }
+
+    void TearDown() override {
+        SDL_FlushEvents(SDL_EVENT_FIRST, SDL_EVENT_LAST);
+        SDL_QuitSubSystem(SDL_INIT_EVENTS);
+    }
+};
+
+TEST_F(GfxWindowBackendSDLTest, HandleEventsLeavesGamepadLifecycleEventsQueued) {
+    constexpr SDL_EventType lifecycleEvents[] = {
+        SDL_EVENT_GAMEPAD_ADDED,
+        SDL_EVENT_GAMEPAD_REMOVED,
+        SDL_EVENT_GAMEPAD_REMAPPED,
+    };
+
+    for (const SDL_EventType type : lifecycleEvents) {
+        SDL_Event event{};
+        event.type = type;
+        ASSERT_TRUE(SDL_PushEvent(&event));
+    }
+
+    GfxWindowBackendSDL2 backend;
+    backend.HandleEvents();
+
+    for (const SDL_EventType type : lifecycleEvents) {
+        EXPECT_TRUE(SDL_HasEvent(type));
+    }
+}
+
+} // namespace
+} // namespace Fast
+
+#endif

--- a/tests/gfx_sdl_window_tests.cpp
+++ b/tests/gfx_sdl_window_tests.cpp
@@ -22,11 +22,10 @@ class GfxWindowBackendSDLTest : public testing::Test {
     }
 };
 
-TEST_F(GfxWindowBackendSDLTest, HandleEventsLeavesGamepadLifecycleEventsQueued) {
+TEST_F(GfxWindowBackendSDLTest, HandleEventsLeavesGamepadAddRemoveEventsQueued) {
     constexpr SDL_EventType lifecycleEvents[] = {
         SDL_EVENT_GAMEPAD_ADDED,
         SDL_EVENT_GAMEPAD_REMOVED,
-        SDL_EVENT_GAMEPAD_REMAPPED,
     };
 
     for (const SDL_EventType type : lifecycleEvents) {
@@ -35,7 +34,7 @@ TEST_F(GfxWindowBackendSDLTest, HandleEventsLeavesGamepadLifecycleEventsQueued) 
         ASSERT_TRUE(SDL_PushEvent(&event));
     }
 
-    GfxWindowBackendSDL2 backend;
+    GfxWindowBackendSDL backend;
     backend.HandleEvents();
 
     for (const SDL_EventType type : lifecycleEvents) {

--- a/tests/rumble_mapping_factory_tests.cpp
+++ b/tests/rumble_mapping_factory_tests.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+
+#include "ship/controller/controldevice/controller/mapping/factories/RumbleMappingFactory.h"
+
+namespace Ship {
+namespace {
+
+TEST(RumbleMappingFactoryTest, CreatesDefaultMappingOnlyForSDLGamepads) {
+    EXPECT_TRUE(RumbleMappingFactory::CreateDefaultSDLRumbleMappings(PhysicalDeviceType::Keyboard, 0, nullptr, nullptr)
+                    .empty());
+    EXPECT_TRUE(
+        RumbleMappingFactory::CreateDefaultSDLRumbleMappings(PhysicalDeviceType::Mouse, 0, nullptr, nullptr).empty());
+
+    const auto mappings =
+        RumbleMappingFactory::CreateDefaultSDLRumbleMappings(PhysicalDeviceType::SDLGamepad, 0, nullptr, nullptr);
+    ASSERT_EQ(mappings.size(), 1);
+    EXPECT_EQ(mappings.front()->GetPhysicalDeviceType(), PhysicalDeviceType::SDLGamepad);
+}
+
+} // namespace
+} // namespace Ship


### PR DESCRIPTION
## Summary

- move libultraship's window, input, controller, and SDL audio paths to SDL3
- update the ImGui backend and platform dependency setup for SDL3
- preserve gamepad handles across hotplug and correctly round display refresh rates
- retain centered mouse capture through SDL3's window mouse rectangle
- skip desktop GLEW initialization when building the OpenGL ES backend

## Why

This supersedes #783 with the migration replayed on current `main`. It carries forward the later [`sdl3-updated`](https://github.com/briaguya0/libultraship/tree/sdl3-updated) implementation used by Shipwright #4859 while closing the remaining SDL3 migration gaps.

## Testing

- Windows x64 Release build
- focused connected-device and SDL window backend tests (2/2)
- all 618 libultraship tests