### PR TITLE
Give OSMesg's integer constructors a fully defined value

### DIFF
--- a/include/libultraship/libultra/message.h
+++ b/include/libultraship/libultra/message.h
@@ -13,9 +13,20 @@ typedef union {
     void* ptr;
 } OSMesg;
 
-#define OS_MESG_8(x) ((OSMesg){ .data8 = (x) })
-#define OS_MESG_16(x) ((OSMesg){ .data16 = (x) })
-#define OS_MESG_32(x) ((OSMesg){ .data32 = (x) })
+/*
+ * Initialising a narrow member leaves the union's remaining bytes -- including the upper half
+ * of the 64-bit ptr -- holding unspecified values, i.e. whatever was on the stack. Receivers
+ * tell an event apart from a task pointer by inspecting the whole pointer, so those bytes
+ * matter: graphics_thread.c does `if ((uintptr_t)msg.ptr < 100)`, and garbage in the high word
+ * turned event 5 into 0x100000005, which then got dereferenced. That crashed on arm64/iOS;
+ * x86_64 desktops only escaped because the leftover bytes happened to be zero.
+ *
+ * Writing the full pointer width instead leaves every member well defined -- the data8/16/32
+ * views still read back the value on the little-endian targets these ports run on.
+ */
+#define OS_MESG_8(x) ((OSMesg){ .ptr = (void*)(uintptr_t)(u8)(x) })
+#define OS_MESG_16(x) ((OSMesg){ .ptr = (void*)(uintptr_t)(u16)(x) })
+#define OS_MESG_32(x) ((OSMesg){ .ptr = (void*)(uintptr_t)(u32)(x) })
 #define OS_MESG_PTR(x) ((OSMesg){ .ptr = (x) })
 
 #define osSendMesg8(queue, msg, flag) osSendMesg(queue, OS_MESG_8(msg), flag)


### PR DESCRIPTION
## Summary

`OS_MESG_8/16/32` initialise only the narrow member of the `OSMesg` union. That
leaves the rest of the object — including the upper half of the 64-bit `ptr` —
holding unspecified bytes. This is a latent correctness bug on every 64-bit
target; it just happens to be benign on x86_64 today. It was found on arm64.

## Up front: the little-endian caveat

This change constructs through `.ptr`, so reading the value back out through
`data8`/`data16`/`data32` is correct **only on little-endian targets**. That is
not a regression — the existing macros are equally endian-dependent in the other
direction, and the union itself is inherently a type-punning construct — but it
is worth stating plainly rather than leaving a reviewer to find it. Every target
these ports build for (x86_64, arm64/aarch64 on macOS, iOS, Android, Windows,
Linux) is little-endian, so the round trip holds in practice everywhere this
code runs.

If a big-endian target ever appears, these macros need revisiting either way.

## The bug

Those uninitialised bytes are load bearing. Receivers discriminate an event from
a task pointer by inspecting the *whole* pointer — consumers do:

```c
if ((uintptr_t)msg.ptr < 100) {
    /* treat as an event */
} else {
    /* treat as a task pointer and dereference */
}
```

With only `data32` written, the high word is whatever was on the stack. In
practice that turned event `5` into `0x100000005`, which:

1. failed the `< 100` test,
2. was therefore taken as a task pointer,
3. was dereferenced, and
4. killed the graphics thread.

x86_64 escaped only because the leftover stack bytes happened to be zero. That
is luck, not a guarantee — nothing in the language or the ABI promises it, and
it can change with any compiler version, optimisation level, or shift in the
surrounding stack frame. The aarch64 Android target in `build-validation.yml` is
exposed to exactly the same latent failure.

## The fix

Construct through `.ptr` so every member of the union is well defined, with the
narrow cast preserved so the value is still truncated to the intended width:

```c
#define OS_MESG_8(x) ((OSMesg){ .ptr = (void*)(uintptr_t)(u8)(x) })
#define OS_MESG_16(x) ((OSMesg){ .ptr = (void*)(uintptr_t)(u16)(x) })
#define OS_MESG_32(x) ((OSMesg){ .ptr = (void*)(uintptr_t)(u32)(x) })
```

`OS_MESG_PTR` is unchanged. A comment block above the macros records why the
full pointer width is written, so the narrow-initialiser form does not get
reintroduced later as a "simplification".

## Scope

One file, `include/libultraship/libultra/message.h`. No behavioural change on
any target that was already working — the value delivered is identical; the
previously-undefined bytes are now defined as zero.

## CI notes

`include/libultraship/libultra/*` is excluded from `clang-tidy-diff` in
`.github/workflows/tidy-format-validation.yml`, so only the clang-format gate
applies here. I ran that gate locally with clang-format-14 across `src` and
`include`; this file passes unmodified and no other file is touched.

---

*Drafted with AI assistance; the diff, the format gate, and the reasoning above
were verified by hand.*