### PR TITLE
gui: sharp ImGui text on HiDPI displays via RasterizerDensity

### DIFF
--- a/include/fast/Fast3dGui.h
+++ b/include/fast/Fast3dGui.h
@@ -142,6 +142,8 @@ class Fast3dGui : public Ship::Gui {
     void RefreshImGuiGamepads() override;
 
   protected:
+    float ComputeDpiScale() override;
+
     void ImGuiWMInit() override;
     void ImGuiWMShutdown() override;
     void ImGuiBackendInit() override;

--- a/include/ship/window/gui/Gui.h
+++ b/include/ship/window/gui/Gui.h
@@ -174,7 +174,25 @@ class Gui : public Component {
      */
     void ShutDownImGui(Ship::Window* window);
 
+    /**
+     * @brief Display backing scale (physical pixels per logical point), computed once at Init.
+     *
+     * 1.0 on standard-DPI displays, typically 2.0 on HiDPI/Retina. Ports that load their own
+     * menu fonts should use this as ImFontConfig::RasterizerDensity so their glyphs stay crisp
+     * under a HiDPI framebuffer.
+     */
+    float GetDpiScale() const {
+        return mDpiScale;
+    }
+
   protected:
+    /**
+     * @brief Returns the backing scale of the platform window; 1.0 in the base implementation.
+     *
+     * Overridden by backends that own a window handle (see Fast3dGui).
+     */
+    virtual float ComputeDpiScale();
+
     /** @brief Calls ImGui::NewFrame() after processing backend-specific input. */
     void StartFrame();
 
@@ -239,6 +257,7 @@ class Gui : public Component {
     std::map<std::string, std::shared_ptr<GuiWindow>> mGuiWindows; ///< Registered window map (name → window).
 
   private:
+    float mDpiScale = 1.0f; ///< Physical pixels per logical point, set at Init (see GetDpiScale()).
     bool mNeedsConsoleVariableSave;
     std::string mImGuiIniPath;
     std::string mImGuiLogPath;

--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -1,5 +1,7 @@
 #include "fast/Fast3dGui.h"
 
+#include <algorithm>
+
 #include "fast/Fast3dWindow.h"
 #include "ship/core/Context.h"
 #include "ship/config/ConsoleVariable.h"
@@ -110,6 +112,21 @@ void Fast3dGui::HandleWindowEvents(Fast::WindowEvent event) {
         default:
             break;
     }
+}
+
+float Fast3dGui::ComputeDpiScale() {
+    // Opengl.Window and Metal.Window alias the same union slot (both hold the SDL_Window*).
+    auto* sdlWindow = static_cast<SDL_Window*>(mImpl.Opengl.Window);
+    if (sdlWindow == nullptr) {
+        return 1.0f;
+    }
+    int logicalW = 0, logicalH = 0, pixelW = 0, pixelH = 0;
+    SDL_GetWindowSize(sdlWindow, &logicalW, &logicalH);
+    SDL_GetWindowSizeInPixels(sdlWindow, &pixelW, &pixelH);
+    if (logicalW <= 0 || pixelW <= 0) {
+        return 1.0f;
+    }
+    return std::clamp(static_cast<float>(pixelW) / static_cast<float>(logicalW), 1.0f, 4.0f);
 }
 
 void Fast3dGui::ImGuiWMInit() {

--- a/src/ship/window/gui/Gui.cpp
+++ b/src/ship/window/gui/Gui.cpp
@@ -95,8 +95,16 @@ void Gui::OnInit(const nlohmann::json& initArgs) {
     mImGuiIo = &ImGui::GetIO();
     mImGuiIo->ConfigFlags |= ImGuiConfigFlags_DockingEnable | ImGuiConfigFlags_NoMouseCursorChange;
 
+    // On a HiDPI display the ImGui overlay is rendered into a scaled framebuffer, but the glyph atlas
+    // is rasterized at the logical point size and then stretched up, so the text looks fuzzy.
+    // RasterizerDensity rasterizes glyphs at the display's real backing scale without changing any
+    // logical sizes, metrics, or layout. 1.0 on standard-DPI displays leaves this a no-op.
+    mDpiScale = ComputeDpiScale();
+
     // Add Font Awesome and merge it into the default font.
-    mImGuiIo->Fonts->AddFontDefault();
+    ImFontConfig defaultFontCfg;
+    defaultFontCfg.RasterizerDensity = mDpiScale;
+    mImGuiIo->Fonts->AddFontDefault(&defaultFontCfg);
     // This must match the default font size, which is 13.0f.
     float baseFontSize = 13.0f;
     // FontAwesome fonts need to have their sizes reduced by 2.0f/3.0f in order to align correctly
@@ -106,6 +114,7 @@ void Gui::OnInit(const nlohmann::json& initArgs) {
     iconsConfig.MergeMode = true;
     iconsConfig.PixelSnapH = true;
     iconsConfig.GlyphMinAdvanceX = iconFontSize;
+    iconsConfig.RasterizerDensity = mDpiScale;
     mImGuiIo->Fonts->AddFontFromMemoryCompressedBase85TTF(fontawesome_compressed_data_base85, iconFontSize,
                                                           &iconsConfig, sIconsRanges);
 
@@ -148,6 +157,10 @@ void Gui::OnInit(const nlohmann::json& initArgs) {
 }
 
 void Gui::ImGuiWMInit() {
+}
+
+float Gui::ComputeDpiScale() {
+    return 1.0f;
 }
 
 void Gui::ShutDownImGui(Ship::Window* window) {


### PR DESCRIPTION
On a HiDPI display the ImGui overlay renders into a scaled framebuffer, but the glyph atlas is rasterized at the logical point size and then stretched up, so text in libultraship's own windows (console, stats, file browser, gfx debugger) looks fuzzy.

This sets `ImFontConfig::RasterizerDensity` from the window's real backing scale, which rasterizes glyphs at native density without changing any logical sizes, metrics, or layout.

`Gui` gains `GetDpiScale()` plus a virtual `ComputeDpiScale()` that returns 1.0 in the base class; `Fast3dGui` overrides it to measure the SDL window (`SDL_GetWindowSizeInPixels` / `SDL_GetWindowSize`, clamped to [1,4]). On standard-DPI displays the ratio is 1.0, so everything is a no-op.

It also gives ports a way to ask for the real scale when they load their own menu fonts. SpaghettiKart, for example, currently hardcodes 2.0 for this, since there was no way to query it.

Testing: compiles clean against main, full test suite passes (634/634). Verified on a Starship build on a Retina Mac: with this change the menu text is crisp, and reverting just this commit makes it fuzzy again. I could not do a runtime check against main itself, since no port builds against SDL3 main yet.