### PR TITLE
[main 2.0.0] Untangle Various Parts from the Context Destructor

### DIFF
--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <SDL2/SDL.h>
 #include "ship/window/gui/Gui.h"
+#include "fast/Fast3dWindow.h"
 #include "fast/WindowEvent.h"
 #include "fast/resource/type/Texture.h"
 #include "ship/window/gui/resource/GuiTexture.h"
@@ -48,6 +49,7 @@ typedef struct {
             uint32_t Height; ///< Framebuffer height in pixels.
         } Gx2;
     };
+    WindowBackend Backend;
 } GuiWindowInitData;
 
 /**


### PR DESCRIPTION
From https://github.com/Kenix3/libultraship/pull/1103

This PR seems mostly moot now. However, I've tried to moving anything that seemed useful over.

Unless this issue still persists...
https://github.com/Kenix3/libultraship/issues/1102
I don't think any of this PR is needed?


I don't know where the below gets created anymore.
<img width="704" height="131" alt="image" src="https://github.com/user-attachments/assets/1f8d10e5-4f94-4cbf-bb70-086a1e13eb5e" />  

Perhaps here? `Engine.cpp`

<img width="1002" height="107" alt="image" src="https://github.com/user-attachments/assets/a62d69ed-0609-429e-bbc6-840b6890e52e" />

It seems to be here I think: `Logger.cpp`
<img width="963" height="224" alt="image" src="https://github.com/user-attachments/assets/df789a95-dcfb-4b28-9ae5-c3011e2d958d" />  
 

Please advise.

Generated by Human Intelligence™