### PR TITLE
Fix warnings (cherry-pick #1126)

### DIFF
--- a/include/fast/lus_gbi.h
+++ b/include/fast/lus_gbi.h
@@ -134,6 +134,9 @@ constexpr int8_t RDP_G_TRI1_WIDE = OPCODE(0x49);
 
 /* macros for command parsing: */
 #define GDMACMD(x) (x)
+#ifdef GIMMCMD
+#undef GIMMCMD
+#endif
 #define GIMMCMD(x) = OPCODE(G_IMMFIRST - (x))
 #define GRDPCMD(x) (0xff - (x))
 

--- a/include/ship/utils/binarytools/BitConverter.h
+++ b/include/ship/utils/binarytools/BitConverter.h
@@ -241,12 +241,12 @@ class BitConverter {
         switch (firstByte) {
             case 0x37: // v64
                 for (size_t pos = 0; pos < (romSize / 2); pos++) {
-                    ((uint16_t*)rom)[pos] = ToUInt16BE(rom, pos * 2);
+                    ((uint16_t*)rom)[pos] = ToUInt16BE(rom, static_cast<int32_t>(pos * 2));
                 }
                 break;
             case 0x40: // n64
                 for (size_t pos = 0; pos < (romSize / 4); pos++) {
-                    ((uint32_t*)rom)[pos] = ToUInt32BE(rom, pos * 4);
+                    ((uint32_t*)rom)[pos] = ToUInt32BE(rom, static_cast<int32_t>(pos * 4));
                 }
                 break;
             case 0x80: // z64


### PR DESCRIPTION
Cherry-picks #1126 (`2cc049d`) from `port-maintenance` onto `main`. Authored by @Pepe20129; applies with no conflicts.

Both warnings are still present on `main` verbatim, and both are in headers, so they propagate into port builds:

- `include/fast/lus_gbi.h:137` — `GIMMCMD` is defined with no redefinition guard, which warns in ports whose own `gbi.h` already defines it.
- `include/ship/utils/binarytools/BitConverter.h:244,249` — `ByteSwap` passes `size_t` expressions (`pos * 2`, `pos * 4`) to `ToUInt16BE`/`ToUInt32BE`, which take `int32_t offset` (`:90`, `:116`). Now explicitly cast.

Part of #1152.
