### PR TITLE
gsSPPopMatrix xml command (cherry-pick #1124)

### DIFF
--- a/src/fast/resource/factory/DisplayListFactory.cpp
+++ b/src/fast/resource/factory/DisplayListFactory.cpp
@@ -336,6 +336,18 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
                 dl->Strings.push_back(str);
                 strcpy((char*)g.words.w1, fName.data());
             }
+        } else if (childName == "PopMatrix") {
+            std::string param = child->Attribute("Param");
+
+            uint8_t paramInt = 0;
+
+            if (param == "G_MTX_MODELVIEW") {
+                paramInt = G_MTX_MODELVIEW;
+            } else if (param == "G_MTX_PROJECTION") {
+                paramInt = G_MTX_PROJECTION;
+            }
+
+            g = gsSPPopMatrix(paramInt);
         } else if (childName == "SetCycleType") {
             uint32_t param = 0;
 


### PR DESCRIPTION
Cherry-picks #1124 (`f0837c0`) from `port-maintenance` onto `main`. Authored by @Jameriquiah; applies with no conflicts, unmodified.

Adds a `PopMatrix` element to the XML display list factory. `main` has no such handler today — the only `Pop` in `DisplayListFactory.cpp` is the unrelated `PopShader` at `:1164`. The runtime side already exists on `main` (the `gsSPPopMatrix` macros at `gbi.h:2732-2738`, and both microcode command handlers at `interpreter.cpp:3341` and `:3350`), so this only wires up the authoring path to reach it.

Worth noting that `main` is in the same pre-#1124 state the commit was originally written against — `f0837c0^` and `main` are equivalent for every PopMatrix-related file — so nothing here depends on intermediate `port-maintenance` state.

### Two things for reviewers

Neither is a regression introduced by this change, and I have deliberately **not** modified the original commit. Raising them because this is the moment they are in front of people.

**1. The `Param` attribute has no effect.**

`GBI_UCODE` defaults to `F3DEX_GBI_2` (`CMakeLists.txt:77`), which selects:

```c
#define gsSPPopMatrixN(n, num)  gsDma2p(G_POPMTX, (num)*64, 64, 2, 0)
#define gsSPPopMatrix(n)        gsSPPopMatrixN((n), 1)
```

`n` is discarded by the macro and never reaches the emitted words, so the `paramInt` computation is dead — `G_MTX_MODELVIEW` and `G_MTX_PROJECTION` produce an identical command. The interpreter agrees: `gfx_pop_mtx_handler_f3dex2` (`interpreter.cpp:3341`) pops `w1 / 64` = 1 matrix, and `gfx_pop_mtx_handler_f3d` (`:3350`) pops `1` unconditionally. Neither reads a matrix-stack selector.

The command does the useful thing (pops one matrix). But an XML author writing `Param="G_MTX_PROJECTION"` will silently get the same result as `G_MTX_MODELVIEW`. This was equally true on `port-maintenance` — it is not something that broke in translation.

**2. A missing `Param` attribute is a crash.**

```cpp
std::string param = child->Attribute("Param");
```

`Attribute()` returns `nullptr` when the attribute is absent, and `std::string(nullptr)` is UB. The existing `Matrix` handler at `DisplayListFactory.cpp:308` does exactly the same thing, so this is established house style rather than a new defect.

It matters more here than there, though. `Matrix` needs both `Path` and `Param` to do anything, so authors always write them. `PopMatrix` needs neither — and per the point above, `Param` is inert — so omitting it is the natural thing to do, and omitting it crashes.

If you would like a guard, this is the minimal form, and I am happy to add it as a follow-up commit here:

```cpp
const char* paramAttr = child->Attribute("Param");
std::string param = paramAttr != nullptr ? paramAttr : "";
```

### Verification

Built and tested locally (gcc, Debug, `LUS_BUILD_TESTS=ON`):

- `cmake --build` clean, exit 0
- **615/615 tests pass**

Not exercised at runtime — emitting and rendering a display list with a `PopMatrix` element needs a real ROM and an XML asset that uses it.

Part of #1152.
