### PR TITLE
Fix partial depth clears drifting at non-4:3 aspect ratios (cherry-pick #1173)

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2918,6 +2918,9 @@ void Interpreter::GfxDpFillRectangle(int32_t ulx, int32_t uly, int32_t lrx, int3
         float y = expanded_lry / 4.0f;
         float w = (expanded_lrx - ulx) / 4.0f;
         float h = (expanded_lry - uly) / 4.0f;
+        float halfNativeWidth = (float)HALF_SCREEN_WIDTH(mActiveFrameBuffer);
+        x = halfNativeWidth + AdjXForAspectRatio(x - halfNativeWidth);
+        w = AdjXForAspectRatio(w);
 
         struct XYWidthHeight area;
         area.x = (int16_t)x;


### PR DESCRIPTION
Cherry-picks #1173 (`5dd092a`) from `port-maintenance` onto `main`. Authored by @JeodC; applies with no conflicts, unmodified.

The z-buffer branch of `GfxDpFillRectangle` mapped the clear rect through `AdjustVIewportOrScissor`, which stretches raster coordinates by `RATIO_X`. Geometry takes a different path — `AdjXForAspectRatio` scales by `RATIO_Y` and centers on the native viewport. The two mappings agree only at the native center, so a depth hole punched for a model near the screen edge landed several percent of the screen width away from it, and the model stayed z-clipped against the world.

The fix pre-compresses x/width about the native center so the later `RATIO_X` multiply reproduces the geometry mapping.

### Applies to `main` as-is

The partial depth clear feature this corrects landed on `main` in #1046, and the target block is byte-identical there (`src/fast/interpreter.cpp:2914-2927`). Both helpers exist: `HALF_SCREEN_WIDTH` (`src/fast/interpreter.cpp:59`) and `AdjXForAspectRatio` (`include/fast/interpreter.h:494`, `src/fast/interpreter.cpp:1469`).

Independent of the fast3d texture work in #1198 — that PR's hunks in `interpreter.cpp` stop around line 2572, well clear of this one at ~2918.

### The "no-op at 4:3" claim checks out

`AdjXForAspectRatio` reduces to:

```cpp
return x * (4.0f / 3.0f) / ((float)mCurDimensions.width / (float)mCurDimensions.height);
```

At 4:3 that factor is exactly 1.0, so both new lines are identities and existing behaviour is bit-for-bit unchanged. At 16:9 it compresses by 0.75, which is the intended correction.

Worth noting for reviewers: the helper also early-returns `x` unchanged for fixed-size off-screen framebuffers (`!resize || forceFixedAspect`), so the fix is likewise inert for those — consistent with how geometry treats them.

### Verification

Built and tested locally (gcc, Debug, `LUS_BUILD_TESTS=ON`):

- `cmake --build` clean, exit 0
- **615/615 tests pass**

Not exercised at runtime. Confirming the actual fix needs a ROM at a non-4:3 aspect ratio with a HUD model that triggers a partial depth clear — the case in the original report.

Part of #1152.
