### PR TITLE
Let ~Context survive a partially initialised context

### DIFF
--- a/src/ship/Context.cpp
+++ b/src/ship/Context.cpp
@@ -42,7 +42,10 @@ void Context::DestroyInstance() {
 
 Context::~Context() {
     SPDLOG_TRACE("destruct context");
-    GetWindow()->SaveWindowToConfig();
+    // A context is built in stages, so an early exit can destroy one before every Init* has run.
+    if (mWindow != nullptr) {
+        mWindow->SaveWindowToConfig();
+    }
     // Explicitly destructing everything so that logging is done last.
     mAudio = nullptr;
     mWindow = nullptr;
@@ -59,9 +62,13 @@ Context::~Context() {
     mScriptLoader = nullptr;
     mKeystore = nullptr;
 #endif
-    GetConfig()->Save();
+    if (mConfig != nullptr) {
+        mConfig->Save();
+    }
     mConfig = nullptr;
-    mLogger->flush();
+    if (mLogger != nullptr) {
+        mLogger->flush();
+    }
     mLogger = nullptr;
 #ifndef _DEBUG
     mLogThreadPool = nullptr;


### PR DESCRIPTION
### Problem

A `Context` is assembled in stages: `CreateUninitializedInstance()` creates the
object, and the individual `Init*` calls fill it in afterwards. The destructor,
however, assumed every one of those stages had run, and dereferenced members
unconditionally:

```cpp
GetWindow()->SaveWindowToConfig();
...
GetConfig()->Save();
mConfig = nullptr;
mLogger->flush();
```

If the context is destroyed part-way through that sequence, those calls run
against null members. A consumer's extractor flow does exactly this: it quits
before it ever reaches `InitLogging()`, so `mLogger` is still null when the
context unwinds, and `mLogger->flush()` dereferences it — SIGSEGV,
`KERN_INVALID_ADDRESS` at `0x0`. `mWindow` and `mConfig` carry the same
exposure on earlier exits.

This is not platform-specific. Any consumer that tears down a
context between `CreateUninitializedInstance()` and the last `Init*` call hits
the same dereference, on any platform.

### Fix

Null-check `mWindow`, `mConfig`, and `mLogger` in `~Context()` before using
them, with a comment explaining the staged-construction invariant so the checks
don't read as defensive noise. Members are used directly instead of via the
`Get*()` accessors, since the accessors exist to hand out a live subsystem, not
to be probed for absence.

### Related work

This continues the direction of **Untangle various parts from the Context
destructor (#1103)**, which loosened the destructor's assumptions about what it
owns and when. That PR addressed ordering and ownership; this one addresses the
remaining assumption that every member is present at all.

### Scope

One file, `src/ship/Context.cpp`, +13/-3, confined to the destructor. No
behaviour change for a fully initialised context: every check passes and the
same calls run in the same order. `clang-format-14` over `src` and `include`
produces no diff.

---

*Prepared with AI assistance; the change, the crash analysis, and the build and
formatting checks were verified by hand.*