### PR TITLE
Restore component-owned state

### DIFF
--- a/include/ship/resource/ResourceManager.h
+++ b/include/ship/resource/ResourceManager.h
@@ -407,6 +407,7 @@ class ResourceManager : public Component {
      * - "validHashes"  (array of uint32): acceptable game-version hashes; empty = all accepted.
      */
     void OnInit(const nlohmann::json& initArgs = nlohmann::json::object()) override;
+    void OnRemoved(bool forced) override;
 
     std::shared_ptr<std::vector<std::shared_ptr<IResource>>> LoadResourcesProcess(const ResourceFilter& filter);
     void UnloadResourcesProcess(const ResourceFilter& filter);

--- a/src/ship/controller/controldeck/ControlDeck.cpp
+++ b/src/ship/controller/controldeck/ControlDeck.cpp
@@ -20,6 +20,7 @@ ControlDeck::ControlDeck(std::vector<CONTROLLERBUTTONS_T> additionalBitmasks,
     mGlobalSDLDeviceSettings = std::make_shared<GlobalSDLDeviceSettings>(mConsoleVariables);
     mControllerDefaultMappings = controllerDefaultMappings == nullptr ? std::make_shared<ControllerDefaultMappings>()
                                                                       : controllerDefaultMappings;
+    mButtonNames = std::move(buttonNames);
 }
 
 ControlDeck::~ControlDeck() {

--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -44,6 +44,12 @@ void ResourceManager::OnInit(const nlohmann::json& initArgs) {
     }
 }
 
+void ResourceManager::OnRemoved(bool forced) {
+    Component::OnRemoved(forced);
+    mResourceLoader.reset();
+    mArchiveManager.reset();
+}
+
 ResourceManager::~ResourceManager() {
     // Guard against logging after the Logger component (and spdlog) has shut down
     // during Context teardown.

--- a/src/ship/window/gui/Gui.cpp
+++ b/src/ship/window/gui/Gui.cpp
@@ -151,6 +151,9 @@ void Gui::ImGuiWMInit() {
 }
 
 void Gui::ShutDownImGui(Ship::Window* window) {
+    if (ImGui::GetCurrentContext() == nullptr) {
+        return;
+    }
     ImGuiWMShutdown();
     ImGuiBackendShutdown();
     ImGui::DestroyContext();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,9 +32,12 @@ add_executable(libultraship_tests
     splittext_tests.cpp
     path_diskfile_tests.cpp
     resource_type_tests.cpp
+    resource_manager_lifecycle_tests.cpp
     archive_self_tests.cpp
     connected_physical_device_manager_tests.cpp
+    control_deck_tests.cpp
     gfx_sdl_window_tests.cpp
+    gui_lifecycle_tests.cpp
     rumble_mapping_factory_tests.cpp
 )
 

--- a/tests/control_deck_tests.cpp
+++ b/tests/control_deck_tests.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+
+#include "ship/config/ConsoleVariable.h"
+#include "ship/controller/controldeck/ControlDeck.h"
+
+namespace Ship {
+namespace {
+
+class TestControlDeck final : public ControlDeck {
+  public:
+    TestControlDeck(std::unordered_map<CONTROLLERBUTTONS_T, std::string> buttonNames,
+                    std::shared_ptr<ConsoleVariable> consoleVariable)
+        : ControlDeck({}, nullptr, std::move(buttonNames), nullptr, std::move(consoleVariable)) {
+    }
+
+    void WriteToPad(void*) override {
+    }
+};
+
+TEST(ControlDeckTest, PreservesGameSpecificButtonNames) {
+    constexpr CONTROLLERBUTTONS_T testButton = 0x4000;
+    auto consoleVariables = std::make_shared<ConsoleVariable>();
+    TestControlDeck controlDeck({ { testButton, "Test" } }, consoleVariables);
+
+    EXPECT_EQ(controlDeck.GetAllButtonNames().at(testButton), "Test");
+    EXPECT_EQ(controlDeck.GetButtonNameForBitmask(testButton), "Test");
+}
+
+} // namespace
+} // namespace Ship

--- a/tests/gui_lifecycle_tests.cpp
+++ b/tests/gui_lifecycle_tests.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+
+#include "ship/window/gui/Gui.h"
+
+#include <imgui.h>
+
+namespace Ship {
+namespace {
+
+TEST(GuiLifecycleTest, ShutdownWithoutContextIsSafe) {
+    ASSERT_EQ(ImGui::GetCurrentContext(), nullptr);
+    Gui gui;
+
+    gui.ShutDownImGui(nullptr);
+
+    EXPECT_EQ(ImGui::GetCurrentContext(), nullptr);
+}
+
+} // namespace
+} // namespace Ship

--- a/tests/resource_manager_lifecycle_tests.cpp
+++ b/tests/resource_manager_lifecycle_tests.cpp
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+
+#include "ship/core/Context.h"
+#include "ship/resource/ResourceManager.h"
+#include "ship/resource/archive/ArchiveManager.h"
+#include "ship/thread/ThreadPool.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+
+namespace Ship {
+namespace {
+
+TEST(ResourceManagerLifecycleTest, ReleasesOwnedComponentsWhenRemoved) {
+    const auto fixture =
+        std::filesystem::temp_directory_path() /
+        ("lus-resource-manager-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+    ASSERT_TRUE(std::filesystem::create_directories(fixture));
+    std::ofstream(fixture / "resource.bin", std::ios::binary) << "resource";
+
+    auto context = Context::CreateInstance("LUS resource manager test", "lus-resource-manager-test");
+    context->Init();
+    auto threadPool = std::make_shared<ThreadPool>(1);
+    context->GetChildren().Add(threadPool);
+    threadPool->Init();
+    auto resourceManager = std::make_shared<ResourceManager>(threadPool);
+    context->GetChildren().Add(resourceManager);
+    resourceManager->Init({ { "archivePaths", std::vector<std::string>{ fixture.string() } },
+                            { "validHashes", std::vector<uint32_t>{} } });
+
+    std::weak_ptr<ResourceManager> weakResourceManager = resourceManager;
+    std::weak_ptr<ArchiveManager> weakArchiveManager = resourceManager->GetArchiveManager();
+    context->GetChildren().Remove(resourceManager, true);
+    resourceManager.reset();
+
+    EXPECT_TRUE(weakResourceManager.expired());
+    EXPECT_TRUE(weakArchiveManager.expired());
+
+    context.reset();
+    std::error_code cleanupError;
+    std::filesystem::remove_all(fixture, cleanupError);
+    EXPECT_FALSE(cleanupError);
+    EXPECT_FALSE(std::filesystem::exists(fixture));
+}
+
+} // namespace
+} // namespace Ship


### PR DESCRIPTION
## Summary
- preserve game-specific button names passed to ControlDeck
- release ResourceManager-owned loader and archive components when the manager leaves the component tree
- safely skip ImGui backend shutdown when no context was initialized
- cover the component-state regressions with focused tests

## Testing
Windows Debug libultraship_tests build
- ctest --test-dir build-validation -C Debug --output-on-failure --timeout 120 (621/621)
- Township SDL3 focused regression tests (11/11)