### PR TITLE
fast3d texture clamp/stride fixes (cherry-pick #1118, #1143, #1172, #1151, #1121, #1135)

### DIFF
--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -295,6 +295,7 @@ struct RDP {
         uint8_t fmt;
         uint8_t siz;
         uint8_t cms, cmt;
+        uint8_t masks, maskt; // mask exponents from SetTile; 2^mask is the WRAP/MIRROR period
         uint8_t shifts, shiftt;
         float uls, ult, lrs, lrt;
         uint16_t tmem; // 0-511, in 64-bit word units

--- a/include/ship/resource/ResourceManager.h
+++ b/include/ship/resource/ResourceManager.h
@@ -208,6 +208,15 @@ class ResourceManager : public Component {
     size_t UnloadResource(const std::string& filePath);
 
     /**
+     * @brief Inserts a runtime-built resource into the cache so LoadResource[Process] returns it by
+     *        path, without any backing archive file. Used for textures synthesized at runtime.
+     *        Evict with UnloadResource(filePath).
+     * @param filePath Virtual path the resource will be retrievable under.
+     * @param resource The resource to cache.
+     */
+    void CacheExternalResource(const std::string& filePath, std::shared_ptr<IResource> resource);
+
+    /**
      * @brief Writes raw data into an archive and optionally evicts the stale cache entry.
      * @param identifier Identifier of the resource to write.
      * @param data       Raw bytes to write.

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -580,10 +580,12 @@ void Interpreter::ImportTextureRgba16(int tile, bool importReplacement) {
         renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13; // < 1.625x
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
-    if ((pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
+    // HD replacement textures must still clamp to the rendered tile region
+    bool isHd = metadata->h_byte_scale != 1 || metadata->v_pixel_scale != 1;
+    if ((isHd || pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if ((pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
+    if ((isHd || pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -648,10 +650,12 @@ void Interpreter::ImportTextureRgba32(int tile, bool importReplacement) {
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
-    if ((pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
+    // HD replacement textures must still clamp to the rendered tile region
+    bool isHd = metadata->h_byte_scale != 1 || metadata->v_pixel_scale != 1;
+    if ((isHd || pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if ((pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
+    if ((isHd || pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -958,10 +962,12 @@ void Interpreter::ImportTextureCi4(int tile, bool importReplacement) {
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
-    if ((pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
+    // HD replacement textures must still clamp to the rendered tile region
+    bool isHd = metadata->h_byte_scale != 1 || metadata->v_pixel_scale != 1;
+    if ((isHd || pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if ((pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
+    if ((isHd || pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -1051,10 +1057,12 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
-    if ((pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
+    // HD replacement textures must still clamp to the rendered tile region
+    bool isHd = metadata->h_byte_scale != 1 || metadata->v_pixel_scale != 1;
+    if ((isHd || pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
         width = tile_w;
     }
-    if ((pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
+    if ((isHd || pyramidLike || clampT) && tile_h > 0 && tile_h < height) {
         height = tile_h;
     }
 
@@ -1157,7 +1165,10 @@ void Interpreter::ImportTextureRaw(int tile, bool importReplacement) {
         memset(mTexUploadBuffer + resourceImageSizeBytes, 0, numLoadedBytes - resourceImageSizeBytes);
     }
 
-    mRapi->UploadTexture(mTexUploadBuffer, resultNewLineSize / 4, resultNewHeight);
+    // Describe the buffer by what was actually packed (the loaded HD stride)
+    uint32_t uploadWidth = safeLineSizeBytes / 4;
+    uint32_t uploadHeight = safeLineSizeBytes > 0 ? safeLoadedBytes / safeLineSizeBytes : 0;
+    mRapi->UploadTexture(mTexUploadBuffer, uploadWidth, uploadHeight);
 }
 
 void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
@@ -1930,10 +1941,13 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             uint32_t loadedPx = tex_width[i] * tex_height[i];
             uint32_t renderedPx = tex_width2[i] * tex_height2[i];
             bool pyrLike = renderedPx > 0 && loadedPx > renderedPx && loadedPx * 8 < renderedPx * 13;
-            if ((pyrLike || (cms & G_TX_CLAMP)) && tex_width2[i] > 0 && tex_width2[i] < tex_width[i]) {
+            // HD replacements must clamp to the tile region
+            bool isHd = mRdp->loaded_texture[i].raw_tex_metadata.h_byte_scale != 1 ||
+                        mRdp->loaded_texture[i].raw_tex_metadata.v_pixel_scale != 1;
+            if ((isHd || pyrLike || (cms & G_TX_CLAMP)) && tex_width2[i] > 0 && tex_width2[i] < tex_width[i]) {
                 tex_width[i] = tex_width2[i];
             }
-            if ((pyrLike || (cmt & G_TX_CLAMP)) && tex_height2[i] > 0 && tex_height2[i] < tex_height[i]) {
+            if ((isHd || pyrLike || (cmt & G_TX_CLAMP)) && tex_height2[i] > 0 && tex_height2[i] < tex_height[i]) {
                 tex_height[i] = tex_height2[i];
             }
 
@@ -2485,7 +2499,13 @@ void Interpreter::GfxDpLoadBlock(uint8_t tile, uint32_t uls, uint32_t ult, uint3
     // The standard gDPLoadTextureBlock macro sets width=1, but manually-built DL
     // commands may set the real pixel width.
     uint32_t actual_line_bytes = size_bytes;
-    if (mRdp->texture_to_load.width > 1) {
+    const RawTexMetadata& blkMeta = mRdp->texture_to_load.raw_tex_metadata;
+    bool blkHd = blkMeta.h_byte_scale != 1 || blkMeta.v_pixel_scale != 1;
+    if (mRdp->texture_to_load.width > 1 && blkHd && blkMeta.height > 0 && size_bytes % blkMeta.height == 0) {
+        // HD-upscaled textures report a sentinel SetTextureImage width, so the per-line stride
+        // derived from it is bogus. The resource's stored height is authoritative.
+        actual_line_bytes = size_bytes / blkMeta.height;
+    } else if (mRdp->texture_to_load.width > 1) {
         uint32_t candidate;
         switch (mRdp->texture_to_load.siz) {
             case G_IM_SIZ_4b:

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -546,6 +546,14 @@ static uint32_t GetEffectiveLineSize(uint32_t lineSizeBytes, uint32_t fullImageL
     return tileLineSizeBytes;
 }
 
+static uint32_t GetTileSizeFromCoordinates(float low, float high) {
+    float size = (high - low + 4.0f) / 4.0f;
+    if (size <= 0.0f) {
+        return 0;
+    }
+    return static_cast<uint32_t>(lroundf(size));
+}
+
 void Interpreter::ImportTextureRgba16(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata;
     const uint8_t* addr =
@@ -572,8 +580,8 @@ void Interpreter::ImportTextureRgba16(int tile, bool importReplacement) {
     // Clamp to the rendered region only when the loaded buffer is ~1.33x of it (mipmap
     // pyramid signature). Window-scrolling tiles have loaded ≈ rendered or loaded >> rendered;
     // skip both. CLAMP wrap mode always opts in.
-    uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
-    uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+    uint32_t tile_w = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].uls, mRdp->texture_tile[tile].lrs);
+    uint32_t tile_h = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].ult, mRdp->texture_tile[tile].lrt);
     uint32_t loadedPixels = width * height;
     uint32_t renderedPixels = tile_w * tile_h;
     bool pyramidLike =
@@ -653,8 +661,8 @@ void Interpreter::ImportTextureRgba32(int tile, bool importReplacement) {
     // Clamp to the rendered region only when the loaded buffer is ~1.33x of it (mipmap
     // pyramid signature). Window-scrolling tiles have loaded ≈ rendered or loaded >> rendered;
     // skip both. CLAMP wrap mode always opts in.
-    uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
-    uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+    uint32_t tile_w = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].uls, mRdp->texture_tile[tile].lrs);
+    uint32_t tile_h = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].ult, mRdp->texture_tile[tile].lrt);
     uint32_t loadedPixels = width * height;
     uint32_t renderedPixels = tile_w * tile_h;
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
@@ -975,8 +983,8 @@ void Interpreter::ImportTextureCi4(int tile, bool importReplacement) {
     // Clamp to the rendered region only when the loaded buffer is ~1.33x of it (mipmap
     // pyramid signature). Window-scrolling tiles have loaded ≈ rendered or loaded >> rendered;
     // skip both. CLAMP wrap mode always opts in.
-    uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
-    uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+    uint32_t tile_w = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].uls, mRdp->texture_tile[tile].lrs);
+    uint32_t tile_h = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].ult, mRdp->texture_tile[tile].lrt);
     uint32_t loadedPixels = width * height;
     uint32_t renderedPixels = tile_w * tile_h;
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
@@ -1080,8 +1088,8 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
     // Clamp to the rendered region only when the loaded buffer is ~1.33x of it (mipmap
     // pyramid signature). Window-scrolling tiles have loaded ≈ rendered or loaded >> rendered;
     // skip both. CLAMP wrap mode always opts in.
-    uint32_t tile_w = (uint32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
-    uint32_t tile_h = (uint32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+    uint32_t tile_w = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].uls, mRdp->texture_tile[tile].lrs);
+    uint32_t tile_h = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].ult, mRdp->texture_tile[tile].lrt);
     uint32_t loadedPixels = width * height;
     uint32_t renderedPixels = tile_w * tile_h;
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
@@ -1985,8 +1993,8 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             }
             tex_width[i] = line_size;
 
-            tex_width2[i] = (uint32_t)(int32_t)((mRdp->texture_tile[tile].lrs - mRdp->texture_tile[tile].uls + 4) / 4);
-            tex_height2[i] = (uint32_t)(int32_t)((mRdp->texture_tile[tile].lrt - mRdp->texture_tile[tile].ult + 4) / 4);
+            tex_width2[i] = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].uls, mRdp->texture_tile[tile].lrs);
+            tex_height2[i] = GetTileSizeFromCoordinates(mRdp->texture_tile[tile].ult, mRdp->texture_tile[tile].lrt);
 
             // Same pyramid-like ratio gate as ImportTexture: only clamp when loaded pixels
             // are close to rendered pixels (mipmap), not when much bigger (window scroll).

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -580,6 +580,16 @@ void Interpreter::ImportTextureRgba16(int tile, bool importReplacement) {
         renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13; // < 1.625x
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
+    // A masked axis wraps every 2^mask texels, so trim an over-loaded texture back to that.
+    // Skip a mask smaller than the tile region though - that's stale tile state, not a real load.
+    uint32_t maskW = mRdp->texture_tile[tile].masks;
+    uint32_t maskH = mRdp->texture_tile[tile].maskt;
+    if (maskW != 0 && (1u << maskW) >= tile_w && (1u << maskW) < width) {
+        width = 1u << maskW;
+    }
+    if (maskH != 0 && (1u << maskH) >= tile_h && (1u << maskH) < height) {
+        height = 1u << maskH;
+    }
     // HD replacement textures must still clamp to the rendered tile region
     bool isHd = metadata->h_byte_scale != 1 || metadata->v_pixel_scale != 1;
     if ((isHd || pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
@@ -650,6 +660,16 @@ void Interpreter::ImportTextureRgba32(int tile, bool importReplacement) {
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
+    // A masked axis wraps every 2^mask texels, so trim an over-loaded texture back to that.
+    // Skip a mask smaller than the tile region though - that's stale tile state, not a real load.
+    uint32_t maskW = mRdp->texture_tile[tile].masks;
+    uint32_t maskH = mRdp->texture_tile[tile].maskt;
+    if (maskW != 0 && (1u << maskW) >= tile_w && (1u << maskW) < width) {
+        width = 1u << maskW;
+    }
+    if (maskH != 0 && (1u << maskH) >= tile_h && (1u << maskH) < height) {
+        height = 1u << maskH;
+    }
     // HD replacement textures must still clamp to the rendered tile region
     bool isHd = metadata->h_byte_scale != 1 || metadata->v_pixel_scale != 1;
     if ((isHd || pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
@@ -962,6 +982,16 @@ void Interpreter::ImportTextureCi4(int tile, bool importReplacement) {
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
+    // A masked axis wraps every 2^mask texels, so trim an over-loaded texture back to that.
+    // Skip a mask smaller than the tile region though - that's stale tile state, not a real load.
+    uint32_t maskW = mRdp->texture_tile[tile].masks;
+    uint32_t maskH = mRdp->texture_tile[tile].maskt;
+    if (maskW != 0 && (1u << maskW) >= tile_w && (1u << maskW) < width) {
+        width = 1u << maskW;
+    }
+    if (maskH != 0 && (1u << maskH) >= tile_h && (1u << maskH) < height) {
+        height = 1u << maskH;
+    }
     // HD replacement textures must still clamp to the rendered tile region
     bool isHd = metadata->h_byte_scale != 1 || metadata->v_pixel_scale != 1;
     if ((isHd || pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
@@ -1057,6 +1087,16 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
     bool pyramidLike = renderedPixels > 0 && loadedPixels > renderedPixels && loadedPixels * 8 < renderedPixels * 13;
     bool clampS = (mRdp->texture_tile[tile].cms & G_TX_CLAMP) != 0;
     bool clampT = (mRdp->texture_tile[tile].cmt & G_TX_CLAMP) != 0;
+    // A masked axis wraps every 2^mask texels, so trim an over-loaded texture back to that.
+    // Skip a mask smaller than the tile region though - that's stale tile state, not a real load.
+    uint32_t maskW = mRdp->texture_tile[tile].masks;
+    uint32_t maskH = mRdp->texture_tile[tile].maskt;
+    if (maskW != 0 && (1u << maskW) >= tile_w && (1u << maskW) < width) {
+        width = 1u << maskW;
+    }
+    if (maskH != 0 && (1u << maskH) >= tile_h && (1u << maskH) < height) {
+        height = 1u << maskH;
+    }
     // HD replacement textures must still clamp to the rendered tile region
     bool isHd = metadata->h_byte_scale != 1 || metadata->v_pixel_scale != 1;
     if ((isHd || pyramidLike || clampS) && tile_w > 0 && tile_w < width) {
@@ -1953,6 +1993,16 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
             uint32_t loadedPx = tex_width[i] * tex_height[i];
             uint32_t renderedPx = tex_width2[i] * tex_height2[i];
             bool pyrLike = renderedPx > 0 && loadedPx > renderedPx && loadedPx * 8 < renderedPx * 13;
+            // Same wrap-period trim as the import paths. The >= tex_width2 guard skips a stale
+            // mask left by an FB blit (the pause background), which would otherwise tile the FB.
+            uint32_t maskW = mRdp->texture_tile[tile].masks;
+            uint32_t maskH = mRdp->texture_tile[tile].maskt;
+            if (maskW != 0 && (1u << maskW) >= tex_width2[i] && (1u << maskW) < tex_width[i]) {
+                tex_width[i] = 1u << maskW;
+            }
+            if (maskH != 0 && (1u << maskH) >= tex_height2[i] && (1u << maskH) < tex_height[i]) {
+                tex_height[i] = 1u << maskH;
+            }
             // HD replacements must clamp to the tile region
             bool isHd = mRdp->loaded_texture[i].raw_tex_metadata.h_byte_scale != 1 ||
                         mRdp->loaded_texture[i].raw_tex_metadata.v_pixel_scale != 1;
@@ -2413,6 +2463,8 @@ void Interpreter::GfxDpSetTile(uint8_t fmt, uint32_t siz, uint32_t line, uint32_
     mRdp->texture_tile[tile].siz = siz;
     mRdp->texture_tile[tile].cms = cms;
     mRdp->texture_tile[tile].cmt = cmt;
+    mRdp->texture_tile[tile].masks = masks;
+    mRdp->texture_tile[tile].maskt = maskt;
     mRdp->texture_tile[tile].shifts = shifts;
     mRdp->texture_tile[tile].shiftt = shiftt;
     mRdp->texture_tile[tile].line_size_bytes = line * 8;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -547,11 +547,12 @@ static uint32_t GetEffectiveLineSize(uint32_t lineSizeBytes, uint32_t fullImageL
 }
 
 static uint32_t GetTileSizeFromCoordinates(float low, float high) {
-    float size = (high - low + 4.0f) / 4.0f;
-    if (size <= 0.0f) {
+    // An unset tile (high <= low) defines no region; return 0 so callers skip the tile-region clamp
+    // instead of collapsing the texture to the phantom 1-texel size the +4 formula would yield.
+    if (high <= low) {
         return 0;
     }
-    return static_cast<uint32_t>(lroundf(size));
+    return static_cast<uint32_t>(lroundf((high - low + 4.0f) / 4.0f));
 }
 
 void Interpreter::ImportTextureRgba16(int tile, bool importReplacement) {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1168,9 +1168,8 @@ void Interpreter::ImportTextureRaw(int tile, bool importReplacement) {
     // Describe the buffer by what was actually packed (the loaded HD stride)
     uint32_t uploadWidth = safeLineSizeBytes / 4;
     uint32_t uploadHeight = safeLineSizeBytes > 0 ? safeLoadedBytes / safeLineSizeBytes : 0;
-    // LoadBlock can record the whole image as one line, turning e.g. a 256x256
-    // texture into a 65536x1 upload. That exceeds GPU limits and aborts on Metal.
-    if (uploadWidth > (uint32_t)mRapi->GetMaxTextureSize()) {
+    const bool singleLineLoad = uploadHeight <= 1 && resultNewLineSize != 0 && resultNewLineSize < safeLineSizeBytes;
+    if (uploadWidth > (uint32_t)mRapi->GetMaxTextureSize() || singleLineLoad) {
         if (safeLoadedBytes == (uint64_t)width * height * 4) {
             // buffer holds the full image, use its real dimensions
             uploadWidth = width;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1168,6 +1168,19 @@ void Interpreter::ImportTextureRaw(int tile, bool importReplacement) {
     // Describe the buffer by what was actually packed (the loaded HD stride)
     uint32_t uploadWidth = safeLineSizeBytes / 4;
     uint32_t uploadHeight = safeLineSizeBytes > 0 ? safeLoadedBytes / safeLineSizeBytes : 0;
+    // LoadBlock can record the whole image as one line, turning e.g. a 256x256
+    // texture into a 65536x1 upload. That exceeds GPU limits and aborts on Metal.
+    if (uploadWidth > (uint32_t)mRapi->GetMaxTextureSize()) {
+        if (safeLoadedBytes == (uint64_t)width * height * 4) {
+            // buffer holds the full image, use its real dimensions
+            uploadWidth = width;
+            uploadHeight = height;
+        } else {
+            // partial load, fall back to the tile-derived dimensions
+            uploadWidth = resultNewLineSize / 4;
+            uploadHeight = resultNewHeight;
+        }
+    }
     mRapi->UploadTexture(mTexUploadBuffer, uploadWidth, uploadHeight);
 }
 

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -439,6 +439,11 @@ size_t ResourceManager::UnloadResource(const std::string& filePath) {
     return UnloadResource({ filePath, mDefaultCacheOwner, mDefaultCacheArchive });
 }
 
+void ResourceManager::CacheExternalResource(const std::string& filePath, std::shared_ptr<IResource> resource) {
+    const std::lock_guard<std::mutex> lock(mMutex);
+    mResourceCache[{ filePath, mDefaultCacheOwner, mDefaultCacheArchive }] = resource;
+}
+
 bool ResourceManager::WriteResource(const ResourceIdentifier& identifier, const std::vector<uint8_t>& data,
                                     bool unloadFile) {
     std::string path;


### PR DESCRIPTION
Brings the `port-maintenance` fast3d texture-clamp work to `main` as one unit: #1118, #1143, #1172, #1151, #1121 and #1135.

They are grouped because each later commit exists to fix a bug the earlier one introduced. Landing any prefix of this chain ships a known regression.

### The chain

**#1118** (@JeodC) is the change we actually want — it stops HD replacement textures being treated like native ones in the tile clamps and stride calculations. But it also rewrote how `ImportTextureRaw` describes the upload buffer:

```c
-    mRapi->UploadTexture(mTexUploadBuffer, resultNewLineSize / 4, resultNewHeight);
+    uint32_t uploadWidth  = safeLineSizeBytes / 4;
+    uint32_t uploadHeight = safeLineSizeBytes > 0 ? safeLoadedBytes / safeLineSizeBytes : 0;
```

`LoadBlock` records the whole image as one line, so that describes a 256x256 texture as a 65536x1 upload.

- **#1143** (@serprex) reshapes when the upload exceeds `GetMaxTextureSize()`. **Metal aborts without this.**
- **#1172** (@JeodC) widens the trigger to any single-line load with a shorter true row stride — replacement textures under the cap still sheared on D3D11, where the cap is 16384.

**#1151** (@JeodC) is a separate rendering fix: a tile masked to NxM only addresses 2^mask texels, but some display lists load a larger block, so fast3d sized the texture from the load and the surface stretched. It is here because it does not apply without #1118 — its five hunks insert directly above #1118's `isHd` lines, and it produces 5 conflicts on plain `main`.

### Why #1121 and #1135 are included

This is the part worth a careful look.

**#1118 also causes a rendering regression on its own**, fixed by #1135 (@bassdr): with an HD texture pack, characters whose CI eye/face textures load via segment with an unset tile size render as a small repeated grid — most visible on adult Zelda / Sheik in the Temple of Time.

An unset tile has `lrs == uls == 0`, so the `(lrs - uls + 4) / 4` formula yields a phantom **1**-texel region rather than 0. #1118's `isHd` clause then clamps the sampled width from its real 32 down to 1, and since that value is also the UV normalizer, the upscaled texture tiles ~32x across the primitive.

#1135's fix is to make an undefined region return 0, so every clamp — all guarded on `size > 0` — skips it. But it patches the body of `GetTileSizeFromCoordinates`, a helper that does not exist on `main`. That helper arrives with **#1121** (@banteg), which is the `main`-targeted original of the already-merged #1164 and is still open.

So #1121 is included here as a dependency. Verified:

| base | `cherry-pick 60c9bb71` (#1135) |
| --- | --- |
| plain `main` | conflict — no helper |
| this branch without #1121 | conflict — no helper |
| this branch with #1121 | clean |

**If #1121 merges first, drop `22ecefd` from this branch and rebase.** It is @banteg's commit, carried here unmodified with authorship intact, purely so this PR does not have to land a regression while waiting. I left a separate verification note on #1121 confirming it still merges and builds clean against current `main`.

### Deviation from the originals

#1172 is taken **partially** — only its `src/fast/interpreter.cpp` hunk. The original also touched `.gitignore`, added `run-clang-format.ps1`, and changed a `LoadGuiTexture` call in `GfxDebuggerWindow.cpp` to match the extra argument added by #1157. #1157 is not on `main`, so that hunk does not apply here (`GfxDebuggerWindow.cpp:657` still takes three args). Noted in that commit's message.

Everything else applies unmodified, with original authorship and `(cherry picked from commit ...)` trailers.

### Note for review

`ResourceManager::CacheExternalResource` arrives with #1118 and has **no caller** on `main` — on `port-maintenance` it is only referenced by a comment in `interpreter.cpp`. It is public API intended for ports that synthesize textures at runtime. Flagging it in case you would rather it land alongside a consumer.

### Verification

Built and tested locally (gcc, Debug, `LUS_BUILD_TESTS=ON`):

- `cmake --build` clean, exit 0
- **615/615 tests pass**
- No new compiler warnings at any step, comparing identical recompiled translation-unit sets
- `GetTileSizeFromCoordinates`, the `ImportTextureRaw` upload block and the #1151 wrap-period trim are all byte-identical to `port-maintenance` HEAD
- No `(lrs - uls + 4) / 4` inline expressions remain — all five call sites now route through the guarded helper
- `masks`/`maskt` are safe to add to the RDP tile struct: `mRdp = new RDP()` value-initializes them to 0, and the `maskW != 0` guard makes 0 a no-op

Not exercised at runtime — the texture paths need a real ROM and per-backend checks. Worth confirming before merge: the D3D11 shear, the Metal abort, the #1151 framebuffer-blit case (the pause background), and the #1135 repro on adult Zelda / Sheik with an HD pack enabled.

Part of #1152.
