### PR TITLE
[main 2.0.0] Revert Removal of Size Arg in GfxDebuggerWindow Constructor

### DIFF
--- a/include/libultraship/window/gui/GfxDebuggerWindow.h
+++ b/include/libultraship/window/gui/GfxDebuggerWindow.h
@@ -43,6 +43,19 @@ class GfxDebuggerWindow : public Ship::GuiWindow {
     GfxDebuggerWindow(const std::string& consoleVariable, const std::string& name,
                       std::shared_ptr<Fast::Fast3dWindow> fast3dWindow, std::shared_ptr<Fast::GfxDebugger> gfxDebugger,
                       std::shared_ptr<Ship::ResourceManager> resourceManager);
+
+    /**
+     * @brief Constructs a GfxDebuggerWindow with constructor-injected dependencies.
+     * @param consoleVariable  CVar name controlling window visibility.
+     * @param name             Window title.
+     * @param size             Initial window size.
+     * @param fast3dWindow     Fast3dWindow whose interpreter and GUI are used.
+     * @param gfxDebugger      GfxDebugger used to capture/inspect display lists.
+     * @param resourceManager  ResourceManager for archive lookups.
+     */
+    GfxDebuggerWindow(const std::string& consoleVariable, const std::string& name, ImVec2 size,
+                      std::shared_ptr<Fast::Fast3dWindow> fast3dWindow, std::shared_ptr<Fast::GfxDebugger> gfxDebugger,
+                      std::shared_ptr<Ship::ResourceManager> resourceManager);
     virtual ~GfxDebuggerWindow();
 
   protected:

--- a/include/ship/window/gui/GuiWindow.h
+++ b/include/ship/window/gui/GuiWindow.h
@@ -103,6 +103,13 @@ class GuiWindow : public GuiElement {
      */
     void Draw() override;
 
+   /**
+    * @brief Sets a windows initial size
+    */
+    void SetOriginalSize(ImGuiVec2 size) {
+        mOriginalSize = size;
+    }
+
   protected:
     /**
      * @brief Overrides SetVisibility to also write the new state to the backing CVar.

--- a/include/ship/window/gui/GuiWindow.h
+++ b/include/ship/window/gui/GuiWindow.h
@@ -103,13 +103,6 @@ class GuiWindow : public GuiElement {
      */
     void Draw() override;
 
-   /**
-    * @brief Sets a windows initial size
-    */
-    void SetOriginalSize(ImVec2 size) {
-        mOriginalSize = size;
-    }
-
   protected:
     /**
      * @brief Overrides SetVisibility to also write the new state to the backing CVar.

--- a/include/ship/window/gui/GuiWindow.h
+++ b/include/ship/window/gui/GuiWindow.h
@@ -106,7 +106,7 @@ class GuiWindow : public GuiElement {
    /**
     * @brief Sets a windows initial size
     */
-    void SetOriginalSize(ImGuiVec2 size) {
+    void SetOriginalSize(ImVec2 size) {
         mOriginalSize = size;
     }
 

--- a/src/libultraship/window/gui/GfxDebuggerWindow.cpp
+++ b/src/libultraship/window/gui/GfxDebuggerWindow.cpp
@@ -32,6 +32,19 @@ GfxDebuggerWindow::GfxDebuggerWindow(const std::string& consoleVariable, const s
     mResourceManager = std::move(resourceManager);
 }
 
+GfxDebuggerWindow::GfxDebuggerWindow(const std::string& consoleVariable, const std::string& name, ImVec2 size,
+                                     std::shared_ptr<Fast::Fast3dWindow> fast3dWindow,
+                                     std::shared_ptr<Fast::GfxDebugger> gfxDebugger,
+                                     std::shared_ptr<Ship::ResourceManager> resourceManager)
+    : GuiWindow(nullptr, nullptr, consoleVariable, false, name, size, ImGuiWindowFlags_None) {
+    if (fast3dWindow) {
+        mInterpreter = fast3dWindow->GetInterpreterWeak();
+        mFast3dGui = std::dynamic_pointer_cast<Fast::Fast3dGui>(fast3dWindow->GetGui());
+    }
+    mGfxDebugger = std::move(gfxDebugger);
+    mResourceManager = std::move(resourceManager);
+}
+
 GfxDebuggerWindow::~GfxDebuggerWindow() {
 }
 


### PR DESCRIPTION
The GfxDebuggerWindow spawns with no size without the user setting the size.

This adds the scale arg in an overload in-case someone out there does not want to include size.

Generated by Human Intelligence™