### PR TITLE
[main 2.0.0] Add ImGui FileBrowserWindow as a fallback file Dialogue

### DIFF
--- a/include/ship/window/gui/FileBrowserWindow.h
+++ b/include/ship/window/gui/FileBrowserWindow.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <filesystem>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "ship/window/gui/GuiWindow.h"
+
+namespace Ship {
+
+/**
+ * @brief A label and glob set for one entry in the browser's filter combo.
+ *
+ * Patterns match by extension: "*.png" keeps names ending in ".png" (case
+ * insensitive) and "*" matches everything.
+ */
+struct FileFilter {
+    std::string Label;                 ///< Human-readable name shown in the filter combo (e.g. "Images").
+    std::vector<std::string> Patterns; ///< Globs, e.g. { "*.png", "*.jpg" }; "*" matches everything.
+};
+
+/**
+ * @brief One file-pick request passed to FileBrowserWindow::Open / OpenBlocking.
+ *
+ * The browser knows nothing about what is being picked. The caller fills in the
+ * title, start directory and filters, and gets the chosen path back through
+ * OnResult (or std::nullopt if the user cancels).
+ */
+struct FileBrowserRequest {
+    std::string Title = "Select a file"; ///< Modal title.
+    std::filesystem::path StartDir;      ///< Directory to open in; empty -> current working directory.
+    std::vector<FileFilter> Filters;     ///< Selectable filters; empty -> show all files.
+    bool Save = false;                   ///< Save mode: adds a filename field and returns directory/filename.
+    std::string DefaultName;             ///< Save-mode default filename.
+    /** @brief Fires on the render thread with the chosen path, or std::nullopt if cancelled. */
+    std::function<void(std::optional<std::filesystem::path>)> OnResult;
+};
+
+/**
+ * @brief An ImGui file browser used in place of a native OS file dialog.
+ *
+ * Draws a modal that walks the filesystem and picks (or, in save mode, names) a
+ * file using only ImGui, so it works with no display server or native dialog on
+ * any backend. Works with mouse, keyboard or controller. Gui registers it once;
+ * it stays invisible until a request comes in and is driven through the static
+ * API below.
+ *
+ * The browser stays domain-agnostic; the calling port owns the rest of the
+ * contract:
+ * - Describe the pick. Set the title, filters and (for saves) the default name
+ *   on the request; the browser only knows what you put there.
+ * - Handle the result in OnResult. It runs on the render thread, a later frame
+ *   than the Open() call, and fires exactly once: the chosen path on confirm,
+ *   or std::nullopt on cancel. Keep it short, or hand heavy work to a worker.
+ * - Mind lifetime. Because OnResult can resolve frames later, anything it
+ *   captures (a `this`, a buffer) must outlive the request. Capture a
+ *   shared_ptr when you can't otherwise guarantee that.
+ * - Drive your own flow with IsOpen() while a pick is in flight, e.g. to hold a
+ *   boot step or keep the render loop running.
+ */
+class FileBrowserWindow : public GuiWindow {
+  public:
+    using GuiWindow::GuiWindow;
+    virtual ~FileBrowserWindow();
+
+    /**
+     * @brief Queue a request and return immediately. OnResult fires later on the render thread.
+     * @param request The pick to perform. Safe to call from any thread.
+     */
+    static void Open(FileBrowserRequest request);
+
+    /**
+     * @brief Queue a request and block until the render loop resolves it.
+     *
+     * Only safe to call off the render thread (e.g. a worker); it waits for the
+     * render loop to draw the browser, so calling it on the render thread deadlocks.
+     * @param request The pick to perform (its OnResult is overwritten).
+     * @return The chosen path, or std::nullopt if cancelled.
+     */
+    static std::optional<std::filesystem::path> OpenBlocking(FileBrowserRequest request);
+
+    /** @brief True while a request is active or queued. */
+    static bool IsOpen();
+
+  protected:
+    /** @brief Popup host: renders the modal directly (no host window) when a request is active. */
+    void Draw() override;
+
+    void InitElement() override;
+    void DrawElement() override;
+    void UpdateElement() override;
+
+  private:
+    /** @brief One row in the current directory listing. */
+    struct Entry {
+        std::string Name;
+        std::filesystem::path Path; ///< For the ".." row this is the parent directory.
+        bool IsDir;
+    };
+
+    /** @brief One sidebar shortcut: an icon, a label and the directory it opens. */
+    struct Place {
+        const char* Icon;
+        std::string Label;
+        std::filesystem::path Path;
+    };
+
+    /** @brief A collapsible group of sidebar shortcuts, e.g. "Places" or "Drives". */
+    struct PlaceGroup {
+        std::string Name;
+        std::vector<Place> Places;
+    };
+
+    void BeginRequest();
+    void SetCwd(const std::filesystem::path& path);
+    void BuildPlaces();
+    void Refresh();
+    void Finish(std::optional<std::filesystem::path> result);
+    void DrawBody();
+    bool PassesFilter(const std::string& name) const;
+
+    FileBrowserRequest mRequest;
+    bool mActive = false;
+    bool mOpenPopup = false;
+    bool mNeedRefresh = false;
+    bool mFocusList = false;
+    int mFilterIndex = 0;
+    std::filesystem::path mCwd;
+    std::vector<Entry> mEntries;
+    std::vector<PlaceGroup> mPlaces;
+    char mPathBuffer[1024] = {};
+    std::string mFilename;
+    char mFilenameBuffer[260] = {};
+};
+
+} // namespace Ship

--- a/include/ship/window/gui/FileBrowserWindow.h
+++ b/include/ship/window/gui/FileBrowserWindow.h
@@ -88,7 +88,7 @@ class FileBrowserWindow : public GuiWindow {
     /** @brief Popup host: renders the modal directly (no host window) when a request is active. */
     void Draw() override;
 
-    void InitElement() override;
+    void OnInit(const nlohmann::json& initArgs = nlohmann::json::object()) override;
     void DrawElement() override;
     void UpdateElement() override;
 

--- a/include/ship/window/gui/Gui.h
+++ b/include/ship/window/gui/Gui.h
@@ -15,6 +15,7 @@
 #include "ship/window/gui/IconsFontAwesome4.h"
 #include "ship/window/gui/GameOverlay.h"
 #include "ship/window/gui/StatsWindow.h"
+#include "ship/window/gui/FileBrowserWindow.h"
 #include "ship/window/gui/GuiWindow.h"
 #include "ship/window/gui/GuiMenuBar.h"
 
@@ -167,6 +168,11 @@ class Gui : public Component {
      *  connected controllers. Called once at init and on controller add/remove so it
      *  is not re-evaluated per frame. The base implementation is a no-op. */
     virtual void RefreshImGuiGamepads();
+
+    /** @brief Per-frame recompute of whether ImGui gamepad nav is enabled: on while a menu or any
+     *  popup is open (and controller nav is enabled), off during gameplay so the game keeps the pad.
+     *  Centralised here because popups have no open/close event to hook. */
+    void UpdateGamepadNavigation();
 
     /**
      * @brief Shuts down the ImGui context and releases backend resources.

--- a/src/libultraship/libultra/os.cpp
+++ b/src/libultraship/libultra/os.cpp
@@ -18,26 +18,8 @@ int32_t osContInit(OSMesgQueue* mq, uint8_t* controllerBits, OSContStatus* statu
     *controllerBits = 0;
     status->status |= 1;
 
-    std::string controllerDb = Ship::Context::LocateFileAcrossAppDirs("gamecontrollerdb.txt");
-    int mappingsAdded = SDL_GameControllerAddMappingsFromFile(controllerDb.c_str());
-    if (mappingsAdded >= 0) {
-        SPDLOG_INFO("Added SDL game controllers from \"{}\" ({})", controllerDb, mappingsAdded);
-    } else {
-        SPDLOG_ERROR("Failed add SDL game controller mappings from \"{}\" ({})", controllerDb, SDL_GetError());
-    }
-
-    SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
-    if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {
-        SPDLOG_ERROR("Failed to initialize SDL game controllers ({})", SDL_GetError());
-        exit(EXIT_FAILURE);
-    }
-
-    sControlDeck = ControllerGetControlDeck();
-    if (!sControlDeck) {
-        SPDLOG_ERROR("osContInit: ControlDeck not found in context");
-        return -1;
-    }
-
+    // The SDL game-controller subsystem and mappings are brought up earlier, in Context::InitControlDeck,
+    // so controllers work in pre-game UI. ControlDeck::Init stays here as it needs the game's controllerBits.
     sControlDeck->Init(controllerBits);
 
     return 0;

--- a/src/ship/controller/controldeck/ControlDeck.cpp
+++ b/src/ship/controller/controldeck/ControlDeck.cpp
@@ -30,6 +30,21 @@ void ControlDeck::Init(uint8_t* controllerBits) {
     mControllerBits = controllerBits;
     *mControllerBits |= 1 << 0;
 
+    // Bring up the SDL game-controller subsystem here rather than in osContInit, so controllers work
+    // in pre-game UI (e.g. navigating extraction prompts). osContInit still runs ControlDeck::Init(),
+    // which needs the game's controllerBits.
+    std::string controllerDb = LocateFileAcrossAppDirs("gamecontrollerdb.txt");
+    int mappingsAdded = SDL_GameControllerAddMappingsFromFile(controllerDb.c_str());
+    if (mappingsAdded >= 0) {
+        SPDLOG_INFO("Added SDL game controller mappings from \"{}\" ({})", controllerDb, mappingsAdded);
+    } else {
+        SPDLOG_ERROR("Failed to add SDL game controller mappings from \"{}\" ({})", controllerDb, SDL_GetError());Expand commentComment on line R282Resolved
+    }
+    SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
+    if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {
+        SPDLOG_ERROR("Failed to initialize SDL game controllers ({})", SDL_GetError());
+    }
+  
     mWheelHandler = std::make_shared<WheelHandler>(GetWindow());
 
     auto self = std::dynamic_pointer_cast<ControlDeck>(GetSharedComponent());

--- a/src/ship/controller/controldeck/ControlDeck.cpp
+++ b/src/ship/controller/controldeck/ControlDeck.cpp
@@ -44,7 +44,7 @@ void ControlDeck::Init(uint8_t* controllerBits) {
     if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {
         SPDLOG_ERROR("Failed to initialize SDL game controllers ({})", SDL_GetError());
     }
-  
+
     mWheelHandler = std::make_shared<WheelHandler>(GetWindow());
 
     auto self = std::dynamic_pointer_cast<ControlDeck>(GetSharedComponent());

--- a/src/ship/controller/controldeck/ControlDeck.cpp
+++ b/src/ship/controller/controldeck/ControlDeck.cpp
@@ -33,12 +33,12 @@ void ControlDeck::Init(uint8_t* controllerBits) {
     // Bring up the SDL game-controller subsystem here rather than in osContInit, so controllers work
     // in pre-game UI (e.g. navigating extraction prompts). osContInit still runs ControlDeck::Init(),
     // which needs the game's controllerBits.
-    std::string controllerDb = LocateFileAcrossAppDirs("gamecontrollerdb.txt");
+    std::string controllerDb = Ship::Context::LocateFileAcrossAppDirs("gamecontrollerdb.txt");
     int mappingsAdded = SDL_GameControllerAddMappingsFromFile(controllerDb.c_str());
     if (mappingsAdded >= 0) {
         SPDLOG_INFO("Added SDL game controller mappings from \"{}\" ({})", controllerDb, mappingsAdded);
     } else {
-        SPDLOG_ERROR("Failed to add SDL game controller mappings from \"{}\" ({})", controllerDb, SDL_GetError());Expand commentComment on line R282Resolved
+        SPDLOG_ERROR("Failed to add SDL game controller mappings from \"{}\" ({})", controllerDb, SDL_GetError());
     }
     SDL_SetHint(SDL_HINT_JOYSTICK_THREAD, "1");
     if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {

--- a/src/ship/window/gui/FileBrowserWindow.cpp
+++ b/src/ship/window/gui/FileBrowserWindow.cpp
@@ -1,0 +1,441 @@
+#include "ship/window/gui/FileBrowserWindow.h"
+#include "ship/window/gui/IconsFontAwesome4.h"
+
+#include <imgui.h>
+#include "spdlog/spdlog.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <deque>
+#include <future>
+#include <mutex>
+#include <set>
+
+namespace fs = std::filesystem;
+
+namespace Ship {
+
+namespace {
+
+std::mutex sMutex;
+std::deque<FileBrowserRequest> sQueue;
+bool sActiveOrQueued = false; // lets IsOpen() answer without reaching into the window instance.
+fs::path sLastDir;            // last directory browsed this session; resumes there on the next pick.
+
+bool CaseLess(const std::string& a, const std::string& b) {
+    return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), [](char x, char y) {
+        return std::tolower((unsigned char)x) < std::tolower((unsigned char)y);
+    });
+}
+
+bool EndsWithCI(const std::string& s, const std::string& suffix) {
+    if (suffix.size() > s.size()) {
+        return false;
+    }
+    return std::equal(suffix.rbegin(), suffix.rend(), s.rbegin(),
+                      [](char a, char b) { return std::tolower((unsigned char)a) == std::tolower((unsigned char)b); });
+}
+
+bool MatchPattern(const std::string& name, const std::string& pattern) {
+    if (pattern == "*" || pattern.empty()) {
+        return true;
+    }
+    if (pattern.size() >= 2 && pattern[0] == '*' && pattern[1] == '.') {
+        return EndsWithCI(name, pattern.substr(1));
+    }
+    return EndsWithCI(name, pattern);
+}
+
+// Ellipsize a sidebar label that's wider than the rail.
+std::string FitLabel(const std::string& text, float maxWidth) {
+    if (ImGui::CalcTextSize(text.c_str()).x <= maxWidth) {
+        return text;
+    }
+    std::string head = text;
+    const std::string ellipsis = "...";
+    while (!head.empty() && ImGui::CalcTextSize((head + ellipsis).c_str()).x > maxWidth) {
+        head.pop_back();
+    }
+    return head + ellipsis;
+}
+
+} // namespace
+
+FileBrowserWindow::~FileBrowserWindow() {
+    SPDLOG_TRACE("destruct file browser window");
+}
+
+void FileBrowserWindow::InitElement() {
+}
+
+void FileBrowserWindow::UpdateElement() {
+}
+
+void FileBrowserWindow::Draw() {
+    if (!IsVisible()) {
+        return;
+    }
+    DrawElement();
+    SyncVisibilityConsoleVariable();
+}
+
+void FileBrowserWindow::DrawElement() {
+    if (!mActive) {
+        std::lock_guard<std::mutex> lock(sMutex);
+        if (sQueue.empty()) {
+            return;
+        }
+        mRequest = std::move(sQueue.front());
+        sQueue.pop_front();
+        BeginRequest();
+    }
+    if (mNeedRefresh) {
+        Refresh();
+        mNeedRefresh = false;
+    }
+
+    const std::string popupId = mRequest.Title + "###ShipFileBrowser";
+    if (mOpenPopup) {
+        ImVec2 center = ImGui::GetMainViewport()->GetWorkCenter();
+        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+        ImGui::OpenPopup(popupId.c_str());
+        mOpenPopup = false;
+    }
+    const ImVec2 viewport = ImGui::GetMainViewport()->WorkSize;
+    ImGui::SetNextWindowSize(ImVec2(viewport.x * 0.8f, viewport.y * 0.8f), ImGuiCond_Appearing);
+
+    if (ImGui::BeginPopupModal(popupId.c_str(), nullptr,
+                               ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoCollapse)) {
+        DrawBody();
+        ImGui::EndPopup();
+    }
+}
+
+void FileBrowserWindow::BeginRequest() {
+    mActive = true;
+    mOpenPopup = true;
+    mNeedRefresh = true;
+    mFocusList = true;
+    mFilterIndex = 0;
+
+    std::error_code ec;
+    // Caller's StartDir wins; otherwise resume where the last pick left off this session, falling
+    // back to the working directory.
+    fs::path start = mRequest.StartDir;
+    if (start.empty()) {
+        start = sLastDir.empty() ? fs::current_path(ec) : sLastDir;
+    }
+    if (ec || !fs::exists(start, ec) || !fs::is_directory(start, ec)) {
+        start = fs::current_path(ec);
+    }
+    SetCwd(start);
+    BuildPlaces();
+
+    mFilename = mRequest.DefaultName;
+    std::snprintf(mFilenameBuffer, sizeof(mFilenameBuffer), "%s", mFilename.c_str());
+}
+
+// Gather the sidebar shortcuts once per request: the user's folders, then the root and mounted
+// media. Touches the disk, so it runs on open rather than every frame.
+void FileBrowserWindow::BuildPlaces() {
+    mPlaces.clear();
+
+    auto isDir = [](const fs::path& p) {
+        std::error_code ec;
+        return fs::is_directory(p, ec);
+    };
+
+    PlaceGroup places;
+    places.Name = "Places";
+    auto add = [&](const char* icon, const std::string& label, const fs::path& path) {
+        if (isDir(path)) {
+            places.Places.push_back({ icon, label, path });
+        }
+    };
+    if (const char* homeEnv = std::getenv("HOME")) {
+        const fs::path home = homeEnv;
+        add(ICON_FA_HOME, "Home", home);
+        add(ICON_FA_DESKTOP, "Desktop", home / "Desktop");
+        add(ICON_FA_FILE_TEXT_O, "Documents", home / "Documents");
+        add(ICON_FA_DOWNLOAD, "Downloads", home / "Downloads");
+        add(ICON_FA_PICTURE_O, "Pictures", home / "Pictures");
+        add(ICON_FA_MUSIC, "Music", home / "Music");
+        add(ICON_FA_FILM, "Videos", home / "Videos");
+    }
+    if (!places.Places.empty()) {
+        mPlaces.push_back(std::move(places));
+    }
+
+    PlaceGroup drives;
+    drives.Name = "Devices";
+    drives.Places.push_back({ ICON_FA_HDD_O, "File System", fs::path("/") });
+
+    std::vector<fs::path> mountRoots = { "/mnt", "/media", "/Volumes" };
+    if (const char* user = std::getenv("USER")) {
+        mountRoots.push_back(fs::path("/media") / user);
+        mountRoots.push_back(fs::path("/run/media") / user);
+    }
+    std::set<std::string> seen;
+    for (const fs::path& mountRoot : mountRoots) {
+        if (!isDir(mountRoot)) {
+            continue;
+        }
+        std::error_code ec;
+        fs::directory_iterator it(mountRoot, fs::directory_options::skip_permission_denied, ec);
+        for (fs::directory_iterator end; !ec && it != end; it.increment(ec)) {
+            const fs::path& path = it->path();
+            if (isDir(path) && seen.insert(path.string()).second) {
+                drives.Places.push_back({ ICON_FA_HDD_O, path.filename().string(), path });
+            }
+        }
+    }
+    if (!drives.Places.empty()) {
+        mPlaces.push_back(std::move(drives));
+    }
+}
+
+void FileBrowserWindow::SetCwd(const fs::path& path) {
+    mCwd = path.lexically_normal();
+    sLastDir = mCwd; // remember for the next pick this session
+    std::snprintf(mPathBuffer, sizeof(mPathBuffer), "%s", mCwd.string().c_str());
+    mNeedRefresh = true;
+}
+
+bool FileBrowserWindow::PassesFilter(const std::string& name) const {
+    if (mRequest.Filters.empty()) {
+        return true;
+    }
+    const FileFilter& filter = mRequest.Filters[mFilterIndex];
+    for (const std::string& pattern : filter.Patterns) {
+        if (MatchPattern(name, pattern)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void FileBrowserWindow::Refresh() {
+    mEntries.clear();
+    mFocusList = true;
+
+    fs::path parent = mCwd.parent_path();
+    if (!parent.empty() && parent != mCwd) {
+        mEntries.push_back({ "..", parent, true });
+    }
+
+    std::vector<Entry> dirs;
+    std::vector<Entry> files;
+    std::error_code ec;
+    fs::directory_iterator it(mCwd, fs::directory_options::skip_permission_denied, ec);
+    if (!ec) {
+        for (fs::directory_iterator end; it != end; it.increment(ec)) {
+            if (ec) {
+                break;
+            }
+            std::error_code ec2;
+            const fs::directory_entry& de = *it;
+            std::string name = de.path().filename().string();
+            if (name.empty() || name[0] == '.') {
+                continue;
+            }
+            if (de.is_directory(ec2)) {
+                dirs.push_back({ name, de.path(), true });
+            } else if (PassesFilter(name)) {
+                files.push_back({ name, de.path(), false });
+            }
+        }
+    }
+    auto byName = [](const Entry& a, const Entry& b) { return CaseLess(a.Name, b.Name); };
+    std::sort(dirs.begin(), dirs.end(), byName);
+    std::sort(files.begin(), files.end(), byName);
+    for (Entry& e : dirs) {
+        mEntries.push_back(std::move(e));
+    }
+    for (Entry& e : files) {
+        mEntries.push_back(std::move(e));
+    }
+}
+
+void FileBrowserWindow::Finish(std::optional<fs::path> result) {
+    auto callback = std::move(mRequest.OnResult);
+    mActive = false;
+    {
+        std::lock_guard<std::mutex> lock(sMutex);
+        sActiveOrQueued = !sQueue.empty();
+    }
+    ImGui::CloseCurrentPopup();
+    if (callback) {
+        callback(std::move(result));
+    }
+}
+
+void FileBrowserWindow::DrawBody() {
+    // Escape cancels for keyboard users; gamepads use the Cancel button (B is taken by ImGui nav).
+    if (!ImGui::IsAnyItemActive() && ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+        Finish(std::nullopt);
+        return;
+    }
+
+    // Set by the address bar, rail or list below, then applied after the list draw so we don't
+    // mutate mEntries while iterating it.
+    fs::path enterDir;
+    std::optional<fs::path> picked;
+    std::string fillName;
+
+    if (ImGui::Button(ICON_FA_LEVEL_UP "###up")) {
+        fs::path parent = mCwd.parent_path();
+        if (!parent.empty() && parent != mCwd) {
+            enterDir = parent;
+        }
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("Up one level");
+    }
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(-1.0f);
+    if (ImGui::InputText("##address", mPathBuffer, sizeof(mPathBuffer), ImGuiInputTextFlags_EnterReturnsTrue)) {
+        std::error_code ec;
+        fs::path typed(mPathBuffer);
+        if (fs::is_directory(typed, ec)) {
+            enterDir = typed;
+        } else if (!mRequest.Save && fs::is_regular_file(typed, ec)) {
+            picked = typed;
+        } else if (mRequest.Save && !typed.empty()) {
+            // Treat a typed file path as a save target: open its directory, pre-fill the name.
+            fs::path parent = typed.parent_path();
+            if (parent.empty() || fs::is_directory(parent, ec)) {
+                if (!parent.empty()) {
+                    enterDir = parent;
+                }
+                fillName = typed.filename().string();
+            }
+        }
+    }
+    ImGui::Separator();
+
+    // Leave room below the rail/list for the footer rows: buttons, plus filter/filename when shown.
+    float footer = ImGui::GetFrameHeightWithSpacing();
+    if (!mRequest.Filters.empty()) {
+        footer += ImGui::GetFrameHeightWithSpacing();
+    }
+    if (mRequest.Save) {
+        footer += ImGui::GetFrameHeightWithSpacing();
+    }
+
+    ImGui::BeginChild("##rail", ImVec2(200.0f, -footer), true);
+    for (const PlaceGroup& group : mPlaces) {
+        if (ImGui::CollapsingHeader(group.Name.c_str(), ImGuiTreeNodeFlags_DefaultOpen)) {
+            for (const Place& place : group.Places) {
+                std::string label =
+                    FitLabel(std::string(place.Icon) + "  " + place.Label, ImGui::GetContentRegionAvail().x);
+                ImGui::PushID(place.Path.string().c_str());
+                if (ImGui::Selectable(label.c_str())) {
+                    enterDir = place.Path;
+                }
+                ImGui::PopID();
+            }
+        }
+    }
+    ImGui::EndChild();
+    ImGui::SameLine();
+
+    ImGui::BeginChild("##list", ImVec2(0.0f, -footer), true);
+    ImGuiListClipper clipper;
+    clipper.Begin((int)mEntries.size());
+    while (clipper.Step()) {
+        for (int i = clipper.DisplayStart; i < clipper.DisplayEnd; ++i) {
+            const Entry& e = mEntries[i];
+            std::string label = std::string(e.IsDir ? ICON_FA_FOLDER : ICON_FA_FILE_O) + "  " + e.Name;
+            ImGui::PushID(i);
+            if (ImGui::Selectable(label.c_str())) {
+                if (e.IsDir) {
+                    enterDir = e.Path;
+                } else if (mRequest.Save) {
+                    fillName = e.Name;
+                } else {
+                    picked = e.Path;
+                }
+            }
+            if (mFocusList && i == 0) {
+                ImGui::SetItemDefaultFocus();
+            }
+            ImGui::PopID();
+        }
+    }
+    clipper.End();
+    mFocusList = false;
+    ImGui::EndChild();
+
+    if (!mRequest.Filters.empty()) {
+        ImGui::SetNextItemWidth(-1.0f);
+        if (ImGui::BeginCombo("##filter", mRequest.Filters[mFilterIndex].Label.c_str())) {
+            for (int i = 0; i < (int)mRequest.Filters.size(); ++i) {
+                bool selected = (i == mFilterIndex);
+                if (ImGui::Selectable(mRequest.Filters[i].Label.c_str(), selected)) {
+                    mFilterIndex = i;
+                    mNeedRefresh = true;
+                }
+                if (selected) {
+                    ImGui::SetItemDefaultFocus();
+                }
+            }
+            ImGui::EndCombo();
+        }
+    }
+
+    bool confirm = false;
+    if (mRequest.Save) {
+        ImGui::SetNextItemWidth(-1.0f);
+        if (ImGui::InputText("##filename", mFilenameBuffer, sizeof(mFilenameBuffer),
+                             ImGuiInputTextFlags_EnterReturnsTrue)) {
+            confirm = true;
+        }
+        mFilename = mFilenameBuffer;
+    }
+
+    if (mRequest.Save) {
+        if (ImGui::Button("Save")) {
+            confirm = true;
+        }
+        ImGui::SameLine();
+    }
+    if (ImGui::Button("Cancel")) {
+        Finish(std::nullopt);
+        return;
+    }
+
+    if (!fillName.empty()) {
+        mFilename = fillName;
+        std::snprintf(mFilenameBuffer, sizeof(mFilenameBuffer), "%s", mFilename.c_str());
+    }
+    if (!enterDir.empty()) {
+        SetCwd(enterDir);
+    } else if (picked) {
+        Finish(picked);
+    } else if (confirm && mRequest.Save && !mFilename.empty()) {
+        Finish((mCwd / mFilename).lexically_normal());
+    }
+}
+
+void FileBrowserWindow::Open(FileBrowserRequest request) {
+    std::lock_guard<std::mutex> lock(sMutex);
+    sQueue.push_back(std::move(request));
+    sActiveOrQueued = true;
+}
+
+std::optional<fs::path> FileBrowserWindow::OpenBlocking(FileBrowserRequest request) {
+    std::promise<std::optional<fs::path>> promise;
+    std::future<std::optional<fs::path>> future = promise.get_future();
+    request.OnResult = [&promise](std::optional<fs::path> result) { promise.set_value(std::move(result)); };
+    Open(std::move(request));
+    return future.get();
+}
+
+bool FileBrowserWindow::IsOpen() {
+    std::lock_guard<std::mutex> lock(sMutex);
+    return sActiveOrQueued;
+}
+
+} // namespace Ship

--- a/src/ship/window/gui/FileBrowserWindow.cpp
+++ b/src/ship/window/gui/FileBrowserWindow.cpp
@@ -67,7 +67,7 @@ FileBrowserWindow::~FileBrowserWindow() {
     SPDLOG_TRACE("destruct file browser window");
 }
 
-void FileBrowserWindow::InitElement() {
+void FileBrowserWindow::OnInit(const nlohmann::json& initArgs) {
 }
 
 void FileBrowserWindow::UpdateElement() {

--- a/src/ship/window/gui/Gui.cpp
+++ b/src/ship/window/gui/Gui.cpp
@@ -206,7 +206,7 @@ void Gui::RefreshImGuiGamepads() {
 }
 
 void Gui::UpdateGamepadNavigation() {
-    const bool navWanted = Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0) &&
+    const bool navWanted = mConsoleVariable->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0) &&
                            (GetMenuOrMenubarVisible() ||
                             ImGui::IsPopupOpen(nullptr, ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel));
     if (navWanted) {

--- a/src/ship/window/gui/Gui.cpp
+++ b/src/ship/window/gui/Gui.cpp
@@ -205,7 +205,21 @@ void Gui::ImGuiWMNewFrame() {
 void Gui::RefreshImGuiGamepads() {
 }
 
+void Gui::UpdateGamepadNavigation() {
+    const bool navWanted = Context::GetRawInstance()->GetConsoleVariables()->GetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0) &&
+                           (GetMenuOrMenubarVisible() ||
+                            ImGui::IsPopupOpen(nullptr, ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel));
+    if (navWanted) {
+        mImGuiIo->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
+    } else {
+        mImGuiIo->ConfigFlags &= ~ImGuiConfigFlags_NavEnableGamepad;
+    }
+}
+
 void Gui::DrawMenu() {
+    // Per frame: popups (boot prompts, the file browser) have no open/close event to hook.
+    UpdateGamepadNavigation();
+
     const std::shared_ptr<Window> wnd = mWindow;
     const std::shared_ptr<Config> conf = mConfig;
 


### PR DESCRIPTION
https://github.com/Kenix3/libultraship/pull/1139
Thanks JeodC

### HOW TO IMPLEMENT
You must add your own `gui->AddGuiWindow()` command. It should create same place as before. But you must hold onto your own pointer now in your Engine.cpp

Todo:
- [x] Port
- [x] Compile
- [ ] Moving the OS to ControlDeck Crashes SpaghettiKart
<img width="756" height="542" alt="image" src="https://github.com/user-attachments/assets/f899fcc8-09d6-4107-b2bb-2f907a7a4e47" />


Resolves https://github.com/Kenix3/libultraship/pull/1139

Generated by Human Intelligence™