### PR TITLE
Make ConsoleVariable thread-safe (port-maintenance)

### DIFF
--- a/include/libultraship/bridge/consolevariablebridge.h
+++ b/include/libultraship/bridge/consolevariablebridge.h
@@ -12,7 +12,7 @@
  * @brief Returns a shared pointer to the CVar with the given name, or nullptr if it does not exist.
  * @param name CVar name (e.g. "gMyOption").
  */
-std::shared_ptr<Ship::CVar> CVarGet(const char* name);
+Ship::CVar* CVarGet(const char* name);
 
 extern "C" {
 #endif

--- a/include/ship/config/ConsoleVariable.h
+++ b/include/ship/config/ConsoleVariable.h
@@ -4,6 +4,7 @@
 #include <nlohmann/json.hpp>
 #include <stdint.h>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <string>
 #include <string_view>
@@ -209,5 +210,7 @@ class ConsoleVariable {
         }
     };
     std::unordered_map<std::string, std::shared_ptr<CVar>, TransparentStringHash, TransparentStringEqual> mVariables;
+    // Guards mVariables against concurrent access from the audio thread and the game thread.
+    std::recursive_mutex mVariablesMutex;
 };
 } // namespace Ship

--- a/include/ship/config/ConsoleVariable.h
+++ b/include/ship/config/ConsoleVariable.h
@@ -4,14 +4,24 @@
 #include <nlohmann/json.hpp>
 #include <stdint.h>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 #include <string>
 #include <string_view>
+#include <atomic>
+#include <deque>
+#include <vector>
 
 namespace Ship {
 
-/** @brief Discriminator tag for the active field of the CVar union. */
-typedef enum class ConsoleVariableType { Integer, Float, String, Color, Color24 } ConsoleVariableType;
+/**
+ * @brief Discriminator tag for the active field of the CVar union.
+ *
+ * None means the entry carries no value: it is either freshly created and not yet
+ * filled in, or it has been cleared. Lookups treat it as if the name did not exist.
+ */
+typedef enum class ConsoleVariableType { None, Integer, Float, String, Color, Color24 } ConsoleVariableType;
 
 /**
  * @brief A single console variable (CVar) holding a typed value.
@@ -20,23 +30,20 @@ typedef enum class ConsoleVariableType { Integer, Float, String, Color, Color24 
  * one value whose type is determined by the Type field. The union members Integer,
  * Float, String, Color, and Color24 are mutually exclusive.
  *
- * @note The String member is heap-allocated and is freed by the destructor.
+ * @note The String member points into the owning ConsoleVariable's string storage. It is
+ *       not owned by the CVar and must not be freed; it stays valid for as long as that
+ *       ConsoleVariable exists.
  */
 typedef struct CVar {
     /** @brief Discriminator indicating which union field is active. */
-    ConsoleVariableType Type;
+    ConsoleVariableType Type = ConsoleVariableType::None;
     union {
-        int32_t Integer;        ///< Active when Type == ConsoleVariableType::Integer.
-        float Float;            ///< Active when Type == ConsoleVariableType::Float.
-        char* String = nullptr; ///< Active when Type == ConsoleVariableType::String (heap-allocated).
-        Color_RGBA8 Color;      ///< Active when Type == ConsoleVariableType::Color.
-        Color_RGB8 Color24;     ///< Active when Type == ConsoleVariableType::Color24.
+        int32_t Integer;              ///< Active when Type == ConsoleVariableType::Integer.
+        float Float;                  ///< Active when Type == ConsoleVariableType::Float.
+        const char* String = nullptr; ///< Active when Type == ConsoleVariableType::String.
+        Color_RGBA8 Color;            ///< Active when Type == ConsoleVariableType::Color.
+        Color_RGB8 Color24;           ///< Active when Type == ConsoleVariableType::Color24.
     };
-    ~CVar() {
-        if (Type == ConsoleVariableType::String && String != nullptr) {
-            free(String);
-        }
-    }
 } CVar;
 
 /**
@@ -56,8 +63,15 @@ class ConsoleVariable {
     /**
      * @brief Returns the raw CVar entry for the given name, or nullptr if not found.
      * @param name CVar name (case-sensitive).
+     *
+     * A cleared name reports as not found, matching the behaviour callers expect from a
+     * name that was never set.
+     *
+     * The returned pointer stays valid for as long as this ConsoleVariable exists: entries
+     * are owned here and are never individually destroyed, so callers may hold it. Reads are
+     * lock free, so this is safe to call from the audio thread while another thread writes.
      */
-    std::shared_ptr<CVar> Get(const char* name);
+    CVar* Get(const char* name);
 
     /**
      * @brief Returns the integer value of a CVar, or the default if not found or wrong type.
@@ -77,7 +91,10 @@ class ConsoleVariable {
      * @brief Returns the string value of a CVar, or the default if not found or wrong type.
      * @param name         CVar name.
      * @param defaultValue Value to return when the CVar is absent.
-     * @return Pointer to internal storage; do not free or store long-term.
+     * @return Pointer to interned storage owned by this ConsoleVariable. It must not be
+     *         freed, and it stays valid until this ConsoleVariable is destroyed, so callers
+     *         may hold it. A later SetString on the same name leaves it untouched and
+     *         publishes a separate string rather than overwriting this one.
      */
     const char* GetString(const char* name, const char* defaultValue);
 
@@ -208,6 +225,51 @@ class ConsoleVariable {
             return a == b;
         }
     };
-    std::unordered_map<std::string, std::shared_ptr<CVar>, TransparentStringHash, TransparentStringEqual> mVariables;
+    using VariableMap = std::unordered_map<std::string, CVar*, TransparentStringHash, TransparentStringEqual>;
+
+    /* Reads happen on the audio thread thousands of times a second and take no lock:
+     * they load the published map and follow a pointer into storage. That works
+     * because nothing a reader can be holding is ever destroyed while this object is
+     * alive, and because that map is replaced rather than edited in place. The three
+     * groups below are what that costs. */
+
+    /* The name -> entry map readers are currently allowed to see. Writers never edit
+     * it; they publish a replacement. */
+    std::atomic<const VariableMap*> mPublished;
+
+    /* Kept until the destructor, because a reader may still be inside any of it.
+     * deque keeps CVar addresses stable as it grows, unordered_set keeps interned
+     * string addresses stable across rehashes, and mPublishedMaps owns every map ever
+     * published, the live one included, so a superseded map is simply left alone rather
+     * than deleted. Clearing a variable retypes it to None in place; interning is what
+     * keeps never freeing a string affordable. */
+    std::deque<CVar> mStorage;
+    std::unordered_set<std::string> mStrings;
+    std::vector<std::unique_ptr<const VariableMap>> mPublishedMaps;
+
+    /* Writer side, all of it under mWriteMutex, which readers never take. Recursive
+     * because the write paths nest: Load() -> SetInteger(), RegisterInteger() ->
+     * SetInteger(). Only a name never seen before rebuilds the map; mPendingPublish
+     * stages that rebuild so Load(), which touches every key, publishes once at the end
+     * rather than once per variable. */
+    std::recursive_mutex mWriteMutex;
+    VariableMap mOwned;
+    std::unique_ptr<VariableMap> mPendingPublish;
+    int mBulkWriteDepth = 0;
+
+    /* The map readers should search, as a reference rather than a pointer. */
+    const VariableMap& Published() const {
+        return *mPublished.load(std::memory_order_acquire);
+    }
+
+    /* All of these require mWriteMutex to be held. */
+    void PublishMap(std::unique_ptr<VariableMap> next);
+    CVar* FindOwned(const char* name);
+    CVar* GetOrCreate(const char* name);
+    const char* Intern(const char* value);
+    static void Publish(CVar* variable, ConsoleVariableType type);
+    static void Clear(CVar* variable);
+    void BeginBulkWrite();
+    void EndBulkWrite();
 };
 } // namespace Ship

--- a/src/libultraship/bridge/consolevariablebridge.cpp
+++ b/src/libultraship/bridge/consolevariablebridge.cpp
@@ -1,7 +1,7 @@
 #include "libultraship/bridge/consolevariablebridge.h"
 #include "ship/Context.h"
 
-std::shared_ptr<Ship::CVar> CVarGet(const char* name) {
+Ship::CVar* CVarGet(const char* name) {
     return Ship::Context::GetRawInstance()->GetConsoleVariables()->Get(name);
 }
 

--- a/src/ship/config/ConsoleVariable.cpp
+++ b/src/ship/config/ConsoleVariable.cpp
@@ -21,11 +21,13 @@ ConsoleVariable::~ConsoleVariable() {
 }
 
 std::shared_ptr<CVar> ConsoleVariable::Get(const char* name) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto it = mVariables.find(name);
     return it != mVariables.end() ? it->second : nullptr;
 }
 
 int32_t ConsoleVariable::GetInteger(const char* name, int32_t defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Integer) {
@@ -36,6 +38,7 @@ int32_t ConsoleVariable::GetInteger(const char* name, int32_t defaultValue) {
 }
 
 float ConsoleVariable::GetFloat(const char* name, float defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Float) {
@@ -46,6 +49,7 @@ float ConsoleVariable::GetFloat(const char* name, float defaultValue) {
 }
 
 const char* ConsoleVariable::GetString(const char* name, const char* defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::String) {
@@ -56,6 +60,7 @@ const char* ConsoleVariable::GetString(const char* name, const char* defaultValu
 }
 
 Color_RGBA8 ConsoleVariable::GetColor(const char* name, Color_RGBA8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Color) {
@@ -73,6 +78,7 @@ Color_RGBA8 ConsoleVariable::GetColor(const char* name, Color_RGBA8 defaultValue
 }
 
 Color_RGB8 ConsoleVariable::GetColor24(const char* name, Color_RGB8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Color24) {
@@ -89,6 +95,7 @@ Color_RGB8 ConsoleVariable::GetColor24(const char* name, Color_RGB8 defaultValue
 }
 
 void ConsoleVariable::SetInteger(const char* name, int32_t value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (variable == nullptr) {
         variable = std::make_shared<CVar>();
@@ -99,6 +106,7 @@ void ConsoleVariable::SetInteger(const char* name, int32_t value) {
 }
 
 void ConsoleVariable::SetFloat(const char* name, float value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (variable == nullptr) {
         variable = std::make_shared<CVar>();
@@ -109,6 +117,7 @@ void ConsoleVariable::SetFloat(const char* name, float value) {
 }
 
 void ConsoleVariable::SetString(const char* name, const char* value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (variable == nullptr) {
         variable = std::make_shared<CVar>();
@@ -122,6 +131,7 @@ void ConsoleVariable::SetString(const char* name, const char* value) {
 }
 
 void ConsoleVariable::SetColor(const char* name, Color_RGBA8 value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (!variable) {
         variable = std::make_shared<CVar>();
@@ -132,6 +142,7 @@ void ConsoleVariable::SetColor(const char* name, Color_RGBA8 value) {
 }
 
 void ConsoleVariable::SetColor24(const char* name, Color_RGB8 value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (!variable) {
         variable = std::make_shared<CVar>();
@@ -142,36 +153,42 @@ void ConsoleVariable::SetColor24(const char* name, Color_RGB8 value) {
 }
 
 void ConsoleVariable::RegisterInteger(const char* name, int32_t defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetInteger(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterFloat(const char* name, float defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetFloat(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterString(const char* name, const char* defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetString(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterColor(const char* name, Color_RGBA8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetColor(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterColor24(const char* name, Color_RGB8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetColor24(name, defaultValue);
     }
 }
 
 void ConsoleVariable::ClearVariable(const char* name) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     auto var = Get(name);
     if (var != nullptr) {
@@ -202,12 +219,14 @@ void ConsoleVariable::ClearVariable(const char* name) {
 }
 
 void ConsoleVariable::ClearBlock(const char* name) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     conf->EraseBlock(StringHelper::Sprintf("CVars.%s", name));
     Load();
 }
 
 void ConsoleVariable::CopyVariable(const char* from, const char* to) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variableFrom = mVariables[from];
     if (!variableFrom) {
         return;
@@ -241,6 +260,7 @@ void ConsoleVariable::CopyVariable(const char* from, const char* to) {
 }
 
 void ConsoleVariable::Save() {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
 
     for (const auto& variable : mVariables) {
@@ -277,6 +297,7 @@ void ConsoleVariable::Save() {
 }
 
 void ConsoleVariable::Load() {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     conf->Reload();
     if (!mVariables.empty()) {

--- a/src/ship/config/ConsoleVariable.cpp
+++ b/src/ship/config/ConsoleVariable.cpp
@@ -6,13 +6,10 @@
 #include "ship/config/Config.h"
 #include "ship/Context.h"
 
-#ifdef _MSC_VER
-#define strdup _strdup
-#endif
-
 namespace Ship {
 
 ConsoleVariable::ConsoleVariable() {
+    PublishMap(std::make_unique<VariableMap>());
     Load();
 }
 
@@ -20,9 +17,89 @@ ConsoleVariable::~ConsoleVariable() {
     SPDLOG_TRACE("destruct console variables");
 }
 
-std::shared_ptr<CVar> ConsoleVariable::Get(const char* name) {
-    auto it = mVariables.find(name);
-    return it != mVariables.end() ? it->second : nullptr;
+// Hands `next` to readers and keeps it alive for good. The map it replaces is not freed:
+// a reader may still be walking it, and there is no lock that would say when it stopped.
+// Ownership moves into mPublishedMaps before the store, so what readers can reach is
+// always something the vector already owns. Growing that vector only moves the pointers,
+// never the maps, so a pointer a reader is already following stays good.
+void ConsoleVariable::PublishMap(std::unique_ptr<VariableMap> next) {
+    const VariableMap* published = next.get();
+    mPublishedMaps.push_back(std::move(next));
+    mPublished.store(published, std::memory_order_release);
+}
+
+CVar* ConsoleVariable::FindOwned(const char* name) {
+    auto it = mOwned.find(name);
+    return it != mOwned.end() ? it->second : nullptr;
+}
+
+// Returns the entry for name, publishing a replacement map if the name is new.
+CVar* ConsoleVariable::GetOrCreate(const char* name) {
+    CVar* owned = FindOwned(name);
+    if (owned == nullptr) {
+        mStorage.emplace_back();
+        owned = &mStorage.back();
+        mOwned.emplace(name, owned);
+    }
+
+    if (mPendingPublish != nullptr) {
+        mPendingPublish->insert_or_assign(std::string(name), owned);
+        return owned;
+    }
+
+    const VariableMap* current = mPublished.load(std::memory_order_acquire);
+    if (current->find(name) != current->end()) {
+        return owned;
+    }
+
+    auto next = std::make_unique<VariableMap>(*current);
+    next->insert_or_assign(std::string(name), owned);
+    PublishMap(std::move(next));
+    return owned;
+}
+
+// Stages an empty key set. Entries themselves stay owned, so names that come back during
+// the bulk write reuse their existing CVar and any pointer already handed out stays valid.
+void ConsoleVariable::BeginBulkWrite() {
+    if (mBulkWriteDepth++ == 0) {
+        mPendingPublish = std::make_unique<VariableMap>();
+    }
+}
+
+void ConsoleVariable::EndBulkWrite() {
+    if (--mBulkWriteDepth > 0) {
+        return;
+    }
+
+    PublishMap(std::move(mPendingPublish));
+}
+
+// Returns a stable, permanent copy of value. Assigning the same text twice reuses the
+// first copy, so a variable that keeps being set to one of a handful of values does not
+// accumulate anything after the first time it sees each of them.
+const char* ConsoleVariable::Intern(const char* value) {
+    return mStrings.emplace(value).first->c_str();
+}
+
+/* Makes a filled-in entry visible to readers. The value is stored first and the type
+ * only afterwards, so a reader that sees a type also sees the value that belongs to it
+ * rather than whatever the union held before. Readers take no lock, so the fence is what
+ * keeps the compiler and the CPU from floating the value store past the type store. */
+void ConsoleVariable::Publish(CVar* variable, ConsoleVariableType type) {
+    std::atomic_thread_fence(std::memory_order_release);
+    variable->Type = type;
+}
+
+CVar* ConsoleVariable::Get(const char* name) {
+    const VariableMap& published = Published();
+    auto it = published.find(name);
+    if (it == published.end()) {
+        return nullptr;
+    }
+    /* An entry typed None is either not filled in yet or has been cleared. Either way it
+     * holds no value, so report it the way a name that was never set is reported. */
+    CVar* variable = it->second;
+    return variable->Type != ConsoleVariableType::None ? variable : nullptr;
 }
 
 int32_t ConsoleVariable::GetInteger(const char* name, int32_t defaultValue) {
@@ -89,91 +166,92 @@ Color_RGB8 ConsoleVariable::GetColor24(const char* name, Color_RGB8 defaultValue
 }
 
 void ConsoleVariable::SetInteger(const char* name, int32_t value) {
-    auto& variable = mVariables[name];
-    if (variable == nullptr) {
-        variable = std::make_shared<CVar>();
-    }
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
+    CVar* variable = GetOrCreate(name);
 
-    variable->Type = ConsoleVariableType::Integer;
     variable->Integer = value;
+    Publish(variable, ConsoleVariableType::Integer);
 }
 
 void ConsoleVariable::SetFloat(const char* name, float value) {
-    auto& variable = mVariables[name];
-    if (variable == nullptr) {
-        variable = std::make_shared<CVar>();
-    }
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
+    CVar* variable = GetOrCreate(name);
 
-    variable->Type = ConsoleVariableType::Float;
     variable->Float = value;
+    Publish(variable, ConsoleVariableType::Float);
 }
 
 void ConsoleVariable::SetString(const char* name, const char* value) {
-    auto& variable = mVariables[name];
-    if (variable == nullptr) {
-        variable = std::make_shared<CVar>();
-    }
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
+    CVar* variable = GetOrCreate(name);
 
-    variable->Type = ConsoleVariableType::String;
-    if (variable->String != nullptr) {
-        free(variable->String);
-    }
-    variable->String = strdup(value);
+    variable->String = Intern(value);
+    Publish(variable, ConsoleVariableType::String);
 }
 
 void ConsoleVariable::SetColor(const char* name, Color_RGBA8 value) {
-    auto& variable = mVariables[name];
-    if (!variable) {
-        variable = std::make_shared<CVar>();
-    }
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
+    CVar* variable = GetOrCreate(name);
 
-    variable->Type = ConsoleVariableType::Color;
     variable->Color = value;
+    Publish(variable, ConsoleVariableType::Color);
 }
 
 void ConsoleVariable::SetColor24(const char* name, Color_RGB8 value) {
-    auto& variable = mVariables[name];
-    if (!variable) {
-        variable = std::make_shared<CVar>();
-    }
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
+    CVar* variable = GetOrCreate(name);
 
-    variable->Type = ConsoleVariableType::Color24;
     variable->Color24 = value;
+    Publish(variable, ConsoleVariableType::Color24);
 }
 
 void ConsoleVariable::RegisterInteger(const char* name, int32_t defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
     if (Get(name) == nullptr) {
         SetInteger(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterFloat(const char* name, float defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
     if (Get(name) == nullptr) {
         SetFloat(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterString(const char* name, const char* defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
     if (Get(name) == nullptr) {
         SetString(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterColor(const char* name, Color_RGBA8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
     if (Get(name) == nullptr) {
         SetColor(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterColor24(const char* name, Color_RGB8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
     if (Get(name) == nullptr) {
         SetColor24(name, defaultValue);
     }
 }
 
+// Retypes an entry to None so lookups stop finding it, leaving it in storage and in the
+// published map. That keeps clearing off the publishing path: resetting a screen full of
+// cosmetics costs a few hundred field writes instead of a few hundred copies of the whole
+// map, none of which could ever be freed.
+void ConsoleVariable::Clear(CVar* variable) {
+    variable->Type = ConsoleVariableType::None;
+}
+
 void ConsoleVariable::ClearVariable(const char* name) {
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
     std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
-    auto var = Get(name);
+    CVar* var = FindOwned(name);
     if (var != nullptr) {
         bool color = var->Type == ConsoleVariableType::Color || var->Type == ConsoleVariableType::Color24;
         if (color) {
@@ -182,43 +260,40 @@ void ConsoleVariable::ClearVariable(const char* name) {
             std::string g = StringHelper::Sprintf("%s.%s", name, "G");
             std::string r = StringHelper::Sprintf("%s.%s", name, "R");
             std::string t = StringHelper::Sprintf("%s.%s", name, "Type");
-            mVariables.erase(a);
-            mVariables.erase(b);
-            mVariables.erase(g);
-            mVariables.erase(r);
-            mVariables.erase(t);
+            for (const std::string& component : { a, b, g, r, t }) {
+                CVar* owned = FindOwned(component.c_str());
+                if (owned != nullptr) {
+                    Clear(owned);
+                }
+            }
             conf->Erase(std::string("CVars.") + a);
             conf->Erase(std::string("CVars.") + b);
             conf->Erase(std::string("CVars.") + g);
             conf->Erase(std::string("CVars.") + r);
             conf->Erase(std::string("CVars.") + t);
-        } else if (var->Type == ConsoleVariableType::String) {
-            free(var->String);
-            var->String = nullptr;
         }
+        Clear(var);
     }
-    mVariables.erase(name);
     conf->Erase(StringHelper::Sprintf("CVars.%s", name));
 }
 
 void ConsoleVariable::ClearBlock(const char* name) {
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
     std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     conf->EraseBlock(StringHelper::Sprintf("CVars.%s", name));
     Load();
 }
 
 void ConsoleVariable::CopyVariable(const char* from, const char* to) {
-    auto& variableFrom = mVariables[from];
-    if (!variableFrom) {
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
+    CVar* variableFrom = Get(from);
+    if (variableFrom == nullptr) {
         return;
     }
-    auto& variableTo = mVariables[to];
-    if (!variableTo) {
-        variableTo = std::make_shared<CVar>();
-    }
+    CVar* variableTo = GetOrCreate(to);
 
-    variableTo->Type = variableFrom->Type;
-    switch (variableTo->Type) {
+    const ConsoleVariableType type = variableFrom->Type;
+    switch (type) {
         case ConsoleVariableType::Integer:
             variableTo->Integer = variableFrom->Integer;
             break;
@@ -226,10 +301,8 @@ void ConsoleVariable::CopyVariable(const char* from, const char* to) {
             variableTo->Float = variableFrom->Float;
             break;
         case ConsoleVariableType::String:
-            if (variableTo->String != nullptr) {
-                free(variableTo->String);
-            }
-            variableTo->String = strdup(variableFrom->String);
+            // Interned, so both names can point at the one copy.
+            variableTo->String = variableFrom->String;
             break;
         case ConsoleVariableType::Color:
             variableTo->Color = variableFrom->Color;
@@ -237,13 +310,17 @@ void ConsoleVariable::CopyVariable(const char* from, const char* to) {
         case ConsoleVariableType::Color24:
             variableTo->Color24 = variableFrom->Color24;
             break;
+        case ConsoleVariableType::None:
+            return;
     }
+    Publish(variableTo, type);
 }
 
 void ConsoleVariable::Save() {
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
     std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
 
-    for (const auto& variable : mVariables) {
+    for (const auto& variable : Published()) {
         const std::string key = StringHelper::Sprintf("CVars.%s", variable.first.c_str());
 
         if (variable.second->Type == ConsoleVariableType::String && variable.second != nullptr) {
@@ -277,15 +354,14 @@ void ConsoleVariable::Save() {
 }
 
 void ConsoleVariable::Load() {
+    std::lock_guard<std::recursive_mutex> lock(mWriteMutex);
     std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     conf->Reload();
-    if (!mVariables.empty()) {
-        mVariables.clear();
-    }
 
+    BeginBulkWrite();
     LoadFromPath("", conf->GetNestedJson()["CVars"].items());
-
     LoadLegacy();
+    EndBulkWrite();
 }
 
 void ConsoleVariable::LoadFromPath(
@@ -367,7 +443,7 @@ void ConsoleVariable::LoadLegacy() {
             if (cfg[1].find("\"") != std::string::npos) {
                 std::string value(cfg[1]);
                 value.erase(std::remove(value.begin(), value.end(), '\"'), value.end());
-                SetString(cfg[0].c_str(), strdup(value.c_str()));
+                SetString(cfg[0].c_str(), value.c_str());
             }
             if (Math::IsNumber<float>(cfg[1])) {
                 SetFloat(cfg[0].c_str(), std::stof(cfg[1]));

--- a/src/ship/window/gui/GameOverlay.cpp
+++ b/src/ship/window/gui/GameOverlay.cpp
@@ -207,7 +207,13 @@ void GameOverlay::Draw() {
             const auto var = Ship::Context::GetRawInstance()->GetConsoleVariables()->Get(text);
             ImVec4 color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
 
+            if (var == nullptr) {
+                continue;
+            }
+
             switch (var->Type) {
+                case ConsoleVariableType::None:
+                    break;
                 case ConsoleVariableType::Float:
 
                     TextDraw(30, textY, true, color, "%s %.2f", text, var->Float);
@@ -228,7 +234,6 @@ void GameOverlay::Draw() {
                     break;
             }
 
-            free((void*)text);
             textY += 30;
         }
 


### PR DESCRIPTION
## Problem

`ConsoleVariable` stores its CVars in a `std::unordered_map` (`mVariables`) with no synchronisation, but the map is accessed from more than one thread. A consumer that reads CVars from the audio thread while the game thread mutates the store will eventually race.

The failure reproduces reliably when the game thread applies a large batch of CVar writes at once (e.g. loading a settings preset) while the audio thread is reading a CVar per note:

```
Signal: 11  INVALID ACCESS TO STORAGE
  Ship::ConsoleVariable::GetInteger(char const*, int)
  CVarGetInteger
  Audio_InitNoteSub
  Audio_ProcessNotes
  ...
  OTRAudio_Thread()
terminate called after throwing an instance of 'std::bad_alloc'
```

The batch of inserts rehashes the map and frees the old bucket array while the audio thread is mid-`find()`, so the lookup walks freed memory. The resulting heap corruption then surfaces as `std::bad_alloc` on the next allocation.

## Fix

Guard every public accessor of `mVariables` with a `std::recursive_mutex`. It is recursive because the public methods call one another (`Register*` -> `Get` + `Set*`, `Load` -> `LoadFromPath` -> `Set*`), so a single non-recursive lock at each entry point would self-deadlock. The two protected helpers (`LoadFromPath`, `LoadLegacy`) are only reached from `Load` and stay under its lock.

Reads on the audio thread take an uncontended lock (a couple of atomics); a large write burst briefly serialises with them instead of crashing.
