### PR TITLE
fix(fast3d): accept tagged Android ARM64 resource pointers

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -5348,7 +5348,9 @@ int32_t gfx_check_image_signature(const char* imgData) {
 #if UINTPTR_MAX > 0xFFFFFFFFu
     // On 64-bit: filter kernel/sentinel addresses. Upper bound covers all
     // user-space layouts (x86_64 47-bit canonical, ARM64 48-bit VA, etc.).
-    if (i > 0x0000FFFFFFFFFFFFull) {
+    // ARM64 Android heap pointers can carry a top-byte memory tag; the CPU
+    // ignores it when dereferencing, but the user-space range check must too.
+    if ((i & 0x00FFFFFFFFFFFFFFull) > 0x0000FFFFFFFFFFFFull) {
         return 0;
     }
 #endif


### PR DESCRIPTION
## Summary
- Mask the ARM64 top byte before Fast3D validates a candidate `__OTR__` resource-path pointer.
- Android allocators can tag heap pointers; rejecting them made Fast3D upload resource-path bytes as texture data.

## Validation
- AI-generated implementation.
- Built, installed, and device-tested on an AYANEO Pocket S Mini (Adreno 740, Android 13).
- User subsequently performed manual testing on the same device.

This is intentionally a one-line Fast3D pointer-validation change.