### PR TITLE
[port-maintenance] [GfxDebuggerWindow] Display CI8 Palettes

### DIFF
--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -81,6 +81,12 @@ class Fast3dGui : public Ship::Gui {
     void HandleWindowEvents(Fast::WindowEvent event);
 
     /**
+     * @brief Returns true if a texture with the given name is already cached.
+     * @param name Texture cache key.
+     */
+    bool HasTextureByName(const std::string& name);
+
+    /**
      * @brief Loads an image from an archive path and caches it under the given name.
      * @param name Path/texture name used to reference the texture in GetTextureByName().
      * @param path Virtual resource path of the source image.
@@ -90,12 +96,6 @@ class Fast3dGui : public Ship::Gui {
                         const ImVec4& tint = ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
 
     /**
-     * @brief Returns true if a texture with the given name is already cached.
-     * @param name Texture cache key.
-     */
-    bool HasTextureByName(const std::string& name);
-
-    /**
      * @brief Uploads a Fast::Texture object to the GPU and caches it under @p name.
      * @param name Texture cache key.
      * @param tex  Source texture data.
@@ -103,6 +103,13 @@ class Fast3dGui : public Ship::Gui {
      */
     void LoadGuiTexture(const std::string& name, const Fast::Texture& tex, const std::string& palettePath = "",
                         const ImVec4& tint = ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
+
+    /**
+     * @brief Downloads the palette currently in the rdp.
+     * @param name Path/texture name used to reference the texture in GetTextureByName().
+     * @return A copy of the palette in the rdp
+     */
+    std::vector<uint8_t> GetRdpTexturePalette();
 
     /**
      * @brief Removes the texture with the given name from the cache and frees GPU resources.

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -436,6 +436,7 @@ class Interpreter {
     void ImportTextureImg(int tile, bool importReplacement);
     void ImportTexture(int i, int tile, bool importReplacement);
     void ImportTextureMask(int i, int tile);
+    const uint8_t* GetRdpPaletteData();
     void CalculateNormalDir(const F3DLight_t*, float coeffs[3]);
     // Opt-in memoization of OTR texture-path resolution, keyed by display-list
     // pointer and dropped with the texture cache. Safe for ports whose display

--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -768,7 +768,7 @@ std::vector<uint8_t> Fast3dGui::GetRdpTexturePalette() {
         return {};
     }
 
-    const uint8_t* paletteData = interpreter->GetPaletteData(0);
+    const uint8_t* paletteData = interpreter->GetRdpPaletteData();
     if (!paletteData) {
         SPDLOG_WARN("ImGui::LoadPaletteTexture: No palette data available");
         return {};

--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -761,6 +761,40 @@ void Fast3dGui::LoadGuiTexture(const std::string& name, const std::string& path,
     LoadGuiTexture(name, *res, palettePath, tint);
 }
 
+std::vector<uint8_t> Fast3dGui::GetRdpTexturePalette() {
+    auto interpreter = mInterpreter.lock();
+    if (!interpreter) {
+        SPDLOG_WARN("ImGui::LoadPaletteTexture: Interpreter unavailable");
+        return {};
+    }
+
+    const uint8_t* paletteData = interpreter->GetPaletteData(0);
+    if (!paletteData) {
+        SPDLOG_WARN("ImGui::LoadPaletteTexture: No palette data available");
+        return {};
+    }
+
+    std::vector<uint8_t> texBuffer;
+    texBuffer.reserve(16 * 16 * 4);
+
+    // CI8 palette: 256 entries, RGBA16 (RGBA5551)
+    for (int32_t i = 0; i < 256; i++) {
+        uint8_t b1 = paletteData[i * 2 + 0];
+        uint8_t b2 = paletteData[i * 2 + 1];
+
+        uint8_t r = (b1 >> 3) * 0xFF / 0x1F;
+        uint8_t g = (((b1 & 7) << 2) | (b2 >> 6)) * 0xFF / 0x1F;
+        uint8_t b = ((b2 >> 1) & 0x1F) * 0xFF / 0x1F;
+        uint8_t a = (b2 & 1) ? 0xFF : 0x00;
+
+        texBuffer.push_back(r);
+        texBuffer.push_back(g);
+        texBuffer.push_back(b);
+        texBuffer.push_back(a);
+    }
+    return texBuffer;
+}
+
 void Fast3dGui::UnloadTexture(const std::string& name) {
     if (mGuiTextures.contains(name)) {
         Ship::GuiTextureMetadata tex = mGuiTextures[name];

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1142,6 +1142,14 @@ void Interpreter::ImportTextureCi8(int tile, bool importReplacement) {
     mRapi->UploadTexture(mTexUploadBuffer, width, height);
 }
 
+/**
+ * Retrieves the current palette in the rdp.
+ * For the gfx debugger to display CI8 palettes as a texture
+ */
+const uint8_t* Interpreter::GetRdpPaletteData() {
+    return mRdp->palette_staging[0];
+}
+
 void Interpreter::ImportTextureImg(int tile, bool importReplacement) {
     const RawTexMetadata* metadata = &mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata;
     const uint8_t* addr =

--- a/src/libultraship/window/gui/GfxDebuggerWindow.cpp
+++ b/src/libultraship/window/gui/GfxDebuggerWindow.cpp
@@ -679,7 +679,6 @@ void GfxDebuggerWindow::DrawDisas() {
                     }
                     ImGui::Text("Texture Palette");
 
-
                     ImDrawList* draw = ImGui::GetWindowDrawList();
                     ImVec2 p = ImGui::GetCursorScreenPos();
 
@@ -694,10 +693,8 @@ void GfxDebuggerWindow::DrawDisas() {
                             const uint8_t* c = &paletteData[(y * 16 + x) * 4];
                             ImU32 color = IM_COL32(c[0], c[1], c[2], c[3]);
 
-                            draw->AddRectFilled(
-                                ImVec2(p.x + x * cell, p.y + y * cell),
-                                ImVec2(p.x + (x + 1) * cell, p.y + (y + 1) * cell),
-                                color);
+                            draw->AddRectFilled(ImVec2(p.x + x * cell, p.y + y * cell),
+                                                ImVec2(p.x + (x + 1) * cell, p.y + (y + 1) * cell), color);
                         }
                     }
 
@@ -742,12 +739,8 @@ void GfxDebuggerWindow::DrawDisas() {
     }
 
     ImGui::SetItemAllowOverlap();
-    
-    ImGui::GetWindowDrawList()->AddRectFilled(
-        ImGui::GetItemRectMin(),
-        ImGui::GetItemRectMax(),
-        IM_COL32(100, 100, 100, 255)
-    );
+    ImGui::GetWindowDrawList()->AddRectFilled(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(),
+                                              IM_COL32(100, 100, 100, 255));
     // End of button
 
     ImGui::BeginChild("##Disassembler", ImVec2(0.0f, 0.0f), true);

--- a/src/libultraship/window/gui/GfxDebuggerWindow.cpp
+++ b/src/libultraship/window/gui/GfxDebuggerWindow.cpp
@@ -670,20 +670,10 @@ void GfxDebuggerWindow::DrawDisas() {
             ImGui::Text("Loaded Textures");
             for (size_t i = 0; i < 2; i++) {
                 auto& tex = mInterpreter.lock()->mRdp->loaded_texture[i];
-                // ImGui::Text("%s", fmt::format("{}: {}x{} type={}", i, tex.raw_tex_metadata.width,
-                //                               tex.raw_tex_metadata.height, getTexType(tex.raw_tex_metadata.type))
-                //                       .c_str());
                 draw_img(std::to_string(i), fmt::format("GfxDebuggerWindowLoadedTexture{}", i), tex.raw_tex_metadata);
-            }
-            ImGui::Text("Texture To Load");
-            {
-                auto& tex = mInterpreter.lock()->mRdp->texture_to_load;
-                draw_img(std::nullopt, TO_LOAD_TEX, tex.raw_tex_metadata);
                 // Draw the palette for CI8 textures
                 if (tex.raw_tex_metadata.type == Fast::TextureType::Palette8bpp) {
-                    auto str = fmt::format("GfxDbgWindowLoadedPaletteTexture{}", i);
-                    gui->UnloadTexture(str);
-                    std::vector<uint8_t> paletteData = gui->GetRdpTexturePalette(str);
+                    std::vector<uint8_t> paletteData = gui->GetRdpTexturePalette();
                     if (paletteData.empty()) {
                         return;
                     }
@@ -695,9 +685,10 @@ void GfxDebuggerWindow::DrawDisas() {
 
                     constexpr float cell = 8.0f; // 8 * 16 = 128x128 texture
 
-                    // Scale the texture to 128x128
-                    // This method was used to prevent pixel blurring.
-                    // ImGui::Image() method blurred the texture
+                    /**
+                     * Scale the texture to 128x128 so it is easier to see.
+                     * This method prevents the pixel blurring that ImGui::Image() does.
+                     */
                     for (int y = 0; y < 16; y++) {
                         for (int x = 0; x < 16; x++) {
                             const uint8_t* c = &paletteData[(y * 16 + x) * 4];
@@ -712,6 +703,11 @@ void GfxDebuggerWindow::DrawDisas() {
 
                     ImGui::Dummy(ImVec2(16 * cell, 16 * cell));
                 }
+            }
+            ImGui::Text("Texture To Load");
+            {
+                auto& tex = mInterpreter.lock()->mRdp->texture_to_load;
+                draw_img(std::nullopt, TO_LOAD_TEX, tex.raw_tex_metadata);
             }
             ImGui::EndChild();
         }

--- a/src/libultraship/window/gui/GfxDebuggerWindow.cpp
+++ b/src/libultraship/window/gui/GfxDebuggerWindow.cpp
@@ -623,7 +623,8 @@ void GfxDebuggerWindow::DrawDisas() {
     const F3DGfx* cmd = dlist;
     auto gui = std::dynamic_pointer_cast<Fast::Fast3dGui>(Ship::Context::GetRawInstance()->GetWindow()->GetGui());
 
-    ImGui::BeginChild("###State", ImVec2(0.0f, 200.0f), true);
+    static float stateHeight = 200.0f; // default height of upper content
+    ImGui::BeginChild("###State", ImVec2(0.0f, stateHeight), true);
     {
         ImGui::BeginGroup();
         {
@@ -677,19 +678,40 @@ void GfxDebuggerWindow::DrawDisas() {
             ImGui::Text("Texture To Load");
             {
                 auto& tex = mInterpreter.lock()->mRdp->texture_to_load;
-                // ImGui::Text("%s", fmt::format("{}x{} type={}", tex.raw_tex_metadata.width,
-                // tex.raw_tex_metadata.height,
-                //                               getTexType(tex.raw_tex_metadata.type))
-                //                       .c_str());
-
-                // if (isNew && g_rdp.texture_to_load.raw_tex_metadata.resource != nullptr) {
-                //     gui->UnloadTexture(TO_LOAD_TEX);
-                //     gui->LoadGuiTexture(TO_LOAD_TEX, *g_rdp.texture_to_load.raw_tex_metadata.resource,
-                //                         ImVec4{ 1.0f, 1.0f, 1.0f, 1.0f });
-                // }
-
-                // ImGui::Image(gui->GetTextureByName(TO_LOAD_TEX), ImVec2{ 100.0f, 100.0f });
                 draw_img(std::nullopt, TO_LOAD_TEX, tex.raw_tex_metadata);
+                // Draw the palette for CI8 textures
+                if (tex.raw_tex_metadata.type == Fast::TextureType::Palette8bpp) {
+                    auto str = fmt::format("GfxDbgWindowLoadedPaletteTexture{}", i);
+                    gui->UnloadTexture(str);
+                    std::vector<uint8_t> paletteData = gui->GetRdpTexturePalette(str);
+                    if (paletteData.empty()) {
+                        return;
+                    }
+                    ImGui::Text("Texture Palette");
+
+
+                    ImDrawList* draw = ImGui::GetWindowDrawList();
+                    ImVec2 p = ImGui::GetCursorScreenPos();
+
+                    constexpr float cell = 8.0f; // 8 * 16 = 128x128 texture
+
+                    // Scale the texture to 128x128
+                    // This method was used to prevent pixel blurring.
+                    // ImGui::Image() method blurred the texture
+                    for (int y = 0; y < 16; y++) {
+                        for (int x = 0; x < 16; x++) {
+                            const uint8_t* c = &paletteData[(y * 16 + x) * 4];
+                            ImU32 color = IM_COL32(c[0], c[1], c[2], c[3]);
+
+                            draw->AddRectFilled(
+                                ImVec2(p.x + x * cell, p.y + y * cell),
+                                ImVec2(p.x + (x + 1) * cell, p.y + (y + 1) * cell),
+                                color);
+                        }
+                    }
+
+                    ImGui::Dummy(ImVec2(16 * cell, 16 * cell));
+                }
             }
             ImGui::EndChild();
         }
@@ -714,6 +736,23 @@ void GfxDebuggerWindow::DrawDisas() {
         ImGui::EndGroup();
     }
     ImGui::EndChild();
+
+    // Add button so the top area can be dragged bigger/smaller.
+    ImGui::InvisibleButton("##splitter", ImVec2(-1, 6.0f));
+
+    if (ImGui::IsItemActive()) {
+        stateHeight += ImGui::GetIO().MouseDelta.y;
+        stateHeight = std::clamp(stateHeight, 50.0f, 800.0f);
+    }
+
+    ImGui::SetItemAllowOverlap();
+    
+    ImGui::GetWindowDrawList()->AddRectFilled(
+        ImGui::GetItemRectMin(),
+        ImGui::GetItemRectMax(),
+        IM_COL32(100, 100, 100, 255)
+    );
+    // End of button
 
     ImGui::BeginChild("##Disassembler", ImVec2(0.0f, 0.0f), true);
     {


### PR DESCRIPTION
* Also adds a draggable bar to the bottom of the top area. This bar allows expanding the top area.

CI8 Palettes are 16x16, however we draw them at 128x128 so that it's easier to see (without pixel blurring).


* Header, organized `HasTextureByName` so both overloads of `LoadGuiTexture` are together.
* Removed a couple lines of unused code.
* CI4 support not available without having access to the `tile` value. Unless you draw the whole 256x256 area and let the user figure out where their palette may or may not be.
* CI8 uses the entire palette RDP memory. So we just display the entire RDP palette memory.
* CI4 can have up to 16 palettes in RDP palette memory. Thus `tile` index required to get palette_index.

<img width="882" height="445" alt="image" src="https://github.com/user-attachments/assets/7111fac5-4211-480f-b646-22147411d93b" />  

(Kart palette has 2 sections, bottom for tyre. That's why it looks weird).  



Generated by Human Intelligence™