### PR TITLE
Check complete pull requests with clang-tidy

### DIFF
--- a/.github/workflows/tidy-format-validation.yml
+++ b/.github/workflows/tidy-format-validation.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -53,7 +53,7 @@ jobs:
           mkdir clang-tidy-result
       - name: Analyze
         run: |
-          git diff -U0 HEAD^ -- 'src' 'include' ':!include/libultraship/color.h' ':!include/ship/utils/color.h' ':!include/libultraship/libultra/*' ':!src/libultraship/libultra/*' ':!src/fast/*' ':!include/fast/*' ':!src/ship/utils/AppleFolderManager.mm' | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+          git diff -U0 "${{ github.event.pull_request.base.sha }}"...HEAD -- 'src' 'include' ':!include/libultraship/color.h' ':!include/ship/utils/color.h' ':!include/libultraship/libultra/*' ':!src/libultraship/libultra/*' ':!src/fast/*' ':!include/fast/*' ':!src/ship/utils/AppleFolderManager.mm' | clang-tidy-diff -p1 -path build -regex='.*\.(cpp|cc|cxx|mm)$' -export-fixes clang-tidy-result/fixes.yml
       - name: Save PR metadata
         run: |
           echo ${{ github.event.number }} > clang-tidy-result/pr-id.txt

--- a/.github/workflows/tidy-format-validation.yml
+++ b/.github/workflows/tidy-format-validation.yml
@@ -53,7 +53,7 @@ jobs:
           mkdir clang-tidy-result
       - name: Analyze
         run: |
-          git diff -U0 "${{ github.event.pull_request.base.sha }}"...HEAD -- 'src' 'include' ':!include/libultraship/color.h' ':!include/ship/utils/color.h' ':!include/libultraship/libultra/*' ':!src/libultraship/libultra/*' ':!src/fast/*' ':!include/fast/*' ':!src/ship/utils/AppleFolderManager.mm' | clang-tidy-diff -p1 -path build -regex='.*\.(cpp|cc|cxx|mm)$' -export-fixes clang-tidy-result/fixes.yml
+          git diff -U0 "${{ github.event.pull_request.base.sha }}"...HEAD -- 'src' 'include' ':!include/libultraship/color.h' ':!include/ship/utils/color.h' ':!include/libultraship/libultra/*' ':!src/libultraship/libultra/*' ':!src/fast/*' ':!include/fast/*' ':!src/ship/utils/AppleFolderManager.mm' ':!src/ship/utils/glob.c' | clang-tidy-diff -p1 -path build -extra-arg=-xc++ -extra-arg=-std=gnu++20 -export-fixes clang-tidy-result/fixes.yml
       - name: Save PR metadata
         run: |
           echo ${{ github.event.number }} > clang-tidy-result/pr-id.txt


### PR DESCRIPTION
## Summary

- run clang-tidy against the complete pull-request range
- keep changed headers in analysis by forcing C++20 parsing
- exclude only the C translation unit `src/ship/utils/glob.c`

## Testing

- parsed the workflow with PyYAML and verified its diff-selection contract
- verified the SDL3 pull-request range selects 15 changed headers, including `MobileImpl.h`, while excluding C inputs
- analyzed `MobileImpl.h` through the LLVM 14 diff driver and a real compile database with the C++20 overrides