### PR TITLE
Warn when a framebuffer size mismatch drops the ImGui frame

### DIFF
--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -120,8 +120,18 @@ void GfxRenderingAPIMetal::RenderDrawData(ImDrawData* drawData) {
     MTL::Texture* screen_texture = mTextures[framebuffer.mTextureId].texture;
     int fb_width = (int)(drawData->DisplaySize.x * drawData->FramebufferScale.x);
     int fb_height = (int)(drawData->DisplaySize.y * drawData->FramebufferScale.y);
-    if (screen_texture->width() != fb_width || screen_texture->height() != fb_height)
+    if (screen_texture->width() != fb_width || screen_texture->height() != fb_height) {
+        // Dropping the frame hides the entire GUI with no other symptom, so say so once.
+        static bool sMismatchReported = false;
+        if (!sMismatchReported) {
+            sMismatchReported = true;
+            SPDLOG_WARN("Metal: skipping ImGui draw, screen texture {}x{} != draw data {}x{} "
+                        "(DisplaySize {}x{} * FramebufferScale {}x{})",
+                        screen_texture->width(), screen_texture->height(), fb_width, fb_height, drawData->DisplaySize.x,
+                        drawData->DisplaySize.y, drawData->FramebufferScale.x, drawData->FramebufferScale.y);
+        }
         return;
+    }
 
     ImGui_ImplMetal_RenderDrawData(drawData, framebuffer.mCommandBuffer, framebuffer.mCommandEncoder);
 }


### PR DESCRIPTION
### The problem

`GfxRenderingAPIMetal::RenderDrawData()` has an early return for the case where
the screen texture's dimensions disagree with the draw data's
`DisplaySize * FramebufferScale`:

```cpp
if (screen_texture->width() != fb_width || screen_texture->height() != fb_height)
    return;
```

When that condition trips, the entire ImGui overlay is dropped for the frame.
If it keeps tripping, the overlay is gone permanently. The symptom is a
completely blank GUI — no menu bar, no windows, no overlay of any kind — with
zero log output and nothing else to distinguish it from a dozen other possible
causes. The game itself still renders, so it does not look like a crash or a
renderer failure; it just looks like the GUI stopped existing.

Working backwards from "blank GUI" to "the Metal backend is silently discarding
the draw data because of a size disagreement" is a genuinely unpleasant debug
session, and nothing in the log narrows it down.

### The change

Log the mismatch once, with both sets of dimensions:

```
Metal: skipping ImGui draw, screen texture 1920x1080 != draw data 3840x2160
(DisplaySize 1920x1080 * FramebufferScale 2x2)
```

That is enough to identify the failure mode immediately and to see which side of
the comparison is wrong.

**Control flow is unchanged.** The function returns early in exactly the same
cases as before; the bare `return;` just becomes a braced block so the warning
can sit in front of it. This is a diagnostics-only change.

### Scope

Metal backend only, so macOS and iOS. No behavioral change on any other backend.

### One thing to flag for review

The one-shot guard is a plain function-local `static bool`, which is not
thread-safe — two threads entering `RenderDrawData()` at once could in principle
both log. The renderer is single-threaded at this point, so in practice this
cannot happen, and I did not want to pay for an atomic on a diagnostic path that
runs at most once. Calling it out explicitly so a reviewer does not have to
wonder whether it was overlooked. Happy to switch it to `std::atomic<bool>` or
`std::call_once` if you would rather not have the assumption baked in.

### Context

This was found while working on an iOS port, where the mismatch is easy to hit,
but the diagnostic has standalone value on macOS: any time this condition occurs
there, it currently presents as a blank GUI with an empty log.

---

*AI assistance was used in preparing this change; the diff was reviewed and
verified by hand.*