### PR TITLE
[main 2.0.0] Only Populate Event Callers Map in Debug Builds

### DIFF
--- a/src/ship/events/Events.cpp
+++ b/src/ship/events/Events.cpp
@@ -112,12 +112,15 @@ void Events::CallEvent(const EventID id, IEvent* event, const char* file, const 
         return;
     }
 
+// For performance reasons the Event Debugger tool should not be compiled in release mode
+#ifdef _DEBUG
     auto& info = registry->Callers[std::string(key)];
     if (info.Path == nullptr) {
         info.Path = file;
         info.Line = line;
     }
     info.Count++;
+#endif
 }
 
 const Events::DispatchContext* Events::GetActiveDispatchContext() const {


### PR DESCRIPTION
From https://github.com/Kenix3/libultraship/pull/1175
Thanks JeodC

Resolves https://github.com/Kenix3/libultraship/issues/1199

Generated by Human Intelligence™