### PR TITLE
Resolve .meta aliases by archive priority (port #1168 to main)

### DIFF
--- a/include/ship/resource/ResourceLoader.h
+++ b/include/ship/resource/ResourceLoader.h
@@ -93,6 +93,15 @@ class ResourceLoader {
      */
     uint32_t GetResourceType(const std::string& type);
 
+    /**
+     * @brief Reads and parses the resource header from the meta-file to produce ResourceInitData.
+     * @param filePath       Virtual path (for error messages).
+     * @param metaFileToLoad File containing the header (may be a separate ".meta" sidecar).
+     * @return Populated ResourceInitData, or nullptr if the header is invalid.
+     */
+    std::shared_ptr<ResourceInitData> ReadResourceInitData(const std::string& filePath,
+                                                           std::shared_ptr<File> metaFileToLoad);
+
   protected:
     /** @brief Registers the built-in factories (Blob, JSON, Shader). Called during construction. */
     void RegisterGlobalResourceFactories();
@@ -108,26 +117,6 @@ class ResourceLoader {
      * @return Matching factory, or nullptr if none is registered.
      */
     std::shared_ptr<ResourceFactory> GetFactory(uint32_t format, std::string typeName, uint32_t version);
-
-    /**
-     * @brief Reads and parses the resource header from the meta-file to produce ResourceInitData.
-     * @param filePath       Virtual path (for error messages).
-     * @param metaFileToLoad File containing the header (may be a separate ".meta" sidecar).
-     * @return Populated ResourceInitData, or nullptr if the header is invalid.
-     */
-    std::shared_ptr<ResourceInitData> ReadResourceInitData(const std::string& filePath,
-                                                           std::shared_ptr<File> metaFileToLoad);
-
-    /**
-     * @brief Resolves a `.meta` at filePath, deciding whether it or filePath itself should load.
-     * @param identifier The requesting identifier; its owner and parent carry over to the result.
-     * @param filePath   Virtual path being loaded.
-     * @param fileToLoad In/out: the file at filePath, null when only a `.meta` is there. Set to
-     *                   the `.meta`'s target when the target is the one chosen.
-     * @return Init data parsed from the `.meta`, or nullptr to keep loading filePath as-is.
-     */
-    std::shared_ptr<ResourceInitData> ResolveMetaAlias(const ResourceIdentifier& identifier,
-                                                       const std::string& filePath, std::shared_ptr<File>& fileToLoad);
 
     /** @brief Creates a ResourceInitData with default/zeroed fields. */
     static std::shared_ptr<ResourceInitData> CreateDefaultResourceInitData();

--- a/include/ship/resource/ResourceLoader.h
+++ b/include/ship/resource/ResourceLoader.h
@@ -118,6 +118,17 @@ class ResourceLoader {
     std::shared_ptr<ResourceInitData> ReadResourceInitData(const std::string& filePath,
                                                            std::shared_ptr<File> metaFileToLoad);
 
+    /**
+     * @brief Resolves a `.meta` at filePath, deciding whether it or filePath itself should load.
+     * @param identifier The requesting identifier; its owner and parent carry over to the result.
+     * @param filePath   Virtual path being loaded.
+     * @param fileToLoad In/out: the file at filePath, null when only a `.meta` is there. Set to
+     *                   the `.meta`'s target when the target is the one chosen.
+     * @return Init data parsed from the `.meta`, or nullptr to keep loading filePath as-is.
+     */
+    std::shared_ptr<ResourceInitData> ResolveMetaAlias(const ResourceIdentifier& identifier,
+                                                       const std::string& filePath, std::shared_ptr<File>& fileToLoad);
+
     /** @brief Creates a ResourceInitData with default/zeroed fields. */
     static std::shared_ptr<ResourceInitData> CreateDefaultResourceInitData();
 

--- a/include/ship/resource/ResourceManager.h
+++ b/include/ship/resource/ResourceManager.h
@@ -418,12 +418,14 @@ class ResourceManager : public Component {
     std::shared_ptr<IResource> GetCachedResource(std::variant<ResourceLoadError, std::shared_ptr<IResource>> cacheLine);
 
     /**
-     * @brief Whether a `.meta` sits at this identifier's path, naming a target to load instead.
+     * @brief Resolves the `.meta` beside this identifier, if its target should load instead.
      *
-     * A `.meta` is keyed by the path it sits at, so a hash-identified resource has one only when
-     * the hash resolves back to a path.
+     * The real asset at the identifier and the `.meta`'s target are both ranked by the archive
+     * holding them, and the higher one loads. A tie goes to the `.meta`.
+     *
+     * @return Init data whose Identifier names the file to load, or nullptr if no `.meta` wins.
      */
-    bool HasMetaAlias(const ResourceIdentifier& identifier);
+    std::shared_ptr<ResourceInitData> ResolveMetaAlias(const ResourceIdentifier& identifier);
 
   private:
     std::unordered_map<ResourceIdentifier, std::variant<ResourceLoadError, std::shared_ptr<IResource>>,

--- a/include/ship/resource/ResourceManager.h
+++ b/include/ship/resource/ResourceManager.h
@@ -417,6 +417,14 @@ class ResourceManager : public Component {
 
     std::shared_ptr<IResource> GetCachedResource(std::variant<ResourceLoadError, std::shared_ptr<IResource>> cacheLine);
 
+    /**
+     * @brief Whether a `.meta` sits at this identifier's path, naming a target to load instead.
+     *
+     * A `.meta` is keyed by the path it sits at, so a hash-identified resource has one only when
+     * the hash resolves back to a path.
+     */
+    bool HasMetaAlias(const ResourceIdentifier& identifier);
+
   private:
     std::unordered_map<ResourceIdentifier, std::variant<ResourceLoadError, std::shared_ptr<IResource>>,
                        ResourceIdentifierHash>

--- a/include/ship/resource/archive/Archive.h
+++ b/include/ship/resource/archive/Archive.h
@@ -159,6 +159,15 @@ class Archive : public std::enable_shared_from_this<Archive> {
     bool IsInitialized();
 
     /**
+     * @brief Load-order priority assigned by the ArchiveManager when the archive is mounted.
+     * Higher means loaded later. -1 if unset.
+     */
+    int32_t GetPriority();
+
+    /** @brief Sets the load-order priority. Called by the ArchiveManager. */
+    void SetPriority(int32_t priority);
+
+    /**
      * @brief Opens the underlying archive file or directory for reading.
      * @return true on success.
      */
@@ -200,6 +209,7 @@ class Archive : public std::enable_shared_from_this<Archive> {
     bool mIsChecksumValid;
     bool mHasGameVersion;
     uint32_t mGameVersion;
+    int32_t mPriority = -1;
     ArchiveManifest mManifest;
     std::string mPath;
     std::shared_ptr<std::unordered_map<uint64_t, std::string>> mHashes;

--- a/include/ship/resource/archive/ArchiveManager.h
+++ b/include/ship/resource/archive/ArchiveManager.h
@@ -230,6 +230,13 @@ class ArchiveManager : public Component {
     /** @brief Rebuilds the hash-to-path and path-to-archive lookup tables from the current archive list. */
     void ResetVirtualFileSystem();
 
+    /**
+     * @brief Records a file in the hash-to-path and path-to-archive lookup tables.
+     * @param filePath Virtual path of the file.
+     * @param archive  Archive serving the file.
+     */
+    void AddFile(const std::string& filePath, const std::shared_ptr<Archive>& archive);
+
   private:
     std::vector<std::shared_ptr<Archive>> mArchives;
     std::vector<uint32_t> mGameVersions;

--- a/include/ship/resource/archive/ArchiveManager.h
+++ b/include/ship/resource/archive/ArchiveManager.h
@@ -233,10 +233,11 @@ class ArchiveManager : public Component {
 
     /**
      * @brief Records a file in the hash-to-path and path-to-archive lookup tables.
+     * @param hash     CRC64 of the virtual path.
      * @param filePath Virtual path of the file.
      * @param archive  Archive serving the file.
      */
-    void AddFile(const std::string& filePath, const std::shared_ptr<Archive>& archive);
+    void AddFile(uint64_t hash, const std::string& filePath, const std::shared_ptr<Archive>& archive);
 
   private:
     std::vector<std::shared_ptr<Archive>> mArchives;

--- a/include/ship/resource/archive/ArchiveManager.h
+++ b/include/ship/resource/archive/ArchiveManager.h
@@ -237,7 +237,7 @@ class ArchiveManager : public Component {
      * @param filePath Virtual path of the file.
      * @param archive  Archive serving the file.
      */
-    void AddFile(uint64_t hash, const std::string& filePath, const std::shared_ptr<Archive>& archive);
+    void AddFileToVfs(uint64_t hash, const std::string& filePath, const std::shared_ptr<Archive>& archive);
 
   private:
     std::vector<std::shared_ptr<Archive>> mArchives;

--- a/include/ship/resource/archive/ArchiveManager.h
+++ b/include/ship/resource/archive/ArchiveManager.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <functional>
 #include "ship/resource/File.h"
+#include "ship/resource/ResourceIdentifier.h"
 #include "ship/core/Component.h"
 #ifdef ENABLE_SCRIPTING
 #include "ship/security/Keystore.h"
@@ -151,10 +152,10 @@ class ArchiveManager : public Component {
     /**
      * @brief Load-order priority of the archive that owns the given file (higher = higher
      * priority; the last-loaded archive wins). Used to rank a real asset against an alias target.
-     * @param filePath Virtual path of the file.
+     * @param identifier Identifier of the file.
      * @return Priority index, or -1 if no loaded archive has the file.
      */
-    int32_t GetFilePriority(const std::string& filePath);
+    int32_t GetFilePriority(const ResourceIdentifier& identifier);
 
     /**
      * @brief Lists virtual paths of all files matching the given search mask across all archives.

--- a/include/ship/resource/archive/ArchiveManager.h
+++ b/include/ship/resource/archive/ArchiveManager.h
@@ -149,6 +149,14 @@ class ArchiveManager : public Component {
     std::shared_ptr<Archive> GetArchiveFromFile(const std::string& filePath);
 
     /**
+     * @brief Load-order priority of the archive that owns the given file (higher = higher
+     * priority; the last-loaded archive wins). Used to rank a real asset against an alias target.
+     * @param filePath Virtual path of the file.
+     * @return Priority index, or -1 if no loaded archive has the file.
+     */
+    int32_t GetFilePriority(const std::string& filePath);
+
+    /**
      * @brief Lists virtual paths of all files matching the given search mask across all archives.
      * @param searchMask Glob pattern (empty = list everything).
      * @return Sorted, deduplicated list of matching paths.

--- a/src/ship/resource/ResourceLoader.cpp
+++ b/src/ship/resource/ResourceLoader.cpp
@@ -209,6 +209,7 @@ std::shared_ptr<ResourceInitData> ResourceLoader::ReadResourceInitData(const std
 
     initData->Type = resourceManager->GetResourceLoader()->GetResourceType(parsed["type"]);
     initData->ResourceVersion = parsed["version"];
+    initData->IsCustom = parsed.value("isCustom", false);
 
     return initData;
 }

--- a/src/ship/resource/ResourceLoader.cpp
+++ b/src/ship/resource/ResourceLoader.cpp
@@ -237,63 +237,12 @@ static void SetBufferOffset(const std::shared_ptr<File>& file, const std::shared
     }
 }
 
-std::shared_ptr<ResourceInitData> ResourceLoader::ResolveMetaAlias(const ResourceIdentifier& identifier,
-                                                                   const std::string& filePath,
-                                                                   std::shared_ptr<File>& fileToLoad) {
-    if (mResourceManager == nullptr || filePath.empty()) {
-        return nullptr;
-    }
-
-    auto metaFileToLoad = mResourceManager->LoadFileProcess(filePath + ".meta");
-    if (metaFileToLoad == nullptr) {
-        return nullptr;
-    }
-
-    auto metaInitData = ReadResourceInitData(filePath, metaFileToLoad);
-
-    auto targetIdentifier = metaInitData->Identifier;
-    targetIdentifier.SetOwner(identifier.GetOwner());
-    targetIdentifier.SetParent(identifier.GetParent());
-    metaInitData->Identifier = targetIdentifier;
-
-    auto targetFileToLoad = mResourceManager->LoadFileProcess(targetIdentifier);
-    if (targetFileToLoad == nullptr) {
-        return nullptr;
-    }
-
-    auto archiveManager = mResourceManager->GetArchiveManager();
-    if (archiveManager == nullptr) {
-        return nullptr;
-    }
-
-    // Both candidates are ranked by the archive holding them, and the higher one loads. A tie
-    // means one archive supplies both, and there its `.meta` is the more specific instruction.
-    // Nothing at filePath reports -1, so any reachable target outranks it.
-    const auto targetPath = ResolveIdentifierPath(targetIdentifier, mResourceManager);
-    const int32_t targetPriority = archiveManager->GetFilePriority(targetPath);
-    const int32_t basePriority = archiveManager->GetFilePriority(filePath);
-    if (targetPriority < basePriority) {
-        SPDLOG_TRACE("Alias {} -> {} not taken: target ranks {} against {} at the requested path", filePath, targetPath,
-                     targetPriority, basePriority);
-        return nullptr;
-    }
-
-    fileToLoad = targetFileToLoad;
-    return metaInitData;
-}
-
 std::shared_ptr<IResource> ResourceLoader::LoadResource(const ResourceIdentifier& identifier,
                                                         std::shared_ptr<File> fileToLoad,
                                                         std::shared_ptr<ResourceInitData> initData) {
-    const auto filePath = ResolveIdentifierPath(identifier, mResourceManager);
-
-    // fileToLoad is the file at filePath, or null when only a `.meta` names this path.
     bool legacyInitData = false;
-    if (initData == nullptr) {
-        initData = ResolveMetaAlias(identifier, filePath, fileToLoad);
-    }
     if (initData == nullptr && fileToLoad != nullptr) {
-        initData = ReadResourceInitDataLegacy(filePath, fileToLoad);
+        initData = ReadResourceInitDataLegacy(ResolveIdentifierPath(identifier, mResourceManager), fileToLoad);
         legacyInitData = true;
     }
 

--- a/src/ship/resource/ResourceLoader.cpp
+++ b/src/ship/resource/ResourceLoader.cpp
@@ -213,43 +213,62 @@ std::shared_ptr<ResourceInitData> ResourceLoader::ReadResourceInitData(const std
     return initData;
 }
 
+std::shared_ptr<ResourceInitData> ResourceLoader::ResolveMetaAlias(const ResourceIdentifier& identifier,
+                                                                   const std::string& filePath,
+                                                                   std::shared_ptr<File>& fileToLoad) {
+    if (mResourceManager == nullptr || filePath.empty()) {
+        return nullptr;
+    }
+
+    auto metaFileToLoad = mResourceManager->LoadFileProcess(filePath + ".meta");
+    if (metaFileToLoad == nullptr) {
+        return nullptr;
+    }
+
+    auto metaInitData = ReadResourceInitData(filePath, metaFileToLoad);
+
+    auto targetIdentifier = metaInitData->Identifier;
+    targetIdentifier.SetOwner(identifier.GetOwner());
+    targetIdentifier.SetParent(identifier.GetParent());
+    metaInitData->Identifier = targetIdentifier;
+
+    auto targetFileToLoad = mResourceManager->LoadFileProcess(targetIdentifier);
+    if (targetFileToLoad == nullptr) {
+        return nullptr;
+    }
+
+    auto archiveManager = mResourceManager->GetArchiveManager();
+    if (archiveManager == nullptr) {
+        return nullptr;
+    }
+
+    // Both candidates are ranked by the archive holding them, and the higher one loads. A tie
+    // means one archive supplies both, and there its `.meta` is the more specific instruction.
+    // Nothing at filePath reports -1, so any reachable target outranks it.
+    const auto targetPath = ResolveIdentifierPath(targetIdentifier, mResourceManager);
+    const int32_t targetPriority = archiveManager->GetFilePriority(targetPath);
+    const int32_t basePriority = archiveManager->GetFilePriority(filePath);
+    if (targetPriority < basePriority) {
+        SPDLOG_TRACE("Alias {} -> {} not taken: target ranks {} against {} at the requested path", filePath, targetPath,
+                     targetPriority, basePriority);
+        return nullptr;
+    }
+
+    fileToLoad = targetFileToLoad;
+    return metaInitData;
+}
+
 std::shared_ptr<IResource> ResourceLoader::LoadResource(const ResourceIdentifier& identifier,
                                                         std::shared_ptr<File> fileToLoad,
                                                         std::shared_ptr<ResourceInitData> initData) {
     const auto filePath = ResolveIdentifierPath(identifier, mResourceManager);
 
-    if (fileToLoad == nullptr) {
-        SPDLOG_ERROR("Failed to load resource: File not loaded");
-        return nullptr;
-    }
-
+    // fileToLoad is the file at filePath, or null when only a `.meta` names this path.
     if (initData == nullptr) {
-        auto resourceManager = mResourceManager;
-        if (resourceManager == nullptr) {
-            SPDLOG_ERROR("Failed to load resource {}: no ResourceManager available", filePath);
-            return nullptr;
-        }
-
-        if (!filePath.empty()) {
-            auto metaFilePath = filePath + ".meta";
-            auto metaFileToLoad = resourceManager->LoadFileProcess(metaFilePath);
-
-            if (metaFileToLoad != nullptr) {
-                auto initDataFromMetaFile = ReadResourceInitData(filePath, metaFileToLoad);
-
-                auto metadataIdentifier = initDataFromMetaFile->Identifier;
-                metadataIdentifier.SetOwner(identifier.GetOwner());
-                metadataIdentifier.SetParent(identifier.GetParent());
-                initDataFromMetaFile->Identifier = metadataIdentifier;
-
-                fileToLoad = resourceManager->LoadFileProcess(metadataIdentifier);
-                initData = initDataFromMetaFile;
-            } else {
-                initData = ReadResourceInitDataLegacy(filePath, fileToLoad);
-            }
-        } else {
-            initData = ReadResourceInitDataLegacy(filePath, fileToLoad);
-        }
+        initData = ResolveMetaAlias(identifier, filePath, fileToLoad);
+    }
+    if (initData == nullptr && fileToLoad != nullptr) {
+        initData = ReadResourceInitDataLegacy(filePath, fileToLoad);
     }
 
     if (initData == nullptr) {

--- a/src/ship/resource/ResourceLoader.cpp
+++ b/src/ship/resource/ResourceLoader.cpp
@@ -213,6 +213,29 @@ std::shared_ptr<ResourceInitData> ResourceLoader::ReadResourceInitData(const std
     return initData;
 }
 
+// Position File::BufferOffset at the resource body. A currently-headed binary resource keeps an OTR
+// header ahead of its body; when init data was supplied externally (a caller or a `.meta`) rather
+// than parsed from that header, skip past it. Headerless buffers (a shader, or any asset once
+// Kenix3/libultraship#1160 removes the header) have no valid byte order / matching type and are left
+// at offset 0. Remove this and its call sites along with the header under #1160.
+static void SetBufferOffset(const std::shared_ptr<File>& file, const std::shared_ptr<ResourceInitData>& initData) {
+    if (file == nullptr || initData->Format != RESOURCE_FORMAT_BINARY || file->Buffer->size() < OTR_HEADER_SIZE) {
+        return;
+    }
+    auto reader = std::make_shared<BinaryReader>(std::make_shared<MemoryStream>(file->Buffer));
+    auto byteOrder = (Endianness)reader->ReadInt8();
+    if (byteOrder != Endianness::Little && byteOrder != Endianness::Big) {
+        return;
+    }
+    reader->SetEndianness(byteOrder);
+    reader->ReadInt8(); // isCustom
+    reader->ReadInt8(); // reserved
+    reader->ReadInt8(); // reserved
+    if (reader->ReadUInt32() == initData->Type) {
+        file->BufferOffset = OTR_HEADER_SIZE;
+    }
+}
+
 std::shared_ptr<ResourceInitData> ResourceLoader::ResolveMetaAlias(const ResourceIdentifier& identifier,
                                                                    const std::string& filePath,
                                                                    std::shared_ptr<File>& fileToLoad) {
@@ -264,11 +287,13 @@ std::shared_ptr<IResource> ResourceLoader::LoadResource(const ResourceIdentifier
     const auto filePath = ResolveIdentifierPath(identifier, mResourceManager);
 
     // fileToLoad is the file at filePath, or null when only a `.meta` names this path.
+    bool legacyInitData = false;
     if (initData == nullptr) {
         initData = ResolveMetaAlias(identifier, filePath, fileToLoad);
     }
     if (initData == nullptr && fileToLoad != nullptr) {
         initData = ReadResourceInitDataLegacy(filePath, fileToLoad);
+        legacyInitData = true;
     }
 
     if (initData == nullptr) {
@@ -297,6 +322,9 @@ std::shared_ptr<IResource> ResourceLoader::LoadResource(const ResourceIdentifier
 
     switch (initData->Format) {
         case RESOURCE_FORMAT_BINARY:
+            if (!legacyInitData) {
+                SetBufferOffset(fileToLoad, initData);
+            }
             fileToLoad->Reader = CreateBinaryReader(fileToLoad, initData);
             break;
         case RESOURCE_FORMAT_XML:

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -101,11 +101,37 @@ std::shared_ptr<File> ResourceManager::LoadFileProcess(uint64_t hash) {
     return file;
 }
 
-bool ResourceManager::HasMetaAlias(const ResourceIdentifier& identifier) {
+std::shared_ptr<ResourceInitData> ResourceManager::ResolveMetaAlias(const ResourceIdentifier& identifier) {
     const std::string* basePath =
         identifier.IsPath() ? &identifier.GetPath() : mArchiveManager->HashToString(identifier.GetPathHash());
+    if (basePath == nullptr || basePath->empty()) {
+        return nullptr;
+    }
 
-    return basePath != nullptr && !basePath->empty() && mArchiveManager->HasFile(*basePath + ".meta");
+    auto metaFile = LoadFileProcess({ *basePath + ".meta", identifier.GetOwner(), identifier.GetParent() });
+    if (metaFile == nullptr) {
+        return nullptr;
+    }
+
+    auto metaInitData = GetResourceLoader()->ReadResourceInitData(*basePath, metaFile);
+
+    auto targetIdentifier = metaInitData->Identifier;
+    targetIdentifier.SetOwner(identifier.GetOwner());
+    targetIdentifier.SetParent(identifier.GetParent());
+    metaInitData->Identifier = targetIdentifier;
+
+    // Both candidates are ranked by the archive holding them, and the higher one loads. A tie
+    // means one archive supplies both, and there its `.meta` is the more specific instruction.
+    // Nothing at the requested path reports -1, so any reachable target outranks it.
+    const int32_t targetPriority = mArchiveManager->GetFilePriority(targetIdentifier);
+    const int32_t basePriority = mArchiveManager->GetFilePriority(identifier);
+    if (targetPriority < basePriority) {
+        SPDLOG_TRACE("Alias {} -> {} not taken: target ranks {} against {} at the requested path", *basePath,
+                     targetIdentifier.GetPath(), targetPriority, basePriority);
+        return nullptr;
+    }
+
+    return metaInitData;
 }
 
 std::shared_ptr<IResource> ResourceManager::LoadResourceProcess(const ResourceIdentifier& identifier, bool loadExact,
@@ -163,10 +189,23 @@ std::shared_ptr<IResource> ResourceManager::LoadResourceProcess(const ResourceId
         }
     }
 
-    // Get the file from the OTR. Finding nothing is not fatal by itself, since a `.meta` here can
-    // name a target elsewhere for the loader to load instead. Give up only when there is neither.
-    auto file = LoadFileProcess(identifier);
-    if (file == nullptr && !HasMetaAlias(identifier)) {
+    // A `.meta` beside this path can name a different file to load in its place
+    std::shared_ptr<File> file = nullptr;
+    if (initData == nullptr) {
+        if (auto metaInitData = ResolveMetaAlias(identifier)) {
+            file = LoadFileProcess(metaInitData->Identifier);
+            if (file != nullptr) {
+                initData = metaInitData;
+            }
+        }
+    }
+
+    // Get the file from the OTR
+    if (file == nullptr) {
+        file = LoadFileProcess(identifier);
+    }
+
+    if (file == nullptr) {
         if (identifier.IsPath()) {
             SPDLOG_TRACE("Failed to load resource file at path {}", identifier.GetPath());
         } else {

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -101,6 +101,13 @@ std::shared_ptr<File> ResourceManager::LoadFileProcess(uint64_t hash) {
     return file;
 }
 
+bool ResourceManager::HasMetaAlias(const ResourceIdentifier& identifier) {
+    const std::string* basePath =
+        identifier.IsPath() ? &identifier.GetPath() : mArchiveManager->HashToString(identifier.GetPathHash());
+
+    return basePath != nullptr && !basePath->empty() && mArchiveManager->HasFile(*basePath + ".meta");
+}
+
 std::shared_ptr<IResource> ResourceManager::LoadResourceProcess(const ResourceIdentifier& identifier, bool loadExact,
                                                                 std::shared_ptr<ResourceInitData> initData) {
     if (initData != nullptr) {
@@ -156,9 +163,10 @@ std::shared_ptr<IResource> ResourceManager::LoadResourceProcess(const ResourceId
         }
     }
 
-    // Get the file from the OTR
+    // Get the file from the OTR. Finding nothing is not fatal by itself, since a `.meta` here can
+    // name a target elsewhere for the loader to load instead. Give up only when there is neither.
     auto file = LoadFileProcess(identifier);
-    if (file == nullptr) {
+    if (file == nullptr && !HasMetaAlias(identifier)) {
         if (identifier.IsPath()) {
             SPDLOG_TRACE("Failed to load resource file at path {}", identifier.GetPath());
         } else {

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -117,7 +117,6 @@ std::shared_ptr<ResourceInitData> ResourceManager::ResolveMetaAlias(const Resour
 
     auto targetIdentifier = metaInitData->Identifier;
     targetIdentifier.SetOwner(identifier.GetOwner());
-    targetIdentifier.SetParent(identifier.GetParent());
     metaInitData->Identifier = targetIdentifier;
 
     // Both candidates are ranked by the archive holding them, and the higher one loads. A tie

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -417,13 +417,6 @@ void ResourceManager::UnloadResourcesProcess(const ResourceFilter& filter) {
 
     for (const auto& key : *list.get()) {
         UnloadResource({ key, mDefaultCacheOwner, mDefaultCacheArchive });
-
-        // A resource reached through a `.meta` is cached under the path the `.meta` sits at, and
-        // nothing is listed under that path for this loop to reach. Evict it alongside the `.meta`
-        // so it cannot outlive the target it was built from.
-        if (key.ends_with(".meta")) {
-            UnloadResource({ key.substr(0, key.size() - 5), mDefaultCacheOwner, mDefaultCacheArchive });
-        }
     }
 }
 

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -417,6 +417,13 @@ void ResourceManager::UnloadResourcesProcess(const ResourceFilter& filter) {
 
     for (const auto& key : *list.get()) {
         UnloadResource({ key, mDefaultCacheOwner, mDefaultCacheArchive });
+
+        // A resource reached through a `.meta` is cached under the path the `.meta` sits at, and
+        // nothing is listed under that path for this loop to reach. Evict it alongside the `.meta`
+        // so it cannot outlive the target it was built from.
+        if (key.ends_with(".meta")) {
+            UnloadResource({ key.substr(0, key.size() - 5), mDefaultCacheOwner, mDefaultCacheArchive });
+        }
     }
 }
 

--- a/src/ship/resource/archive/Archive.cpp
+++ b/src/ship/resource/archive/Archive.cpp
@@ -172,11 +172,7 @@ void Archive::SetGameVersion(uint32_t gameVersion) {
 }
 
 void Archive::IndexFile(const std::string& filePath) {
-    if (filePath.length() > 5 && filePath.substr(filePath.length() - 5) == ".meta") {
-        IndexFile(filePath.substr(0, filePath.length() - 5));
-        return;
-    }
-
+    // Indexed under the literal name, so a `foo.meta` alias stays distinct from the `foo` it redirects.
     (*mHashes)[CRC64(filePath.c_str())] = filePath;
 }
 

--- a/src/ship/resource/archive/Archive.cpp
+++ b/src/ship/resource/archive/Archive.cpp
@@ -167,6 +167,14 @@ void Archive::SetInitialized(bool isInitialized) {
     mIsInitialized = isInitialized;
 }
 
+int32_t Archive::GetPriority() {
+    return mPriority;
+}
+
+void Archive::SetPriority(int32_t priority) {
+    mPriority = priority;
+}
+
 void Archive::SetGameVersion(uint32_t gameVersion) {
     mGameVersion = gameVersion;
 }

--- a/src/ship/resource/archive/ArchiveManager.cpp
+++ b/src/ship/resource/archive/ArchiveManager.cpp
@@ -68,8 +68,10 @@ std::shared_ptr<Archive> ArchiveManager::GetArchiveFromFile(const std::string& f
     return mFileToArchive[CRC64(filePath.c_str())];
 }
 
-int32_t ArchiveManager::GetFilePriority(const std::string& filePath) {
-    auto it = mFileToArchive.find(CRC64(filePath.c_str()));
+int32_t ArchiveManager::GetFilePriority(const ResourceIdentifier& identifier) {
+    const uint64_t hash = identifier.IsPath() ? CRC64(identifier.GetPath().c_str()) : identifier.GetPathHash();
+
+    auto it = mFileToArchive.find(hash);
     if (it == mFileToArchive.end() || it->second == nullptr) {
         return -1;
     }

--- a/src/ship/resource/archive/ArchiveManager.cpp
+++ b/src/ship/resource/archive/ArchiveManager.cpp
@@ -158,13 +158,24 @@ void ArchiveManager::ResetVirtualFileSystem() {
     }
 }
 
+void ArchiveManager::AddFile(const std::string& filePath, const std::shared_ptr<Archive>& archive) {
+    const uint64_t hash = CRC64(filePath.c_str());
+    mHashes[hash] = filePath;
+    mFileToArchive[hash] = archive;
+
+    // add foo hash to mHashes for foo.meta, but don't add it to mFileToArchive because we
+    // don't know this archive has foo
+    if (filePath.ends_with(".meta")) {
+        const std::string basePath = filePath.substr(0, filePath.size() - 5);
+        mHashes[CRC64(basePath.c_str())] = basePath;
+    }
+}
+
 bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::string& filePath,
                                const std::vector<uint8_t>& data) {
     if (archive) {
         if (archive->WriteFile(filePath, data)) {
-            auto hash = CRC64(filePath.c_str());
-            mHashes[hash] = filePath;
-            mFileToArchive[hash] = archive;
+            AddFile(filePath, archive);
             return true; // Successfully wrote file
         }
     }
@@ -290,8 +301,7 @@ std::shared_ptr<Archive> ArchiveManager::AddArchive(std::shared_ptr<Archive> arc
     }
     const auto fileList = archive->ListFiles();
     for (auto& [hash, filename] : *fileList.get()) {
-        mHashes[hash] = filename;
-        mFileToArchive[hash] = archive;
+        AddFile(filename, archive);
 
         size_t lastSlash = filename.find_last_of('/');
         if (lastSlash != std::string::npos) {

--- a/src/ship/resource/archive/ArchiveManager.cpp
+++ b/src/ship/resource/archive/ArchiveManager.cpp
@@ -160,8 +160,7 @@ void ArchiveManager::ResetVirtualFileSystem() {
     }
 }
 
-void ArchiveManager::AddFile(const std::string& filePath, const std::shared_ptr<Archive>& archive) {
-    const uint64_t hash = CRC64(filePath.c_str());
+void ArchiveManager::AddFile(uint64_t hash, const std::string& filePath, const std::shared_ptr<Archive>& archive) {
     mHashes[hash] = filePath;
     mFileToArchive[hash] = archive;
 
@@ -177,7 +176,8 @@ bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::stri
                                const std::vector<uint8_t>& data) {
     if (archive) {
         if (archive->WriteFile(filePath, data)) {
-            AddFile(filePath, archive);
+            auto hash = CRC64(filePath.c_str());
+            AddFile(hash, filePath, archive);
             return true; // Successfully wrote file
         }
     }
@@ -303,7 +303,7 @@ std::shared_ptr<Archive> ArchiveManager::AddArchive(std::shared_ptr<Archive> arc
     }
     const auto fileList = archive->ListFiles();
     for (auto& [hash, filename] : *fileList.get()) {
-        AddFile(filename, archive);
+        AddFile(hash, filename, archive);
 
         size_t lastSlash = filename.find_last_of('/');
         if (lastSlash != std::string::npos) {

--- a/src/ship/resource/archive/ArchiveManager.cpp
+++ b/src/ship/resource/archive/ArchiveManager.cpp
@@ -160,7 +160,7 @@ void ArchiveManager::ResetVirtualFileSystem() {
     }
 }
 
-void ArchiveManager::AddFile(uint64_t hash, const std::string& filePath, const std::shared_ptr<Archive>& archive) {
+void ArchiveManager::AddFileToVfs(uint64_t hash, const std::string& filePath, const std::shared_ptr<Archive>& archive) {
     mHashes[hash] = filePath;
     mFileToArchive[hash] = archive;
 
@@ -177,7 +177,7 @@ bool ArchiveManager::WriteFile(std::shared_ptr<Archive> archive, const std::stri
     if (archive) {
         if (archive->WriteFile(filePath, data)) {
             auto hash = CRC64(filePath.c_str());
-            AddFile(hash, filePath, archive);
+            AddFileToVfs(hash, filePath, archive);
             return true; // Successfully wrote file
         }
     }
@@ -303,7 +303,7 @@ std::shared_ptr<Archive> ArchiveManager::AddArchive(std::shared_ptr<Archive> arc
     }
     const auto fileList = archive->ListFiles();
     for (auto& [hash, filename] : *fileList.get()) {
-        AddFile(hash, filename, archive);
+        AddFileToVfs(hash, filename, archive);
 
         size_t lastSlash = filename.find_last_of('/');
         if (lastSlash != std::string::npos) {

--- a/src/ship/resource/archive/ArchiveManager.cpp
+++ b/src/ship/resource/archive/ArchiveManager.cpp
@@ -68,6 +68,14 @@ std::shared_ptr<Archive> ArchiveManager::GetArchiveFromFile(const std::string& f
     return mFileToArchive[CRC64(filePath.c_str())];
 }
 
+int32_t ArchiveManager::GetFilePriority(const std::string& filePath) {
+    auto it = mFileToArchive.find(CRC64(filePath.c_str()));
+    if (it == mFileToArchive.end() || it->second == nullptr) {
+        return -1;
+    }
+    return it->second->GetPriority();
+}
+
 std::shared_ptr<std::vector<std::string>> ArchiveManager::ListFiles(const std::string& searchMask) {
     std::list<std::string> includes = {};
     if (!searchMask.empty()) {
@@ -276,6 +284,7 @@ std::shared_ptr<Archive> ArchiveManager::AddArchive(std::shared_ptr<Archive> arc
     SPDLOG_INFO("Adding Archive {} to Archive Manager", archive->GetPath());
 
     mArchives.push_back(archive);
+    archive->SetPriority(static_cast<int32_t>(mArchives.size() - 1));
     if (archive->HasGameVersion()) {
         mGameVersions.push_back(archive->GetGameVersion());
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(libultraship_tests
     sound_matrix_decoder_tests.cpp
     path_file_helper_tests.cpp
     archive_resource_tests.cpp
+    archive_resource_meta_resolution_tests.cpp
     glob_tests.cpp
     splittext_tests.cpp
     path_diskfile_tests.cpp

--- a/tests/archive_resource_fixtures.h
+++ b/tests/archive_resource_fixtures.h
@@ -1,0 +1,122 @@
+#pragma once
+
+// Archive fixtures shared by the archive/resource test suites.
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "ship/resource/File.h"
+#include "ship/resource/archive/Archive.h"
+#include "ship/utils/StrHash64.h"
+
+namespace LusTest {
+
+// In-memory archive that does not require Context.
+class TestRamArchive : public Ship::Archive {
+  public:
+    explicit TestRamArchive(const std::string& path = "ram://test",
+                            const std::unordered_map<std::string, std::string>& files = {},
+                            const std::string& manifest = R"({"name":"TestArchive","code_version":1})")
+        : Ship::Archive(path), mTestFiles(files), mManifestJson(manifest) {
+    }
+
+    bool Open() override {
+        for (const auto& [path, _] : mTestFiles) {
+            IndexFile(path);
+        }
+        return true;
+    }
+
+    bool Close() override {
+        return true;
+    }
+
+    bool WriteFile(const std::string& path, const std::vector<uint8_t>& data) override {
+        std::string content(data.begin(), data.end());
+        mTestFiles[path] = content;
+        IndexFile(path);
+        return true;
+    }
+
+    std::shared_ptr<Ship::File> LoadFile(const std::string& filePath) override {
+        // Serve manifest.json so Archive::Load() can parse it without Context
+        if (filePath == "manifest.json") {
+            return MakeFile(mManifestJson);
+        }
+        auto it = mTestFiles.find(filePath);
+        if (it == mTestFiles.end()) {
+            return nullptr;
+        }
+        return MakeFile(it->second);
+    }
+
+    // Resolve hash → path locally so we don't need Context::GetCurrent()
+    std::shared_ptr<Ship::File> LoadFile(uint64_t hash) override {
+        for (const auto& [path, _] : mTestFiles) {
+            if (CRC64(path.c_str()) == hash) {
+                return LoadFile(path);
+            }
+        }
+        return nullptr;
+    }
+
+  private:
+    std::unordered_map<std::string, std::string> mTestFiles;
+    std::string mManifestJson;
+
+    static std::shared_ptr<Ship::File> MakeFile(const std::string& content) {
+        auto file = std::make_shared<Ship::File>();
+        file->Buffer = std::make_shared<std::vector<char>>(content.begin(), content.end());
+        file->IsLoaded = true;
+        return file;
+    }
+};
+
+// Helper: build and load a TestRamArchive with given files
+inline std::shared_ptr<TestRamArchive> LoadedArchive(const std::string& path,
+                                                     const std::unordered_map<std::string, std::string>& files) {
+    auto archive = std::make_shared<TestRamArchive>(path, files);
+    archive->Load();
+    return archive;
+}
+
+// A real directory on disk. ArchiveManager::Init only marks itself initialized once it has
+// found at least one archive in the paths it was given, so a ResourceManager needs one of
+// these to get through OnInit.
+class TempDirectoryArchive {
+  public:
+    explicit TempDirectoryArchive(const std::unordered_map<std::string, std::string>& files = {}) {
+        static size_t sCounter = 0;
+        mPath = std::filesystem::temp_directory_path() / ("lus_resource_manager_test_" + std::to_string(sCounter++));
+        std::filesystem::create_directories(mPath);
+        WriteTextFile("manifest.json", R"({"name":"TempArchive","code_version":1})");
+        for (const auto& [path, content] : files) {
+            WriteTextFile(path, content);
+        }
+    }
+
+    ~TempDirectoryArchive() {
+        std::error_code ec;
+        std::filesystem::remove_all(mPath, ec);
+    }
+
+    const std::filesystem::path& GetPath() const {
+        return mPath;
+    }
+
+  private:
+    std::filesystem::path mPath;
+
+    void WriteTextFile(const std::string& relativePath, const std::string& content) {
+        const auto filePath = mPath / relativePath;
+        std::filesystem::create_directories(filePath.parent_path());
+        std::ofstream out(filePath, std::ios::binary);
+        out << content;
+    }
+};
+
+} // namespace LusTest

--- a/tests/archive_resource_meta_resolution_tests.cpp
+++ b/tests/archive_resource_meta_resolution_tests.cpp
@@ -1,0 +1,399 @@
+#include <gtest/gtest.h>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "ship/resource/File.h"
+#include "ship/resource/Resource.h"
+#include "ship/resource/ResourceLoader.h"
+#include "ship/resource/ResourceManager.h"
+#include "ship/resource/ResourceType.h"
+#include "ship/resource/archive/Archive.h"
+#include "ship/resource/archive/ArchiveManager.h"
+#include "ship/resource/factory/BlobFactory.h"
+#include "ship/resource/type/Blob.h"
+#include "ship/utils/StrHash64.h"
+#include "ship/utils/binarytools/endianness.h"
+
+#include "archive_resource_fixtures.h"
+
+namespace {
+
+const std::string kBase = "textures/base.bin";
+const std::string kBaseMeta = kBase + ".meta";
+const std::string kAlias = "textures/alias.bin";
+
+constexpr size_t kBlobPadding = 16;
+
+std::string BlobBody(const std::string& payload) {
+    const uint32_t size = static_cast<uint32_t>(payload.size());
+    std::string body(sizeof(uint32_t), '\0');
+    std::memcpy(body.data(), &size, sizeof(uint32_t));
+    return body + payload;
+}
+
+std::string BareBlob(const std::string& payload) {
+    return BlobBody(payload);
+}
+
+std::string HeaderedBlob(const std::string& payload) {
+    std::string header(OTR_HEADER_SIZE, '\0');
+    header[0] = static_cast<char>(Ship::Endianness::Native);
+    const uint32_t type = static_cast<uint32_t>(Ship::ResourceType::Blob);
+    std::memcpy(header.data() + 4, &type, sizeof(uint32_t));
+    return header + BlobBody(payload);
+}
+
+std::string MetaJson(const std::string& targetPath, bool isCustom = false) {
+    std::string json = R"({"type":"Blob","format":"Binary","version":0)";
+    if (!targetPath.empty()) {
+        json += R"(,"path":")" + targetPath + R"(")";
+    }
+    if (isCustom) {
+        json += R"(,"isCustom":true)";
+    }
+    return json + "}";
+}
+
+class UnreadableFileArchive : public LusTest::TestRamArchive {
+  public:
+    UnreadableFileArchive(const std::string& path, const std::unordered_map<std::string, std::string>& files,
+                          std::string unreadable)
+        : LusTest::TestRamArchive(path, files), mUnreadable(std::move(unreadable)) {
+    }
+
+    using LusTest::TestRamArchive::LoadFile;
+
+    std::shared_ptr<Ship::File> LoadFile(const std::string& filePath) override {
+        return filePath == mUnreadable ? nullptr : LusTest::TestRamArchive::LoadFile(filePath);
+    }
+
+  private:
+    std::string mUnreadable;
+};
+
+struct MetaAliasHarness {
+    MetaAliasHarness()
+        : base(), threadPool(std::make_shared<Ship::ThreadPool>(1)),
+          manager(std::make_shared<Ship::ResourceManager>(threadPool)) {
+        manager->Init({ { "archivePaths", std::vector<std::string>{ base.GetPath().string() } },
+                        { "validHashes", std::vector<uint32_t>{} } });
+        manager->GetResourceLoader()->RegisterResourceFactory(std::make_shared<Ship::ResourceFactoryBinaryBlobV0>(),
+                                                              RESOURCE_FORMAT_BINARY, "Blob",
+                                                              static_cast<uint32_t>(Ship::ResourceType::Blob), 0);
+    }
+
+    void Mount(const std::string& name, const std::unordered_map<std::string, std::string>& files) {
+        manager->GetArchiveManager()->AddArchive(LusTest::LoadedArchive("ram://" + name, files));
+    }
+
+    void Mount(const std::shared_ptr<Ship::Archive>& archive) {
+        archive->Load();
+        manager->GetArchiveManager()->AddArchive(archive);
+    }
+
+    std::string Load(const std::string& path) {
+        return PayloadOf(manager->LoadResourceProcess(path));
+    }
+
+    std::string Load(const Ship::ResourceIdentifier& identifier) {
+        return PayloadOf(manager->LoadResourceProcess(identifier));
+    }
+
+    static std::string PayloadOf(const std::shared_ptr<Ship::IResource>& resource) {
+        auto blob = std::dynamic_pointer_cast<Ship::Blob>(resource);
+        if (blob == nullptr) {
+            return "<load failed>";
+        }
+        if (blob->Data.size() < kBlobPadding) {
+            return "<truncated>";
+        }
+        return std::string(blob->Data.begin(), blob->Data.end() - kBlobPadding);
+    }
+
+    LusTest::TempDirectoryArchive base;
+    std::shared_ptr<Ship::ThreadPool> threadPool;
+    std::shared_ptr<Ship::ResourceManager> manager;
+};
+
+} // namespace
+
+// ============================================================
+// Single-archive cases
+// ============================================================
+
+// One archive ships the real asset, the `.meta` and the target all at once.
+//
+//   vanilla   base.bin
+//   mod       base.bin, alias.bin, base.bin.meta -> alias.bin
+//
+// Loads alias.bin: one archive supplies both candidates, so its `.meta` decides.
+TEST(MetaAliasResolution, OwnMetaOutranksOwnRealAsset) {
+    MetaAliasHarness h;
+    h.Mount("vanilla", { { kBase, HeaderedBlob("vanilla") } });
+    h.Mount("mod",
+            { { kBase, HeaderedBlob("mod real") }, { kBaseMeta, MetaJson(kAlias) }, { kAlias, BareBlob("aliased") } });
+
+    EXPECT_EQ(h.Load(kBase), "aliased");
+}
+
+// A `.meta` whose target is nowhere to be found.
+//
+//   vanilla   base.bin
+//   mod       base.bin, base.bin.meta -> alias.bin
+//
+// Loads mod's base.bin: with no target there is nothing to alias to, so the real asset remains.
+TEST(MetaAliasResolution, FallsBackToRealAssetWhenTargetAbsent) {
+    MetaAliasHarness h;
+    h.Mount("vanilla", { { kBase, HeaderedBlob("vanilla") } });
+    h.Mount("mod", { { kBase, HeaderedBlob("mod real") }, { kBaseMeta, MetaJson(kAlias) } });
+
+    EXPECT_EQ(h.Load(kBase), "mod real");
+}
+
+// The higher archive ships no real asset at the requested path, only the alias and its target.
+//
+//   vanilla   base.bin
+//   mod       alias.bin, base.bin.meta -> alias.bin
+//
+// Loads alias.bin: the alias ranks at mod, which outranks vanilla's real asset.
+TEST(MetaAliasResolution, AliasResolvesWithNoRealAssetInItsArchive) {
+    MetaAliasHarness h;
+    h.Mount("vanilla", { { kBase, HeaderedBlob("vanilla") } });
+    h.Mount("mod", { { kBaseMeta, MetaJson(kAlias) }, { kAlias, BareBlob("aliased") } });
+
+    EXPECT_EQ(h.Load(kBase), "aliased");
+}
+
+// An archive with only a `.meta`, pointing at a file that does not exist.
+//
+//   vanilla   base.bin
+//   mod       base.bin.meta -> alias.bin
+//
+// Loads vanilla's base.bin.
+TEST(MetaAliasResolution, MetaOnlyArchiveDoesNotShadowLowerRealAsset) {
+    MetaAliasHarness h;
+    h.Mount("vanilla", { { kBase, HeaderedBlob("vanilla") } });
+    h.Mount("mod", { { kBaseMeta, MetaJson(kAlias) } });
+
+    EXPECT_EQ(h.Load(kBase), "vanilla");
+}
+
+// No `.meta` involved at all — plain archive priority.
+//
+//   vanilla   base.bin
+//   mod       base.bin
+//
+// Loads mod's base.bin: the highest-ranked real asset.
+TEST(MetaAliasResolution, RealAssetLoadsWhenNoMetaExists) {
+    MetaAliasHarness h;
+    h.Mount("vanilla", { { kBase, HeaderedBlob("vanilla") } });
+    h.Mount("mod", { { kBase, HeaderedBlob("mod real") } });
+
+    EXPECT_EQ(h.Load(kBase), "mod real");
+}
+
+// An alias target that still carries its OTR header.
+//
+//   vanilla   base.bin
+//   mod       alias.bin (headered), base.bin.meta -> alias.bin
+//
+// Loads alias.bin's payload: init data from a `.meta` skips the legacy header parse, so the
+// header has to be stepped over or the factory reads it as payload.
+TEST(MetaAliasResolution, HeaderedAliasTargetSkipsOtrHeader) {
+    MetaAliasHarness h;
+    h.Mount("vanilla", { { kBase, HeaderedBlob("vanilla") } });
+    h.Mount("mod", { { kBaseMeta, MetaJson(kAlias) }, { kAlias, HeaderedBlob("aliased") } });
+
+    EXPECT_EQ(h.Load(kBase), "aliased");
+}
+
+// ============================================================
+// Layered cases
+// ============================================================
+
+// The `.meta`, the real asset and the target spread across three archives.
+//
+//   vanilla     base.bin
+//   10-meta     base.bin.meta -> alias.bin
+//   20-real     base.bin
+//   30-target   alias.bin
+//
+// Loads alias.bin: the alias ranks where its target lives (30), above the real asset at 20.
+TEST(MetaAliasResolution, AliasTargetInHigherArchiveOutranksRealAsset) {
+    MetaAliasHarness h;
+    h.Mount("vanilla", { { kBase, HeaderedBlob("vanilla") } });
+    h.Mount("10-meta", { { kBaseMeta, MetaJson(kAlias) } });
+    h.Mount("20-real", { { kBase, HeaderedBlob("mod real") } });
+    h.Mount("30-target", { { kAlias, BareBlob("aliased") } });
+
+    EXPECT_EQ(h.Load(kBase), "aliased");
+}
+
+// The same stack with the target archive removed and the `.meta` left untouched.
+//
+//   vanilla   base.bin
+//   10-meta   base.bin.meta -> alias.bin
+//   20-real   base.bin
+//
+// Loads 20-real's base.bin.
+TEST(MetaAliasResolution, AliasFallsBackWhenTargetArchiveDropped) {
+    MetaAliasHarness h;
+    h.Mount("vanilla", { { kBase, HeaderedBlob("vanilla") } });
+    h.Mount("10-meta", { { kBaseMeta, MetaJson(kAlias) } });
+    h.Mount("20-real", { { kBase, HeaderedBlob("mod real") } });
+
+    EXPECT_EQ(h.Load(kBase), "mod real");
+}
+
+// A real asset ranked above the alias target.
+//
+//   vanilla              base.bin
+//   10-meta-and-target   alias.bin, base.bin.meta -> alias.bin
+//   20-real              base.bin
+//
+// Loads 20-real's base.bin: the alias ranks where its target lives (10), which loses to a real
+// asset at 20.
+TEST(MetaAliasResolution, RealAssetOutranksLowerAliasTarget) {
+    MetaAliasHarness h;
+    h.Mount("vanilla", { { kBase, HeaderedBlob("vanilla") } });
+    h.Mount("10-meta-and-target", { { kBaseMeta, MetaJson(kAlias) }, { kAlias, BareBlob("aliased") } });
+    h.Mount("20-real", { { kBase, HeaderedBlob("mod real") } });
+
+    EXPECT_EQ(h.Load(kBase), "mod real");
+}
+
+// A `.meta` pointing down the stack at a target below itself.
+//
+//   vanilla     base.bin
+//   10-target   alias.bin
+//   20-meta     base.bin.meta -> alias.bin
+//
+// Loads alias.bin: the target is resolved across every mounted archive, not just from the
+// `.meta`'s own archive upward.
+TEST(MetaAliasResolution, AliasTargetBelowTheMetaStillResolves) {
+    MetaAliasHarness h;
+    h.Mount("vanilla", { { kBase, HeaderedBlob("vanilla") } });
+    h.Mount("10-target", { { kAlias, BareBlob("aliased") } });
+    h.Mount("20-meta", { { kBaseMeta, MetaJson(kAlias) } });
+
+    EXPECT_EQ(h.Load(kBase), "aliased");
+}
+
+// ============================================================
+// Resolution details
+// ============================================================
+
+// A `.meta` with no "path" key, beside a resource that carries no init data of its own.
+//
+//   archive   base.bin (no OTR header), base.bin.meta (no "path")
+//
+// Loads base.bin: the `.meta` provides its init data.
+TEST(MetaAliasResolution, MetaProvidesInitDataForHeaderlessResource) {
+    MetaAliasHarness h;
+    h.Mount("archive", { { kBase, BareBlob("base") }, { kBaseMeta, MetaJson("") } });
+
+    EXPECT_EQ(h.Load(kBase), "base");
+}
+
+// A `.meta` declaring its target custom.
+//
+//   archive   alias.bin, base.bin.meta -> alias.bin ("isCustom": true)
+//
+// Loads alias.bin as custom.
+TEST(MetaAliasResolution, MetaCanDeclareIsCustom) {
+    MetaAliasHarness h;
+    h.Mount("archive", { { kBaseMeta, MetaJson(kAlias, /*isCustom=*/true) }, { kAlias, BareBlob("aliased") } });
+
+    auto resource = h.manager->LoadResourceProcess(kBase);
+    ASSERT_NE(resource, nullptr);
+    EXPECT_TRUE(h.manager->GetResourceIsCustom(resource));
+}
+
+// The same `.meta` without an "isCustom" key.
+//
+//   archive   alias.bin, base.bin.meta -> alias.bin
+//
+// Loads alias.bin as non-custom.
+TEST(MetaAliasResolution, AliasedResourceIsNotCustomByDefault) {
+    MetaAliasHarness h;
+    h.Mount("archive", { { kBaseMeta, MetaJson(kAlias) }, { kAlias, BareBlob("aliased") } });
+
+    auto resource = h.manager->LoadResourceProcess(kBase);
+    ASSERT_NE(resource, nullptr);
+    EXPECT_FALSE(h.manager->GetResourceIsCustom(resource));
+}
+
+// A request by CRC64 rather than by path.
+//
+//   archive   alias.bin, base.bin.meta -> alias.bin
+//
+// Loads alias.bin.
+TEST(MetaAliasResolution, HashIdentifiedRequestResolvesMeta) {
+    MetaAliasHarness h;
+    h.Mount("archive", { { kBaseMeta, MetaJson(kAlias) }, { kAlias, BareBlob("aliased") } });
+
+    EXPECT_EQ(h.Load(Ship::ResourceIdentifier(CRC64(kBase.c_str()), 0, nullptr)), "aliased");
+}
+
+// An alias target that is indexed but cannot be served — a zero-byte zip entry, or a folder
+// entry deleted since it was indexed.
+//
+//   vanilla   base.bin
+//   mod       alias.bin (indexed, unreadable), base.bin.meta -> alias.bin
+//
+// Loads vanilla's base.bin.
+TEST(MetaAliasResolution, UnreadableAliasTargetFallsBackToRealAsset) {
+    MetaAliasHarness h;
+    h.Mount("vanilla", { { kBase, HeaderedBlob("vanilla") } });
+    h.Mount(
+        std::make_shared<UnreadableFileArchive>("ram://mod",
+                                                std::unordered_map<std::string, std::string>{
+                                                    { kBaseMeta, MetaJson(kAlias) }, { kAlias, BareBlob("aliased") } },
+                                                kAlias));
+
+    EXPECT_EQ(h.Load(kBase), "vanilla");
+}
+
+// Unloading an archive whose `.meta` produced a cached resource.
+//
+//   archive   alias.bin, base.bin.meta -> alias.bin
+//
+// Evicts the resource cached at base.bin.
+TEST(MetaAliasResolution, UnloadEvictsResourceReachedThroughMeta) {
+    MetaAliasHarness h;
+    h.Mount("archive", { { kBaseMeta, MetaJson(kAlias) }, { kAlias, BareBlob("aliased") } });
+
+    ASSERT_EQ(h.Load(kBase), "aliased");
+    ASSERT_NE(h.manager->GetCachedResource(kBase), nullptr);
+
+    h.manager->UnloadResources("*");
+
+    EXPECT_EQ(h.manager->GetCachedResource(kBase), nullptr);
+}
+
+// An alias shipped under alt/, unloaded by directory the way a loading zone does. The request has
+// no alt/ prefix — LoadResourceProcess prepends it, so the resource caches under the alt path.
+//
+//   vanilla   base.bin
+//   mod       alt/alias.bin, alt/base.bin.meta -> alt/alias.bin
+//
+// Evicts the resource cached at alt/base.bin.
+TEST(MetaAliasResolution, AltDirectoryUnloadEvictsAliasedResource) {
+    const std::string altBase = Ship::IResource::gAltAssetPrefix + kBase;
+    const std::string altAlias = Ship::IResource::gAltAssetPrefix + kAlias;
+
+    MetaAliasHarness h;
+    h.Mount("vanilla", { { kBase, HeaderedBlob("vanilla") } });
+    h.Mount("mod", { { altBase + ".meta", MetaJson(altAlias) }, { altAlias, BareBlob("aliased") } });
+    h.manager->SetAltAssetsEnabled(true);
+
+    ASSERT_EQ(h.Load(kBase), "aliased");
+    ASSERT_NE(h.manager->GetCachedResource(altBase), nullptr);
+
+    h.manager->UnloadResources(Ship::IResource::gAltAssetPrefix + "*");
+
+    EXPECT_EQ(h.manager->GetCachedResource(altBase), nullptr);
+}

--- a/tests/archive_resource_tests.cpp
+++ b/tests/archive_resource_tests.cpp
@@ -16,111 +16,13 @@
 #include "ship/resource/type/Blob.h"
 #include "ship/utils/StrHash64.h"
 
-// ============================================================
-// TestRamArchive — in-memory archive that does not require Context
-// ============================================================
+#include "archive_resource_fixtures.h"
 
 namespace {
 
-class TestRamArchive final : public Ship::Archive {
-  public:
-    explicit TestRamArchive(const std::string& path = "ram://test",
-                            const std::unordered_map<std::string, std::string>& files = {},
-                            const std::string& manifest = R"({"name":"TestArchive","code_version":1})")
-        : Ship::Archive(path), mTestFiles(files), mManifestJson(manifest) {
-    }
-
-    bool Open() override {
-        for (const auto& [path, _] : mTestFiles) {
-            IndexFile(path);
-        }
-        return true;
-    }
-
-    bool Close() override {
-        return true;
-    }
-
-    bool WriteFile(const std::string& path, const std::vector<uint8_t>& data) override {
-        std::string content(data.begin(), data.end());
-        mTestFiles[path] = content;
-        IndexFile(path);
-        return true;
-    }
-
-    std::shared_ptr<Ship::File> LoadFile(const std::string& filePath) override {
-        // Serve manifest.json so Archive::Load() can parse it without Context
-        if (filePath == "manifest.json") {
-            return MakeFile(mManifestJson);
-        }
-        auto it = mTestFiles.find(filePath);
-        if (it == mTestFiles.end()) {
-            return nullptr;
-        }
-        return MakeFile(it->second);
-    }
-
-    // Resolve hash → path locally so we don't need Context::GetCurrent()
-    std::shared_ptr<Ship::File> LoadFile(uint64_t hash) override {
-        for (const auto& [path, _] : mTestFiles) {
-            if (CRC64(path.c_str()) == hash) {
-                return LoadFile(path);
-            }
-        }
-        return nullptr;
-    }
-
-  private:
-    std::unordered_map<std::string, std::string> mTestFiles;
-    std::string mManifestJson;
-
-    static std::shared_ptr<Ship::File> MakeFile(const std::string& content) {
-        auto file = std::make_shared<Ship::File>();
-        file->Buffer = std::make_shared<std::vector<char>>(content.begin(), content.end());
-        file->IsLoaded = true;
-        return file;
-    }
-};
-
-// Helper: build and load a TestRamArchive with given files
-std::shared_ptr<TestRamArchive> LoadedArchive(const std::string& path,
-                                              const std::unordered_map<std::string, std::string>& files) {
-    auto archive = std::make_shared<TestRamArchive>(path, files);
-    archive->Load();
-    return archive;
-}
-
-class TempDirectoryArchive {
-  public:
-    explicit TempDirectoryArchive(const std::unordered_map<std::string, std::string>& files = {}) {
-        static size_t sCounter = 0;
-        mPath = std::filesystem::temp_directory_path() / ("lus_resource_manager_test_" + std::to_string(sCounter++));
-        std::filesystem::create_directories(mPath);
-        WriteTextFile("manifest.json", R"({"name":"TempArchive","code_version":1})");
-        for (const auto& [path, content] : files) {
-            WriteTextFile(path, content);
-        }
-    }
-
-    ~TempDirectoryArchive() {
-        std::error_code ec;
-        std::filesystem::remove_all(mPath, ec);
-    }
-
-    const std::filesystem::path& GetPath() const {
-        return mPath;
-    }
-
-  private:
-    std::filesystem::path mPath;
-
-    void WriteTextFile(const std::string& relativePath, const std::string& content) {
-        const auto filePath = mPath / relativePath;
-        std::filesystem::create_directories(filePath.parent_path());
-        std::ofstream out(filePath, std::ios::binary);
-        out << content;
-    }
-};
+using LusTest::LoadedArchive;
+using LusTest::TempDirectoryArchive;
+using LusTest::TestRamArchive;
 
 struct ResourceManagerHarness {
     explicit ResourceManagerHarness(const std::unordered_map<std::string, std::string>& files = {})


### PR DESCRIPTION
Ports #1168 ("Resolve `.meta` aliases by archive priority") onto `main`, per #1208.

Not a cherry-pick. `main`'s `.meta` handling is different code — #1187 reworked `ResourceInitData`
and `ResourceIdentifier` together — so `git cherry-pick 9a1a2bd9` conflicts across
`ResourceLoader.cpp` and `ResourceManager.cpp`. This is a reimplementation against the identifier
model.

## What changes

A request for `X` loads whichever of {the file at `X`} and {the target its `.meta` names} sits in
the higher-priority archive, ranked by the archive holding each **asset** rather than the one
holding the `.meta`. Ties go to the `.meta`, since an archive shipping both is being specific about
which it means.

That replaces "the `.meta` always wins", which broke two ways:

- a `.meta` whose target was absent nulled out the file to load and failed outright instead of
  falling back (#1165)
- an archive shipping only a `.meta` claimed a path it had no file for, shadowing real assets in
  every archive below it (#984)

## Commits

| | | |
|---|---|---|
| 1 | Index `.meta` files under their literal name | #1208 item 1 — root cause of #984 |
| 2 | Track archive load-order priority | item 1 |
| 3 | Resolve `.meta` aliases by archive priority | item 1 |
| 4 | Skip the OTR header for binary `.meta` alias targets | item 2 |
| 5 | Let a `.meta` declare `isCustom` | item 3 |
| 6 | Evict aliased resources when their `.meta` is unloaded | item 4 |
| 7 | Index the path a `.meta` implies | supersedes 6, fixes hash-identified aliases |
| 8 | Add tests for `.meta` alias resolution | |
| 9 | Resolve `.meta` aliases in ResourceManager | review feedback |
| 10 | Pass the file hash into AddFile | review feedback |
| 11 | Stop constraining a `.meta` target to the requesting archive | |

Commits 1–3 must land together — 1 alone regresses the target-absent cases.

## Answering the review

Both comments asked for these APIs to be expressed in terms of `ResourceIdentifier`. Tracing the
parameters showed they were symptoms of the logic sitting at the wrong layer, so commit 9 moves it
rather than re-typing a signature.

`ResourceLoader` documents itself as taking a File and its `ResourceInitData` and handing them to a
factory. It was also deciding *which* file to load, reaching back through `mResourceManager` to find
a sidecar, rank it, and load whichever won. And the decision was split: `ResourceManager` decided a
`.meta` might exist, the loader decided whether it wins, and the seam between them travelled as a
null `fileToLoad` — one parameter meaning "here is the pre-loaded file", "here is a hint that may be
replaced", and "nothing is here, go look for a `.meta`" depending on the caller.

`ResolveMetaAlias` now lives on `ResourceManager`, next to the file loading it depends on.
`LoadResourceProcess` resolves the alias, loads whatever won, and hands the loader a file and init
data that agree. `HasMetaAlias` is gone — it existed only to stop the early bail from firing when a
path had nothing but a sidecar, and the bail now simply sits after resolution.

`GetFilePriority` takes a `ResourceIdentifier` (commit 9). It deliberately ignores
`identifier.GetParent()`: scoping the ranking to one archive contradicts the reach-back rule, and
nothing in the tree ever loads with a parent set, so a parent-aware branch would encode a semantic
decision nobody has made. Happy to revisit if that's what was meant.

## Two things found while doing this

**A `.meta` implies a path, which nothing was indexing** (commit 7). `ArchiveManager` keeps two
tables: `mHashes` maps a hash to a path, `mFileToArchive` maps a hash to the archive serving it.
Commit 1 stopped indexing sidecars under their base name, which fixed #984 — a meta-only archive was
claiming a path it had no file for — but it also dropped the `mHashes` entry, which was harmless and
useful. Without it nothing mapped `CRC64(foo)` back to `foo`, so a request identified by hash had no
path to append `.meta` to and could never resolve an alias, and `ListFiles` never mentioned `foo`, so
a directory unload could not reach a resource cached under it.

Commit 7 records `foo` in `mHashes` for every `foo.meta` and deliberately not in `mFileToArchive`.
That closes the hash case, and it retires commit 6: the suffix strip existed because nothing was
listed at the base path for the unload walk to reach, and now something is.

This matters for the motivating use case — an archive shipping only `gLinkHumanSkel.meta` with no
real `gLinkHumanSkel` anywhere is #1165's cross-game scenario, and ports resolve display lists by
CRC64.

**Parent was being copied onto the alias target** (commit 11). An identifier's parent means "load
this from that archive" — `LoadFileProcess` hands the path straight to it instead of going through
the virtual file system. Copying it onto the target claimed the target lives in the same archive as
the request, which the `.meta` says nothing about; a target is resolved across every mounted archive,
the same way `GetFilePriority` ranks it. Owner still carries over, so a resource reached through an
alias stays tagged for whoever asked for it.

## Decisions worth review

**Hash-identified resources can resolve a `.meta`.** #1208 leaves this one open. A `.meta` is keyed
by the path it sits beside, and `main`'s `ResourceIdentifier` may hold a hash rather than a path, so
resolving one requires turning the hash back into a path first. Supporting it is the reason commit 7
exists.

They are a live path, not a hypothetical — `ResourceManager::LoadResource(uint64_t crc)` braces a
hash identifier straight through, and ports reach it via `ResourceGetDataByCrc`. Excluding them would
also be internally inconsistent: `ResourceLoader` already resolves hash→path, so aliasing would work
for a hash request when the archive happened to ship a real file too, and silently not when it
shipped only the `.meta`.

**Decided against supporting alias chaining.** A `.meta` carries `ResourceInitData` — `type`,
`format`, `version`, `isCustom` — not just a target path. Allowing `X.meta → Y.meta → Z` would mean
deciding *which* of those `.meta` files the init data is read from, and there is no obviously correct
answer. Getting it wrong mis-parses the resource silently rather than failing.

So a `.meta` target has to be a real file. Where `Y` exists only as a `Y.meta`, resolution gives up
and whatever sits at `X` loads instead. This is not a regression — `port-maintenance` behaves
identically.

**Item 2 (`SetBufferOffset`) is explicitly transitional** and retires with the header under #1160,
as #1208 notes.

## Verification

**Unit tests** — `tests/archive_resource_meta_resolution_tests.cpp`, 17 cases over in-memory
archives mounted in a known order. Covers the ten scenarios from the manual kit plus the things it
cannot reach: `isCustom` in both directions, a `.meta` with no `"path"` key supplying init data for a
headerless resource, requests by CRC64, an alias target that is indexed but cannot be served, and
eviction on directory unload including under `alt/`.

They were written against the pre-review code and pass unchanged through commits 9–11, which is what
makes the refactor checkable rather than merely plausible. Two mutations confirm they are not
vacuous: inverting the priority comparison fails 9 of them including the control, and restoring
`IndexFile`'s suffix strip fails 9 including the no-shadowing case.

**Manual kit**, with full instructions and the resolution model:
**https://github.com/briaguya0/Ghostship/tree/meta-alias-testing/meta-alias-testing**

Ten cases, each run in its own process with a restart between, confirmed visually on the title
screen. The vehicle is a baserom texture aliased to a synthetic replacement, so vanilla reads as
legible copyright text rather than an ambiguous colour.

| # | case | before | after | |
|---|---|---|---|---|
| 1 | real + meta + target | green | **magenta** | flip |
| 2 | real + meta, no target | green | green | held |
| 3 | meta + target, no real | corrupted | **magenta** | flip |
| 4 | meta only | corrupted | **vanilla** | flip |
| 5 | real, no meta | green | green | held |
| 6 | target carrying an OTR header | corrupted | **magenta** | flip |
| 7 | flagship: meta < real < target | green | **magenta** | flip |
| 8 | flagship, target dropped | green | green | held |
| 9 | L1: real ranked above target | green | green | control |
| 10 | reach-back: target below the meta | corrupted | **magenta** | flip |

Case 7 → magenta with the target present and case 8 → green without it, from the same unmodified
`.meta`, is #1165. Cases 3, 4 and 10 are #984 — case 4 logged 91 failed loads in a five-second
baseline run and now logs zero. Case 9 is the control against an inverted comparison: same `.meta`,
same target present, but with the real asset ranked above it, so it must stay green.

The kit was re-run after commits 7–11 with identical results.

**Not covered by either.** Commit 11 has no test behind it: every unit test and every kit case has
`parent == nullptr`, so the line it removes was a no-op in all of them. It is justified by reading
`LoadFileProcess`, not by observation. The same blind spot applies to `GetFilePriority` ignoring
parent.

## Unrelated findings

Both turned up while capturing the baseline, neither is caused by this change, and neither is fixed
here:

1. Failed resource loads retry every frame despite the `NotFound` cache entry, because the early
   return in `LoadResourceProcess` only fires for alt-asset paths.
2. Every archive is opened and indexed twice per launch, from a single `LoadResourceFiles()` call
   site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
