### PR TITLE
fast3d: accept in-module low pointers in the SETTIMG guard on non-Windows (cherry-pick #1176)

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -7,6 +7,9 @@
 #include <stdbool.h>
 #include <assert.h>
 #include <stdio.h>
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
 
 #include <any>
 #include <map>
@@ -3846,6 +3849,27 @@ bool gfx_othermode_h_handler_f3d(F3DGfx** cmd0) {
     return false;
 }
 
+// A resolved address still in the N64 segmented range (<= 0x0FFFFFFF) usually means SegAddr
+// failed to resolve it (segment not set up). Keep it only if it belongs to a loaded module,
+// where it's a real low pointer (e.g. a static TLUT) rather than an unresolved segment addr.
+static bool IsValidResolvedAddress(uintptr_t addr) {
+    if (addr > 0x0FFFFFFF) {
+        return true;
+    }
+
+    // Still in the N64 segmented range, but might be a false positive (a real low pointer).
+#ifdef _WIN32
+    // For Windows, check whether the address belongs to a dll.
+    HMODULE module = nullptr;
+    return GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                              reinterpret_cast<LPCSTR>(addr), &module) != 0;
+#else
+    // For non-Windows platforms, check whether the address belongs to a loaded object.
+    Dl_info info;
+    return dladdr(reinterpret_cast<void*>(addr), &info) != 0;
+#endif
+}
+
 bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
     Interpreter* gfx = mInstance.lock().get();
     F3DGfx* cmd = *cmd0;
@@ -3880,23 +3904,9 @@ bool gfx_set_timg_handler_rdp(F3DGfx** cmd0) {
         }
     }
 
-    // If the resolved address is still in the N64 segmented range, SegAddr
-    // failed to resolve it (segment not set up). Skip to avoid dereferencing
-    // invalid memory.
-    // For Windows, also check if the address is not from a dll because this validation returns a false positive caused
-    // by how the virtual memory is allocated.
-#ifdef _WIN32
-    HMODULE module = nullptr;
-    if (i <= 0x0FFFFFFF &&
-        !(GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                             reinterpret_cast<LPCSTR>(i), &module))) {
+    if (!IsValidResolvedAddress(i)) {
         return false;
     }
-#else
-    if (i <= 0x0FFFFFFF) {
-        return false;
-    }
-#endif
 
     gfx->GfxDpSetTextureImage(C0(21, 3), C0(19, 2), C0(0, 12) + 1, imgData, texFlags, rawTexMetdata, (void*)i);
 


### PR DESCRIPTION
Cherry-picks #1176 (`bbb565b`) from `port-maintenance` onto `main`. Applies with no conflicts, unmodified.

`gfx_set_timg_handler_rdp` rejects any resolved address `<= 0x0FFFFFFF` as an unresolved N64 segment address (guard added in #1042). The Win32 branch exempts addresses belonging to a loaded module via `GetModuleHandleExA`; the non-Windows branch never got that check, so it rejects *every* low address.

On a non-PIE build a valid host pointer to statically-linked data is low, and such a pointer can legitimately reach SETTIMG. The skipped SETTIMG leaves `texture_to_load` stale, and the following `LoadTLUT` hits `SUPPORT_CHECK(texture_to_load.siz == G_IM_SIZ_16b)` — an assert in debug builds, blank text in release. The trigger seen downstream was Ship of Harkinian's `GfxPrint` loading its font palette from a static array, which is why it shows up everywhere debug text is drawn on non-PIE Linux.

The fix extracts the guard into `IsValidResolvedAddress` and gives the non-Windows path the `dladdr` equivalent of the Win32 module check. Provenance-based, so it is correct regardless of ASLR, and `dladdr` is only reached for addresses `<= 0x0FFFFFFF`, which heap textures short-circuit past — no per-texture cost.

### Applies to `main` as-is

`main` carries the pre-#1176 guard verbatim (`src/fast/interpreter.cpp:3883-3899`), including the same Windows/non-Windows asymmetry, so the bug is present there unchanged.

`dladdr` is already used elsewhere on `main` — `src/ship/debug/CrashHandler.cpp:186` and `src/ship/window/FileDrop.cpp:58`, both including `<dlfcn.h>` — so the symbol and its linkage are already proven on every non-Windows target this builds for.

Independent of the other in-flight fast3d work: this touches the include block and `gfx_set_timg_handler_rdp` (~3849, ~3904), while #1198's hunks stop around 2572 and #1205's sits at ~2918.

### Related, not superseded

#1122 is a **draft** against `port-maintenance` that also loosens this guard, but for a different provenance: it skips the range check entirely when a resource was loaded, covering heap pointers that fall below the threshold when ASLR is disabled. The two are complementary — this PR handles low pointers into loaded objects (static data), #1122 handles the post-resource-load case. Landing this does not preclude that.

### Verification

Built and tested locally (gcc, Debug, `LUS_BUILD_TESTS=ON`):

- `cmake --build` clean, exit 0
- **615/615 tests pass**

Not exercised at runtime here. The original test plan covers the repro — a non-PIE build drawing debug text through a static TLUT.

Part of #1152.
