### PR TITLE
fast3d: fix swapped F3DEX lookat axes breaking env mapping

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -4944,11 +4944,14 @@ void Interpreter::SpReset() {
     mRsp->modelview_matrix_stack_size = 1;
     mRsp->current_num_lights = 2;
     mRsp->lights_changed = true;
-    mRsp->lookat[0].dir[0] = 127;
-    mRsp->lookat[0].dir[1] = 0;
+    // Transposed from the SDK basis on purpose: lookat[0] is LOOKATX and drives S.
+    // Only games that never send a lookat see these, and MK64 matches output with them.
+    // TODO: Use ucode DMEM defaults from hardware.
+    mRsp->lookat[0].dir[0] = 0;
+    mRsp->lookat[0].dir[1] = 127;
     mRsp->lookat[0].dir[2] = 0;
-    mRsp->lookat[1].dir[0] = 0;
-    mRsp->lookat[1].dir[1] = 127;
+    mRsp->lookat[1].dir[0] = 127;
+    mRsp->lookat[1].dir[1] = 0;
     mRsp->lookat[1].dir[2] = 0;
     CalculateNormalDir(&mRsp->lookat[0], mRsp->current_lookat_coeffs[0]);
     CalculateNormalDir(&mRsp->lookat[1], mRsp->current_lookat_coeffs[1]);

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2370,7 +2370,7 @@ void Interpreter::GfxSpMovememF3d(uint8_t index, uint8_t offset, const void* dat
             break;
         case F3DEX_G_MV_LOOKATY:
         case F3DEX_G_MV_LOOKATX:
-            memcpy(mRsp->lookat + (index - F3DEX_G_MV_LOOKATY) / 2, data, sizeof(F3DLight_t));
+            memcpy(mRsp->lookat + (F3DEX_G_MV_LOOKATX - index) / 2, data, sizeof(F3DLight_t));
             break;
         case F3DEX_G_MV_L0:
         case F3DEX_G_MV_L1:
@@ -4942,11 +4942,11 @@ void Interpreter::SpReset() {
     mRsp->modelview_matrix_stack_size = 1;
     mRsp->current_num_lights = 2;
     mRsp->lights_changed = true;
-    mRsp->lookat[0].dir[0] = 0;
-    mRsp->lookat[0].dir[1] = 127;
+    mRsp->lookat[0].dir[0] = 127;
+    mRsp->lookat[0].dir[1] = 0;
     mRsp->lookat[0].dir[2] = 0;
-    mRsp->lookat[1].dir[0] = 127;
-    mRsp->lookat[1].dir[1] = 0;
+    mRsp->lookat[1].dir[0] = 0;
+    mRsp->lookat[1].dir[1] = 127;
     mRsp->lookat[1].dir[2] = 0;
     CalculateNormalDir(&mRsp->lookat[0], mRsp->current_lookat_coeffs[0]);
     CalculateNormalDir(&mRsp->lookat[1], mRsp->current_lookat_coeffs[1]);

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -2368,9 +2368,11 @@ void Interpreter::GfxSpMovememF3d(uint8_t index, uint8_t offset, const void* dat
         case F3DEX_G_MV_VIEWPORT:
             CalcAndSetViewport((const F3DVp_t*)data);
             break;
-        case F3DEX_G_MV_LOOKATY:
         case F3DEX_G_MV_LOOKATX:
-            memcpy(mRsp->lookat + (F3DEX_G_MV_LOOKATX - index) / 2, data, sizeof(F3DLight_t));
+            memcpy(mRsp->lookat + 0, data, sizeof(F3DLight_t));
+            break;
+        case F3DEX_G_MV_LOOKATY:
+            memcpy(mRsp->lookat + 1, data, sizeof(F3DLight_t));
             break;
         case F3DEX_G_MV_L0:
         case F3DEX_G_MV_L1:


### PR DESCRIPTION
Before (LUS on the right):
<img width="5120" height="1440" alt="image" src="https://github.com/user-attachments/assets/4e5d4742-4d1c-47a2-8b1d-cb20e22659e6" />

After:
<img width="320" height="240" alt="Screenshot 2026-08-07 163932" src="https://github.com/user-attachments/assets/8874ac7a-ab92-43b9-8a4e-999b9fe157ca" />

`G_MV_LOOKATX` and `G_MV_LOOKATY` were stored into mRsp->lookat in reverse. Mistakenly introduced in #598 which added the `F3DEX1` case, copying the idiom from the `F3DEX_G_MV_L0` case immediately below it: `(index - BASE) / 2`. That works for lights because `G_MV_L0..L7` ascend. It does not work for lookat: gbi.h declares `G_MV_LOOKATY 0x82` before `G_MV_LOOKATX 0x84`. #727 added the `SpReset` defaults, written as `lookat[0] = {0,127,0} / lookat[1] = {127,0,0}` to agree with the already-inverted storage. This made the inversion internally self-consistent, which is why it survived.