### PR TITLE
use spdlog::fmt_lib over fmt, opens up SPDLOG_USE_STD_FORMAT in future

### DIFF
--- a/cmake/dependencies/android.cmake
+++ b/cmake/dependencies/android.cmake
@@ -40,7 +40,7 @@ if (NOT ${tinyxml2_FOUND})
 endif()
 
 #=================== spdlog ===================
-find_package(spdlog QUIET)
+find_package(spdlog 1.10 QUIET)
 if (NOT ${spdlog_FOUND})
     FetchContent_Declare(
         spdlog

--- a/cmake/dependencies/ios.cmake
+++ b/cmake/dependencies/ios.cmake
@@ -40,7 +40,7 @@ if (NOT ${tinyxml2_FOUND})
 endif()
 
 #=================== spdlog ===================
-find_package(spdlog QUIET)
+find_package(spdlog 1.10 QUIET)
 if (NOT ${spdlog_FOUND})
     FetchContent_Declare(
         spdlog

--- a/cmake/dependencies/mac.cmake
+++ b/cmake/dependencies/mac.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 #=================== spdlog ===================
 # macports has issues with this because of fmt
 # brew doesn't support building multiarch
-find_package(spdlog QUIET)
+find_package(spdlog 1.10 QUIET)
 if (NOT ${spdlog_FOUND})
     FetchContent_Declare(
         spdlog

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,7 +98,7 @@ target_link_libraries(libultraship PUBLIC nlohmann_json::nlohmann_json)
 find_package(tinyxml2 REQUIRED)
 target_link_libraries(libultraship PUBLIC tinyxml2::tinyxml2)
 
-find_package(spdlog REQUIRED)
+find_package(spdlog 1.10 REQUIRED)
 target_link_libraries(libultraship PUBLIC spdlog::spdlog)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -30,7 +30,6 @@
 #include <SDL3/SDL_render.h>
 #include <imgui_impl_metal.h>
 #include <spdlog/spdlog.h>
-#include <spdlog/fmt/fmt.h>
 
 #include "fast/backends/gfx_metal_shader.h"
 
@@ -897,7 +896,7 @@ void GfxRenderingAPIMetal::StartDrawToFramebuffer(int fb_id, float noise_scale) 
         // commit+waitUntilCompleted doesn't deadlock on enqueue ordering.
         MTL::CommandQueue* queue = fb.mUseReadbackQueue ? mReadbackQueue : mCommandQueue;
         fb.mCommandBuffer = queue->commandBuffer();
-        std::string fbcb_label = fmt::format("FrameBuffer {} Command Buffer", fb_id);
+        std::string fbcb_label = spdlog::fmt_lib::format("FrameBuffer {} Command Buffer", fb_id);
         fb.mCommandBuffer->setLabel(NS::String::string(fbcb_label.c_str(), NS::UTF8StringEncoding));
 
         if (!fb.mUseReadbackQueue) {
@@ -906,7 +905,7 @@ void GfxRenderingAPIMetal::StartDrawToFramebuffer(int fb_id, float noise_scale) 
         }
 
         fb.mCommandEncoder = fb.mCommandBuffer->renderCommandEncoder(fb.mRenderPassDescriptor);
-        std::string fbce_label = fmt::format("FrameBuffer {} Command Encoder", fb_id);
+        std::string fbce_label = spdlog::fmt_lib::format("FrameBuffer {} Command Encoder", fb_id);
         fb.mCommandEncoder->setLabel(NS::String::string(fbce_label.c_str(), NS::UTF8StringEncoding));
         fb.mCommandEncoder->setDepthClipMode(MTL::DepthClipModeClamp);
     }
@@ -946,7 +945,7 @@ void GfxRenderingAPIMetal::ClearFramebuffer(bool color, bool depth) {
     // Create a new render encoder back onto the framebuffer
     framebuffer.mCommandEncoder = framebuffer.mCommandBuffer->renderCommandEncoder(framebuffer.mRenderPassDescriptor);
 
-    std::string fbce_label = fmt::format("FrameBuffer {} Command Encoder After Clear", mCurrentFramebuffer);
+    std::string fbce_label = spdlog::fmt_lib::format("FrameBuffer {} Command Encoder After Clear", mCurrentFramebuffer);
     framebuffer.mCommandEncoder->setLabel(NS::String::string(fbce_label.c_str(), NS::UTF8StringEncoding));
     framebuffer.mCommandEncoder->setDepthClipMode(MTL::DepthClipModeClamp);
     framebuffer.mCommandEncoder->setViewport(*framebuffer.mViewport);
@@ -1019,7 +1018,8 @@ void GfxRenderingAPIMetal::ResolveMSAAColorBuffer(int fb_id_target, int fb_id_so
         target_framebuffer.mCommandEncoder =
             target_framebuffer.mCommandBuffer->renderCommandEncoder(target_framebuffer.mRenderPassDescriptor);
 
-        std::string fbce_label = fmt::format("FrameBuffer {} Command Encoder After MSAA Resolve", fb_id_target);
+        std::string fbce_label =
+            spdlog::fmt_lib::format("FrameBuffer {} Command Encoder After MSAA Resolve", fb_id_target);
         target_framebuffer.mCommandEncoder->setLabel(NS::String::string(fbce_label.c_str(), NS::UTF8StringEncoding));
     }
 }
@@ -1157,7 +1157,7 @@ void GfxRenderingAPIMetal::CopyFramebuffer(int fb_dst_id, int fb_src_id, int src
     source_framebuffer.mCommandEncoder =
         source_framebuffer.mCommandBuffer->renderCommandEncoder(source_framebuffer.mRenderPassDescriptor);
 
-    std::string fbce_label = fmt::format("FrameBuffer {} Command Encoder After Copy", fb_src_id);
+    std::string fbce_label = spdlog::fmt_lib::format("FrameBuffer {} Command Encoder After Copy", fb_src_id);
     source_framebuffer.mCommandEncoder->setLabel(NS::String::string(fbce_label.c_str(), NS::UTF8StringEncoding));
     source_framebuffer.mCommandEncoder->setDepthClipMode(MTL::DepthClipModeClamp);
     source_framebuffer.mCommandEncoder->setViewport(*source_framebuffer.mViewport);

--- a/src/fast/backends/gfx_sdl.cpp
+++ b/src/fast/backends/gfx_sdl.cpp
@@ -226,7 +226,7 @@ void GfxWindowBackendSDL::SetFullscreenImpl(bool on, bool call_callback) {
     SDL_DisplayID display_in_use = SDL_GetDisplayForWindow(mWnd);
     if (display_in_use == 0) {
         SPDLOG_WARN("Can't detect on which monitor we are. Probably out of display area?");
-        SPDLOG_WARN(SDL_GetError());
+        SPDLOG_WARN("{}", SDL_GetError());
     }
 
     if (on) {
@@ -241,7 +241,7 @@ void GfxWindowBackendSDL::SetFullscreenImpl(bool on, bool call_callback) {
                 !SDL_GetClosestFullscreenDisplayMode(display_in_use, desktopMode->w, desktopMode->h,
                                                      desktopMode->refresh_rate, true, &fullscreenMode)) {
                 SPDLOG_ERROR("Failed to find an exclusive fullscreen mode.");
-                SPDLOG_ERROR(SDL_GetError());
+                SPDLOG_ERROR("{}", SDL_GetError());
             } else {
                 mode = &fullscreenMode;
             }
@@ -249,7 +249,7 @@ void GfxWindowBackendSDL::SetFullscreenImpl(bool on, bool call_callback) {
 
         if (!SDL_SetWindowFullscreenMode(mWnd, mode)) {
             SPDLOG_ERROR("Failed to set the fullscreen display mode.");
-            SPDLOG_ERROR(SDL_GetError());
+            SPDLOG_ERROR("{}", SDL_GetError());
         }
     }
 
@@ -264,7 +264,7 @@ void GfxWindowBackendSDL::SetFullscreenImpl(bool on, bool call_callback) {
         mFullScreen = on;
     } else {
         SPDLOG_ERROR("Failed to switch from or to fullscreen mode.");
-        SPDLOG_ERROR(SDL_GetError());
+        SPDLOG_ERROR("{}", SDL_GetError());
     }
 #endif
 

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -36,7 +36,7 @@
 
 #include "libultraship/libultra/os.h"
 
-#include <spdlog/fmt/fmt.h>
+#include <spdlog/common.h>
 
 #ifdef _WIN32
 #include <windows.h>

--- a/src/libultraship/window/gui/GfxDebuggerWindow.cpp
+++ b/src/libultraship/window/gui/GfxDebuggerWindow.cpp
@@ -5,7 +5,6 @@
 #include "ship/resource/ResourceManager.h"
 #include "fast/debug/GfxDebugger.h"
 #include <stack>
-#include <spdlog/fmt/fmt.h>
 #include "libultraship/bridge.h"
 #include "fast/interpreter.h"
 #include "fast/Fast3dWindow.h"
@@ -82,7 +81,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 SDL_SetClipboardText(text.c_str());
             }
             if (ImGui::Selectable("Copy address")) {
-                std::string address = fmt::format("0x{:x}", (uintptr_t)cmd);
+                std::string address = spdlog::fmt_lib::format("0x{:x}", (uintptr_t)cmd);
                 SDL_SetClipboardText(address.c_str());
             }
             if (parentPosY > 0) {
@@ -141,13 +140,13 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
 
             gfxd_execute();
 
-            nodeWithText(cmd, fmt::format("{}", buff));
+            nodeWithText(cmd, spdlog::fmt_lib::format("{}", buff));
 #else
-            nodeWithText(cmd, fmt::format("{}", opname));
+            nodeWithText(cmd, spdlog::fmt_lib::format("{}", opname));
 #endif // GFX_DEBUG_DISASSEMBLER
         } else {
             int8_t opcode = (int8_t)(cmd->words.w0 >> 24);
-            nodeWithText(cmd, fmt::format("UNK: 0x{:X}", opcode));
+            nodeWithText(cmd, spdlog::fmt_lib::format("UNK: 0x{:X}", opcode));
         }
     };
 
@@ -163,9 +162,9 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 uint32_t l = C0(0, 16);
 
                 if (p == 7) {
-                    nodeWithText(cmd0, fmt::format("gDPNoOpOpenDisp(): {}:{}", filename, l));
+                    nodeWithText(cmd0, spdlog::fmt_lib::format("gDPNoOpOpenDisp(): {}:{}", filename, l));
                 } else if (p == 8) {
-                    nodeWithText(cmd0, fmt::format("gDPNoOpCloseDisp(): {}:{}", filename, l));
+                    nodeWithText(cmd0, spdlog::fmt_lib::format("gDPNoOpCloseDisp(): {}:{}", filename, l));
                 } else {
                     simpleNode(cmd0, opcode);
                 }
@@ -182,10 +181,12 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
 #endif
                 F3DGfx* subGFX = (F3DGfx*)mInterpreter.lock()->SegAddr(cmd->words.w1);
                 if (C0(16, 1) == 0) {
-                    nodeWithText(cmd0, fmt::format("G_DL: 0x{:x} -> {}", cmd->words.w1, (void*)subGFX), subGFX);
+                    nodeWithText(cmd0, spdlog::fmt_lib::format("G_DL: 0x{:x} -> {}", cmd->words.w1, (void*)subGFX),
+                                 subGFX);
                     cmd++;
                 } else {
-                    nodeWithText(cmd0, fmt::format("G_DL (branch): 0x{:x} -> {}", cmd->words.w1, (void*)subGFX),
+                    nodeWithText(cmd0,
+                                 spdlog::fmt_lib::format("G_DL (branch): 0x{:x} -> {}", cmd->words.w1, (void*)subGFX),
                                  subGFX);
                     return;
                 }
@@ -217,7 +218,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                     dlName = "UNKNOWN";
                 }
 
-                nodeWithText(cmd0, fmt::format("G_MARKER: {}", dlName));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_MARKER: {}", dlName));
                 cmd++;
                 break;
             }
@@ -231,7 +232,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                         dlName = "UNKNOWN";
 
                     F3DGfx* subGfx = (F3DGfx*)ResourceGetDataByCrc(hash);
-                    nodeWithText(cmd0, fmt::format("G_DL_OTR_HASH: {}", dlName), subGfx);
+                    nodeWithText(cmd0, spdlog::fmt_lib::format("G_DL_OTR_HASH: {}", dlName), subGfx);
                     cmd++;
                 } else {
                     assert(0 && "Invalid in gfx_pc????");
@@ -248,11 +249,11 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 }
 
                 if (C0(16, 1) == 0 && subGfx != nullptr) {
-                    nodeWithText(cmd0, fmt::format("G_DL_OTR_HASH: {}", fileName), subGfx);
+                    nodeWithText(cmd0, spdlog::fmt_lib::format("G_DL_OTR_HASH: {}", fileName), subGfx);
                     cmd++;
                     break;
                 } else {
-                    nodeWithText(cmd0, fmt::format("G_DL_OTR_HASH (branch): {}", fileName), subGfx);
+                    nodeWithText(cmd0, spdlog::fmt_lib::format("G_DL_OTR_HASH (branch): {}", fileName), subGfx);
                     return;
                 }
 
@@ -266,10 +267,12 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 F3DGfx* subGFX = (F3DGfx*)mInterpreter.lock()->SegAddr(segAddr);
 
                 if (C0(16, 1) == 0) {
-                    nodeWithText(cmd0, fmt::format("G_DL_INDEX: 0x{:x} -> {}", segAddr, (void*)subGFX), subGFX);
+                    nodeWithText(cmd0, spdlog::fmt_lib::format("G_DL_INDEX: 0x{:x} -> {}", segAddr, (void*)subGFX),
+                                 subGFX);
                     cmd++;
                 } else {
-                    nodeWithText(cmd0, fmt::format("G_DL_INDEX (branch): 0x{:x} -> {}", segAddr, (void*)subGFX),
+                    nodeWithText(cmd0,
+                                 spdlog::fmt_lib::format("G_DL_INDEX (branch): 0x{:x} -> {}", segAddr, (void*)subGFX),
                                  subGFX);
                     return;
                 }
@@ -296,10 +299,12 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 // if (subGfx && (g_rsp.loaded_vertices[vbidx].z <= zval ||
                 //                (g_rsp.extra_geometry_mode & G_EX_ALWAYS_EXECUTE_BRANCH) != 0)) {
                 if (subGfx) {
-                    nodeWithText(cmd0, fmt::format("G_BRANCH_Z_OTR: zval {}, vIdx {}, DL {}", zval, vbidx, dlName),
-                                 subGfx);
+                    nodeWithText(
+                        cmd0, spdlog::fmt_lib::format("G_BRANCH_Z_OTR: zval {}, vIdx {}, DL {}", zval, vbidx, dlName),
+                        subGfx);
                 } else {
-                    nodeWithText(cmd0, fmt::format("G_BRANCH_Z_OTR: zval {}, vIdx {}, DL {}", zval, vbidx, dlName));
+                    nodeWithText(
+                        cmd0, spdlog::fmt_lib::format("G_BRANCH_Z_OTR: zval {}, vIdx {}, DL {}", zval, vbidx, dlName));
                 }
 
                 cmd++;
@@ -314,7 +319,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                     name = "UNKNOWN";
                 }
 
-                nodeWithText(cmd0, fmt::format("G_SETTIMG_OTR_HASH: {}", name));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_SETTIMG_OTR_HASH: {}", name));
 
                 cmd++;
                 break;
@@ -322,7 +327,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
 
             case OTR_G_SETTIMG_OTR_FILEPATH: {
                 const char* fileName = (char*)cmd->words.w1;
-                nodeWithText(cmd0, fmt::format("G_SETTIMG_OTR_FILEPATH: {}", fileName));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_SETTIMG_OTR_FILEPATH: {}", fileName));
 
                 cmd++;
                 break;
@@ -336,7 +341,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                     name = "UNKNOWN";
                 }
 
-                nodeWithText(cmd0, fmt::format("G_VTX_OTR_HASH: {}", name));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_VTX_OTR_HASH: {}", name));
 
                 cmd++;
                 break;
@@ -344,7 +349,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
 
             case OTR_G_VTX_OTR_FILEPATH: {
                 const char* fileName = (char*)cmd->words.w1;
-                nodeWithText(cmd0, fmt::format("G_VTX_OTR_FILEPATH: {}", fileName));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_VTX_OTR_FILEPATH: {}", fileName));
 
                 cmd += 2;
                 break;
@@ -358,7 +363,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                     name = "UNKNOWN";
                 }
 
-                nodeWithText(cmd0, fmt::format("G_MTX_OTR: {}", name));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_MTX_OTR: {}", name));
 
                 cmd++;
                 break;
@@ -366,7 +371,7 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
 
             case OTR_G_MTX_OTR_FILEPATH: {
                 const char* fileName = (char*)cmd->words.w1;
-                nodeWithText(cmd0, fmt::format("G_MTX_OTR_FILEPATH: {}", fileName));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_MTX_OTR_FILEPATH: {}", fileName));
 
                 cmd++;
                 break;
@@ -382,26 +387,28 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                     name = "UNKNOWN";
                 }
 
-                nodeWithText(cmd0, fmt::format("G_MOVEMEM_HASH: idx {}, offset {}, {}", index, offset, name));
+                nodeWithText(cmd0,
+                             spdlog::fmt_lib::format("G_MOVEMEM_HASH: idx {}, offset {}, {}", index, offset, name));
 
                 cmd++;
                 break;
             }
 
             case OTR_G_IMAGERECT: {
-                nodeWithText(cmd0, fmt::format("G_IMAGERECT"));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_IMAGERECT"));
                 cmd += 3;
                 break;
             }
 
             case OTR_G_TRI1_OTR: {
-                nodeWithText(cmd0, fmt::format("G_TRI1_OTR: v00 {}, v01 {}, v02 {}", C0(0, 16), C1(16, 16), C1(0, 16)));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_TRI1_OTR: v00 {}, v01 {}, v02 {}", C0(0, 16), C1(16, 16),
+                                                           C1(0, 16)));
                 cmd++;
                 break;
             }
 
             case OTR_G_PUSHCD: {
-                nodeWithText(cmd0, fmt::format("G_PUSHCD: filename {}", cmd->words.w1));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_PUSHCD: filename {}", cmd->words.w1));
                 cmd++;
                 break;
             }
@@ -409,12 +416,12 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
             case OTR_G_INVALTEXCACHE: {
                 const char* texAddr = (const char*)cmd->words.w1;
                 if (texAddr == 0) {
-                    nodeWithText(cmd0, fmt::format("G_INVALTEXCACHE: clear all entries"));
+                    nodeWithText(cmd0, spdlog::fmt_lib::format("G_INVALTEXCACHE: clear all entries"));
                 } else {
                     if (((uintptr_t)texAddr & 1) == 0 && mResourceManager->OtrSignatureCheck(texAddr)) {
-                        nodeWithText(cmd0, fmt::format("G_INVALTEXCACHE: {}", texAddr));
+                        nodeWithText(cmd0, spdlog::fmt_lib::format("G_INVALTEXCACHE: {}", texAddr));
                     } else {
-                        nodeWithText(cmd0, fmt::format("G_INVALTEXCACHE: 0x{:x}", (uintptr_t)texAddr));
+                        nodeWithText(cmd0, spdlog::fmt_lib::format("G_INVALTEXCACHE: 0x{:x}", (uintptr_t)texAddr));
                     }
                 }
 
@@ -423,26 +430,26 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
             }
 
             case OTR_G_SETTIMG_FB: {
-                nodeWithText(cmd0, fmt::format("G_SETTIMG_FB: src FB {}", (int32_t)cmd->words.w1));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_SETTIMG_FB: src FB {}", (int32_t)cmd->words.w1));
                 cmd++;
                 break;
             }
 
             case OTR_G_COPYFB: {
-                nodeWithText(cmd0, fmt::format("G_COPYFB: src FB {}, dest FB {}, new frames only {}", C0(0, 11),
-                                               C0(11, 11), C0(22, 1)));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_COPYFB: src FB {}, dest FB {}, new frames only {}",
+                                                           C0(0, 11), C0(11, 11), C0(22, 1)));
                 cmd++;
                 break;
             }
 
             case OTR_G_SETFB: {
-                nodeWithText(cmd0, fmt::format("G_SETFB: src FB {}", (int32_t)cmd->words.w1));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_SETFB: src FB {}", (int32_t)cmd->words.w1));
                 cmd++;
                 break;
             }
 
             case OTR_G_RESETFB: {
-                nodeWithText(cmd0, fmt::format("G_RESETFB"));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_RESETFB"));
                 cmd++;
                 break;
             }
@@ -451,8 +458,9 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 int fbId = C0(0, 8);
                 bool bswap = C0(8, 1);
                 cmd++;
-                nodeWithText(cmd0, fmt::format("G_READFB: src FB {}, byteswap {}, ulx {}, uly {}, width {}, height {}",
-                                               fbId, bswap, C0(0, 16), C0(16, 16), C1(0, 16), C1(16, 16)));
+                nodeWithText(cmd0, spdlog::fmt_lib::format(
+                                       "G_READFB: src FB {}, byteswap {}, ulx {}, uly {}, width {}, height {}", fbId,
+                                       bswap, C0(0, 16), C0(16, 16), C1(0, 16), C1(16, 16)));
                 cmd++;
                 break;
             }
@@ -471,9 +479,9 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 uint32_t dtdy = C1(0, 16);
 
                 nodeWithText(
-                    cmd0,
-                    fmt::format("G_TEXRECT_WIDE: ulx {}, uly {}, lrx {}, lry {}, tile {}, s {}, t {}, dsdx {}, dtdy {}",
-                                ulx, uly, lrx, lry, uls, tile, ult, dsdx, dtdy));
+                    cmd0, spdlog::fmt_lib::format(
+                              "G_TEXRECT_WIDE: ulx {}, uly {}, lrx {}, lry {}, tile {}, s {}, t {}, dsdx {}, dtdy {}",
+                              ulx, uly, lrx, lry, uls, tile, ult, dsdx, dtdy));
 
                 cmd++;
                 break;
@@ -485,34 +493,35 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 cmd++;
                 int32_t ulx = (int32_t)(C0(0, 24) << 8) >> 8;
                 int32_t uly = (int32_t)(C1(0, 24) << 8) >> 8;
-                nodeWithText(cmd0, fmt::format("G_FILLWIDERECT: ulx {}, uly {}, lrx {}, lry {}", ulx, uly, lrx, lry));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_FILLWIDERECT: ulx {}, uly {}, lrx {}, lry {}", ulx, uly,
+                                                           lrx, lry));
 
                 cmd++;
                 break;
             }
 
             case OTR_G_SETGRAYSCALE: {
-                nodeWithText(cmd0, fmt::format("G_SETGRAYSCALE: Enable {}", (uint32_t)cmd->words.w1));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_SETGRAYSCALE: Enable {}", (uint32_t)cmd->words.w1));
                 cmd++;
                 break;
             }
 
             case OTR_G_PUSH_SHADER: {
                 const char* shader = (const char*)cmd->words.w1;
-                nodeWithText(cmd0, fmt::format("G_PUSH_SHADER: {}", shader == nullptr ? "None" : shader));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_PUSH_SHADER: {}", shader == nullptr ? "None" : shader));
                 cmd++;
                 break;
             }
 
             case OTR_G_POP_SHADER: {
-                nodeWithText(cmd0, fmt::format("G_POP_SHADER"));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_POP_SHADER"));
                 cmd++;
                 break;
             }
 
             case OTR_G_SETINTENSITY: {
-                nodeWithText(cmd0, fmt::format("G_SETINTENSITY: red {}, green {}, blue {}, alpha {}", C1(24, 8),
-                                               C1(16, 8), C1(8, 8), C1(0, 8)));
+                nodeWithText(cmd0, spdlog::fmt_lib::format("G_SETINTENSITY: red {}, green {}, blue {}, alpha {}",
+                                                           C1(24, 8), C1(16, 8), C1(8, 8), C1(0, 8)));
                 cmd++;
                 break;
             }
@@ -520,7 +529,8 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
             case OTR_G_EXTRAGEOMETRYMODE: {
                 uint32_t setBits = (uint32_t)cmd->words.w1;
                 uint32_t clearBits = ~C0(0, 24);
-                nodeWithText(cmd0, fmt::format("G_EXTRAGEOMETRYMODE: Set {}, Clear {}", setBits, clearBits));
+                nodeWithText(cmd0,
+                             spdlog::fmt_lib::format("G_EXTRAGEOMETRYMODE: Set {}, Clear {}", setBits, clearBits));
                 cmd++;
                 break;
             }
@@ -534,11 +544,11 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
 
                 if (mResourceManager->OtrSignatureCheck(timg)) {
                     timg += 7;
-                    nodeWithText(cmd0, fmt::format("G_REGBLENDEDTEX: src {}, mask {}, blended {}", timg, (void*)mask,
-                                                   (void*)replacementTex));
+                    nodeWithText(cmd0, spdlog::fmt_lib::format("G_REGBLENDEDTEX: src {}, mask {}, blended {}", timg,
+                                                               (void*)mask, (void*)replacementTex));
                 } else {
-                    nodeWithText(cmd0, fmt::format("G_REGBLENDEDTEX: src {}, mask {}, blended {}", (void*)timg,
-                                                   (void*)mask, (void*)replacementTex));
+                    nodeWithText(cmd0, spdlog::fmt_lib::format("G_REGBLENDEDTEX: src {}, mask {}, blended {}",
+                                                               (void*)timg, (void*)mask, (void*)replacementTex));
                 }
 
                 cmd++;
@@ -602,7 +612,7 @@ void GfxDebuggerWindow::DrawDisas() {
     ImGui::Text("dlist: %p", dlist);
     std::string bp = "";
     for (auto& gfx : dbg->GetBreakPoint()) {
-        bp += fmt::format("/{}", (const void*)gfx);
+        bp += spdlog::fmt_lib::format("/{}", (const void*)gfx);
     }
     ImGui::Text("BreakPoint: %s", bp.c_str());
 
@@ -624,7 +634,7 @@ void GfxDebuggerWindow::DrawDisas() {
             ImGui::Text("Disp Stack");
             ImGui::BeginChild("### Disp Stack", ImVec2(400.0f, 0.0f), true, ImGuiWindowFlags_HorizontalScrollbar);
             for (auto& disp : g_exec_stack.disp_stack) {
-                ImGui::Text("%s", fmt::format("{}:{}", disp.file, disp.line).c_str());
+                ImGui::Text("%s", spdlog::fmt_lib::format("{}:{}", disp.file, disp.line).c_str());
             }
             ImGui::EndChild();
         }
@@ -638,8 +648,8 @@ void GfxDebuggerWindow::DrawDisas() {
             // for (size_t i = 0; i < 8; i++) {
             //     auto& tile = g_rdp.texture_tile[i];
             //     ImGui::Text(
-            //         "%s", fmt::format("{}: fmt={}; siz={}; cms={}; cmt={};", i, tile.fmt, tile.siz, tile.cms,
-            //         tile.cmt)
+            //         "%s", spdlog::fmt_lib::format("{}: fmt={}; siz={}; cms={}; cmt={};", i, tile.fmt, tile.siz,
+            //         tile.cms, tile.cmt)
             //                   .c_str());
             // }
 
@@ -663,15 +673,16 @@ void GfxDebuggerWindow::DrawDisas() {
             ImGui::Text("Loaded Textures");
             for (size_t i = 0; i < 2; i++) {
                 auto& tex = mInterpreter.lock()->mRdp->loaded_texture[i];
-                // ImGui::Text("%s", fmt::format("{}: {}x{} type={}", i, tex.raw_tex_metadata.width,
+                // ImGui::Text("%s", spdlog::fmt_lib::format("{}: {}x{} type={}", i, tex.raw_tex_metadata.width,
                 //                               tex.raw_tex_metadata.height, getTexType(tex.raw_tex_metadata.type))
                 //                       .c_str());
-                draw_img(std::to_string(i), fmt::format("GfxDebuggerWindowLoadedTexture{}", i), tex.raw_tex_metadata);
+                draw_img(std::to_string(i), spdlog::fmt_lib::format("GfxDebuggerWindowLoadedTexture{}", i),
+                         tex.raw_tex_metadata);
             }
             ImGui::Text("Texture To Load");
             {
                 auto& tex = mInterpreter.lock()->mRdp->texture_to_load;
-                // ImGui::Text("%s", fmt::format("{}x{} type={}", tex.raw_tex_metadata.width,
+                // ImGui::Text("%s", spdlog::fmt_lib::format("{}x{} type={}", tex.raw_tex_metadata.width,
                 // tex.raw_tex_metadata.height,
                 //                               getTexType(tex.raw_tex_metadata.type))
                 //                       .c_str());

--- a/src/ship/debug/CrashHandler.cpp
+++ b/src/ship/debug/CrashHandler.cpp
@@ -79,7 +79,7 @@ void CrashHandler::PrintCommon() {
         mCallback(mOutBuffer.get(), &mOutBuffersize);
     }
 
-    SPDLOG_CRITICAL(mOutBuffer.get());
+    SPDLOG_CRITICAL("{}", mOutBuffer.get());
 }
 
 #if defined(__linux__) && !defined(__ANDROID__)


### PR DESCRIPTION
requires spdlog 1.10