### PR TITLE
Add G_SETTILESIZE_LERP for constant-size texture scroll interpolation (cherry-pick #1141)

### DIFF
--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -561,6 +561,10 @@ class Interpreter {
     size_t mShadersIndex;
     int mInterpolationIndex;
     int mInterpolationIndexTarget;
+    // Interpolation factor for the current rendered frame within a game tick:
+    // 0 = previous tick, 1 = current tick. Set by the port before each
+    // DrawAndRunGraphicsCommands call, like mInterpolationIndex.
+    float mInterpolationT = 1.0f;
 };
 
 void gfx_set_target_ucode(UcodeHandlers ucode);

--- a/include/fast/lus_gbi.h
+++ b/include/fast/lus_gbi.h
@@ -74,6 +74,7 @@ constexpr int8_t RDP_G_SETTARGETINTERPINDEX = OPCODE(0x46);
 constexpr int8_t RDP_G_LOADBLOCK_WIDE = OPCODE(0x47);
 constexpr int8_t RDP_G_VTX_WIDE = OPCODE(0x48);
 constexpr int8_t RDP_G_TRI1_WIDE = OPCODE(0x49);
+constexpr int8_t RDP_G_SETTILESIZE_LERP = OPCODE(0x4a);
 
 /*
  * The following commands are the "generated" RDP commands; the user

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -196,6 +196,7 @@
 #define G_POP_SHADER 0x44
 #define G_SETTILESIZE_INTERP 0x45
 #define G_SETTARGETINTERPINDEX 0x46
+#define G_SETTILESIZE_LERP 0x4a
 
 /*
  * The following commands are the "generated" RDP commands; the user
@@ -3277,6 +3278,32 @@ typedef union Gfx {
 
 #define __gDPSetTileSizeInterp(pkt, t, uls, ult, lrs, lrt) \
     gDPLoadTileGeneric(pkt, G_SETTILESIZE_INTERP, t, uls, ult, lrs, lrt)
+
+/*
+ * Tile size interpolated at draw time between two endpoints using the
+ * interpreter's mInterpolationT (0 = previous game tick, 1 = current tick).
+ */
+#define __gDPSetTileSizeLerpCoord(g, w, coord) \
+    _DW({                                      \
+        float _f = (coord);                    \
+        (g).words.w = *(uint32_t*)&_f;         \
+    })
+
+#define __gDPSetTileSizeLerp(pkt, t, uls0, ult0, lrs0, lrt0, uls1, ult1, lrs1, lrt1) \
+    _DW({                                                                            \
+        Gfx* _g = (Gfx*)(pkt);                                                       \
+                                                                                     \
+        _g[0].words.w0 = _SHIFTL(G_SETTILESIZE_LERP, 24, 8);                         \
+        _g[0].words.w1 = _SHIFTL(t, 24, 3);                                          \
+        __gDPSetTileSizeLerpCoord(_g[1], w0, uls0);                                  \
+        __gDPSetTileSizeLerpCoord(_g[1], w1, ult0);                                  \
+        __gDPSetTileSizeLerpCoord(_g[2], w0, lrs0);                                  \
+        __gDPSetTileSizeLerpCoord(_g[2], w1, lrt0);                                  \
+        __gDPSetTileSizeLerpCoord(_g[3], w0, uls1);                                  \
+        __gDPSetTileSizeLerpCoord(_g[3], w1, ult1);                                  \
+        __gDPSetTileSizeLerpCoord(_g[4], w0, lrs1);                                  \
+        __gDPSetTileSizeLerpCoord(_g[4], w1, lrt1);                                  \
+    })
 #define gDPSetTileSize(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_SETTILESIZE, t, uls, ult, lrs, lrt)
 #define gsDPSetTileSize(t, uls, ult, lrs, lrt) gsDPLoadTileGeneric(G_SETTILESIZE, t, uls, ult, lrs, lrt)
 #define gDPLoadTile(pkt, t, uls, ult, lrs, lrt) gDPLoadTileGeneric(pkt, G_LOADTILE, t, uls, ult, lrs, lrt)

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -4192,6 +4192,29 @@ bool gfx_set_tile_size_interp_handler_rdp(F3DGfx** cmd0) {
     return false;
 }
 
+bool gfx_set_tile_size_lerp_handler_rdp(F3DGfx** cmd0) {
+    F3DGfx* cmd = *cmd0;
+    Interpreter* gfx = mInstance.lock().get();
+
+    int tile = C1(24, 3);
+    float coords[8];
+    for (int i = 0; i < 8; i += 2) {
+        ++(*cmd0);
+        memcpy(&coords[i], &(*cmd0)->words.w0, sizeof(float));
+        memcpy(&coords[i + 1], &(*cmd0)->words.w1, sizeof(float));
+    }
+
+    float t = gfx->mInterpolationT;
+    gfx->mRdp->texture_tile[tile].uls = coords[0] + t * (coords[4] - coords[0]);
+    gfx->mRdp->texture_tile[tile].ult = coords[1] + t * (coords[5] - coords[1]);
+    gfx->mRdp->texture_tile[tile].lrs = coords[2] + t * (coords[6] - coords[2]);
+    gfx->mRdp->texture_tile[tile].lrt = coords[3] + t * (coords[7] - coords[3]);
+    gfx->mRdp->textures_changed[0] = true;
+    gfx->mRdp->textures_changed[1] = true;
+
+    return false;
+}
+
 bool gfx_set_interpolation_index_target(F3DGfx** cmd0) {
     F3DGfx* cmd = *cmd0;
     Interpreter* gfx = mInstance.lock().get();
@@ -4509,34 +4532,35 @@ static constexpr UcodeHandler rdpHandlers = {
     { RDP_G_SETTARGETINTERPINDEX,
       { "G_SETTARGETINTERPINDEX", gfx_set_interpolation_index_target } }, // G_SETTARGETINTERPINDEX
     { RDP_G_SETTILESIZE_INTERP,
-      { "G_SETTILESIZE_INTERP", gfx_set_tile_size_interp_handler_rdp } },            // G_SETTILESIZE_INTERP
-    { RDP_G_TEXRECT, { "G_TEXRECT", gfx_tex_rect_and_flip_handler_rdp } },           // G_TEXRECT (-28)
-    { RDP_G_TEXRECTFLIP, { "G_TEXRECTFLIP", gfx_tex_rect_and_flip_handler_rdp } },   // G_TEXRECTFLIP (-27)
-    { RDP_G_RDPLOADSYNC, { "mRdpLOADSYNC", gfx_stubbed_command_handler } },          // mRdpLOADSYNC (-26)
-    { RDP_G_RDPPIPESYNC, { "mRdpPIPESYNC", gfx_stubbed_command_handler } },          // mRdpPIPESYNC (-25)
-    { RDP_G_RDPTILESYNC, { "mRdpTILESYNC", gfx_stubbed_command_handler } },          // mRdpPIPESYNC (-24)
-    { RDP_G_RDPFULLSYNC, { "mRdpFULLSYNC", gfx_stubbed_command_handler } },          // mRdpFULLSYNC (-23)
-    { RDP_G_SETKEYGB, { "G_SETKEYGB", gfx_set_key_gb_handler_rdp } },                // G_SETKEYGB (-22)
-    { RDP_G_SETKEYR, { "G_SETKEYR", gfx_set_key_r_handler_rdp } },                   // G_SETKEYR (-21)
-    { RDP_G_SETCONVERT, { "G_SETCONVERT", gfx_set_convert_handler_rdp } },           // G_SETCONVERT (-20)
-    { RDP_G_SETSCISSOR, { "G_SETSCISSOR", gfx_SetScissor_handler_rdp } },            // G_SETSCISSOR (-19)
-    { RDP_G_SETPRIMDEPTH, { "G_SETPRIMDEPTH", gfx_set_prim_depth_handler_rdp } },    // G_SETPRIMDEPTH (-18)
-    { RDP_G_RDPSETOTHERMODE, { "mRdpSETOTHERMODE", gfx_rdp_set_other_mode_rdp } },   // mRdpSETOTHERMODE (-17)
-    { RDP_G_LOADTLUT, { "G_LOADTLUT", gfx_load_tlut_handler_rdp } },                 // G_LOADTLUT (-16)
-    { RDP_G_SETTILESIZE, { "G_SETTILESIZE", gfx_set_tile_size_handler_rdp } },       // G_SETTILESIZE (-14)
-    { RDP_G_LOADBLOCK, { "G_LOADBLOCK", gfx_load_block_handler_rdp } },              // G_LOADBLOCK (-13)
-    { RDP_G_LOADTILE, { "G_LOADTILE", gfx_load_tile_handler_rdp } },                 // G_LOADTILE (-12)
-    { RDP_G_SETTILE, { "G_SETTILE", gfx_set_tile_handler_rdp } },                    // G_SETTILE (-11)
-    { RDP_G_FILLRECT, { "G_FILLRECT", gfx_fill_rect_handler_rdp } },                 // G_FILLRECT (-10)
-    { RDP_G_SETFILLCOLOR, { "G_SETFILLCOLOR", gfx_set_fill_color_handler_rdp } },    // G_SETFILLCOLOR (-9)
-    { RDP_G_SETFOGCOLOR, { "G_SETFOGCOLOR", gfx_set_fog_color_handler_rdp } },       // G_SETFOGCOLOR (-8)
-    { RDP_G_SETBLENDCOLOR, { "G_SETBLENDCOLOR", gfx_set_blend_color_handler_rdp } }, // G_SETBLENDCOLOR (-7)
-    { RDP_G_SETPRIMCOLOR, { "G_SETPRIMCOLOR", gfx_set_prim_color_handler_rdp } },    // G_SETPRIMCOLOR (-6)
-    { RDP_G_SETENVCOLOR, { "G_SETENVCOLOR", gfx_set_env_color_handler_rdp } },       // G_SETENVCOLOR (-5)
-    { RDP_G_SETCOMBINE, { "G_SETCOMBINE", gfx_set_combine_handler_rdp } },           // G_SETCOMBINE (-4)
-    { RDP_G_SETTIMG, { "G_SETTIMG", gfx_set_timg_handler_rdp } },                    // G_SETTIMG (-3)
-    { RDP_G_SETZIMG, { "G_SETZIMG", gfx_set_z_img_handler_rdp } },                   // G_SETZIMG (-2)
-    { RDP_G_SETCIMG, { "G_SETCIMG", gfx_set_c_img_handler_rdp } },                   // G_SETCIMG (-1)
+      { "G_SETTILESIZE_INTERP", gfx_set_tile_size_interp_handler_rdp } },                     // G_SETTILESIZE_INTERP
+    { RDP_G_SETTILESIZE_LERP, { "G_SETTILESIZE_LERP", gfx_set_tile_size_lerp_handler_rdp } }, // G_SETTILESIZE_LERP
+    { RDP_G_TEXRECT, { "G_TEXRECT", gfx_tex_rect_and_flip_handler_rdp } },                    // G_TEXRECT (-28)
+    { RDP_G_TEXRECTFLIP, { "G_TEXRECTFLIP", gfx_tex_rect_and_flip_handler_rdp } },            // G_TEXRECTFLIP (-27)
+    { RDP_G_RDPLOADSYNC, { "mRdpLOADSYNC", gfx_stubbed_command_handler } },                   // mRdpLOADSYNC (-26)
+    { RDP_G_RDPPIPESYNC, { "mRdpPIPESYNC", gfx_stubbed_command_handler } },                   // mRdpPIPESYNC (-25)
+    { RDP_G_RDPTILESYNC, { "mRdpTILESYNC", gfx_stubbed_command_handler } },                   // mRdpPIPESYNC (-24)
+    { RDP_G_RDPFULLSYNC, { "mRdpFULLSYNC", gfx_stubbed_command_handler } },                   // mRdpFULLSYNC (-23)
+    { RDP_G_SETKEYGB, { "G_SETKEYGB", gfx_set_key_gb_handler_rdp } },                         // G_SETKEYGB (-22)
+    { RDP_G_SETKEYR, { "G_SETKEYR", gfx_set_key_r_handler_rdp } },                            // G_SETKEYR (-21)
+    { RDP_G_SETCONVERT, { "G_SETCONVERT", gfx_set_convert_handler_rdp } },                    // G_SETCONVERT (-20)
+    { RDP_G_SETSCISSOR, { "G_SETSCISSOR", gfx_SetScissor_handler_rdp } },                     // G_SETSCISSOR (-19)
+    { RDP_G_SETPRIMDEPTH, { "G_SETPRIMDEPTH", gfx_set_prim_depth_handler_rdp } },             // G_SETPRIMDEPTH (-18)
+    { RDP_G_RDPSETOTHERMODE, { "mRdpSETOTHERMODE", gfx_rdp_set_other_mode_rdp } },            // mRdpSETOTHERMODE (-17)
+    { RDP_G_LOADTLUT, { "G_LOADTLUT", gfx_load_tlut_handler_rdp } },                          // G_LOADTLUT (-16)
+    { RDP_G_SETTILESIZE, { "G_SETTILESIZE", gfx_set_tile_size_handler_rdp } },                // G_SETTILESIZE (-14)
+    { RDP_G_LOADBLOCK, { "G_LOADBLOCK", gfx_load_block_handler_rdp } },                       // G_LOADBLOCK (-13)
+    { RDP_G_LOADTILE, { "G_LOADTILE", gfx_load_tile_handler_rdp } },                          // G_LOADTILE (-12)
+    { RDP_G_SETTILE, { "G_SETTILE", gfx_set_tile_handler_rdp } },                             // G_SETTILE (-11)
+    { RDP_G_FILLRECT, { "G_FILLRECT", gfx_fill_rect_handler_rdp } },                          // G_FILLRECT (-10)
+    { RDP_G_SETFILLCOLOR, { "G_SETFILLCOLOR", gfx_set_fill_color_handler_rdp } },             // G_SETFILLCOLOR (-9)
+    { RDP_G_SETFOGCOLOR, { "G_SETFOGCOLOR", gfx_set_fog_color_handler_rdp } },                // G_SETFOGCOLOR (-8)
+    { RDP_G_SETBLENDCOLOR, { "G_SETBLENDCOLOR", gfx_set_blend_color_handler_rdp } },          // G_SETBLENDCOLOR (-7)
+    { RDP_G_SETPRIMCOLOR, { "G_SETPRIMCOLOR", gfx_set_prim_color_handler_rdp } },             // G_SETPRIMCOLOR (-6)
+    { RDP_G_SETENVCOLOR, { "G_SETENVCOLOR", gfx_set_env_color_handler_rdp } },                // G_SETENVCOLOR (-5)
+    { RDP_G_SETCOMBINE, { "G_SETCOMBINE", gfx_set_combine_handler_rdp } },                    // G_SETCOMBINE (-4)
+    { RDP_G_SETTIMG, { "G_SETTIMG", gfx_set_timg_handler_rdp } },                             // G_SETTIMG (-3)
+    { RDP_G_SETZIMG, { "G_SETZIMG", gfx_set_z_img_handler_rdp } },                            // G_SETZIMG (-2)
+    { RDP_G_SETCIMG, { "G_SETCIMG", gfx_set_c_img_handler_rdp } },                            // G_SETCIMG (-1)
 };
 
 static constexpr UcodeHandler otrHandlers = {

--- a/src/libultraship/window/gui/GfxDebuggerWindow.cpp
+++ b/src/libultraship/window/gui/GfxDebuggerWindow.cpp
@@ -209,6 +209,20 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 break;
             }
 
+            // Header word plus 2 float tile coordinates
+            case RDP_G_SETTILESIZE_INTERP: {
+                simpleNode(cmd, opcode);
+                cmd += 3;
+                break;
+            }
+
+            // Header word plus 4 float tile coordinate endpoints
+            case RDP_G_SETTILESIZE_LERP: {
+                simpleNode(cmd, opcode);
+                cmd += 5;
+                break;
+            }
+
             case OTR_G_MARKER: {
                 cmd++;
                 uint64_t hash = ((uint64_t)cmd->words.w0 << 32) + cmd->words.w1;


### PR DESCRIPTION
Cherry-picks #1141 (`c57da1b`) from `port-maintenance` onto `main`. Authored by @serprex; applies with no conflicts, unmodified.

Adds `G_SETTILESIZE_LERP` (opcode `0x4a`, 5 Gfx), carrying tile coordinate endpoints as floats and evaluating them at draw time against a new `Interpreter::mInterpolationT` set by the port per rendered frame. Unlike `G_SETTILESIZE_INTERP`'s per-frame index scheme, display list size no longer scales with the interpolation frame count.

All the prerequisite interpolation infrastructure already exists on `main` — `RDP_G_SETTILESIZE_INTERP` (`include/fast/lus_gbi.h:72`), `G_SETTILESIZE_INTERP` (`include/libultraship/libultra/gbi.h:197`), `mInterpolationIndexTarget` (`include/fast/interpreter.h:563`) and `gfx_set_tile_size_interp_handler_rdp` (`src/fast/interpreter.cpp:4511`). This adds a parallel command alongside them.

### It also fixes an existing debugger bug — not just the new feature

Not implied by the title, so calling it out.

`G_SETTILESIZE_INTERP` is a **3-Gfx** command: the interpreter advances `*cmd0` twice past two float payload words, in both branches of `gfx_set_tile_size_interp_handler_rdp` (`src/fast/interpreter.cpp:4181-4191`).

`GfxDebuggerWindow::DrawDisasNode` on `main` has **no case for it**. That switch only special-cases multi-word commands explicitly — `G_TEXRECT`/`G_TEXRECTFLIP` do `cmd += 3`, `OTR_G_MARKER` walks its own hash — and anything unlisted advances by a single word. So today the debugger walks `G_SETTILESIZE_INTERP` as 1 Gfx and then decodes its two raw float payload words as if they were commands, desyncing the rest of the disassembly.

This commit adds both cases:

```cpp
case RDP_G_SETTILESIZE_INTERP: { simpleNode(cmd, opcode); cmd += 3; break; }
case RDP_G_SETTILESIZE_LERP:   { simpleNode(cmd, opcode); cmd += 5; break; }
```

The `INTERP` half is a standalone fix for a bug already present on `main`, independent of the new command.

### On the diff size

`+98 −28` overstates it. Adding one row to the `rdpHandlers` table re-wrapped every trailing comment in it under clang-format, which accounts for most of the churn. The substantive change is roughly 40 lines: the new handler, the table entry, the `mInterpolationT` member, the opcode constant, the gbi macros, and the two debugger cases.

### One note for review

The new gbi macro type-puns through a pointer cast:

```c
#define __gDPSetTileSizeLerpCoord(g, w, coord) \
    _DW({ float _f = (coord); (g).words.w = *(uint32_t*)&_f; })
```

That is a strict-aliasing violation. The handler side reads the coordinates back with `memcpy`, which is fine — it is only the emit side that casts, and this header gets compiled as C by ports. `memcpy` here would be free and correct. Left as-authored since this is a cherry-pick.

### Verification

Built and tested locally (gcc, Debug, `LUS_BUILD_TESTS=ON`):

- `cmake --build` clean, exit 0
- **615/615 tests pass**

Not exercised at runtime — driving the new command needs a port emitting it, and confirming the debugger fix needs the GfxDebugger open on a display list containing `G_SETTILESIZE_INTERP`.

Part of #1152.
