### PR TITLE
Add tons of missing XML commands to DisplayListFactory

### DIFF
--- a/src/fast/resource/factory/DisplayListFactory.cpp
+++ b/src/fast/resource/factory/DisplayListFactory.cpp
@@ -2,7 +2,9 @@
 #include "fast/resource/type/DisplayList.h"
 #include "spdlog/spdlog.h"
 #include "libultraship/libultra/gbi.h"
+#include "libultraship/libultra/gs2dex.h"
 #include "fast/lus_gbi.h"
+#include "ship/utils/StrHash64.h"
 #include <tinyxml2.h>
 
 namespace Fast {
@@ -42,6 +44,84 @@ std::unordered_map<std::string, uint32_t> renderModes = {
     { "G_RM_ZB_CLD_SURF2", G_RM_ZB_CLD_SURF2 },
 };
 
+const std::unordered_map<std::string, uint32_t> imageFormats = {
+    { "G_IM_FMT_RGBA", G_IM_FMT_RGBA }, { "G_IM_FMT_YUV", G_IM_FMT_YUV }, { "G_IM_FMT_CI", G_IM_FMT_CI },
+    { "G_IM_FMT_IA", G_IM_FMT_IA },     { "G_IM_FMT_I", G_IM_FMT_I },
+};
+
+const std::unordered_map<std::string, uint32_t> imageSizes = {
+    { "G_IM_SIZ_4b", G_IM_SIZ_4b },
+    { "G_IM_SIZ_8b", G_IM_SIZ_8b },
+    { "G_IM_SIZ_16b", G_IM_SIZ_16b },
+    { "G_IM_SIZ_32b", G_IM_SIZ_32b },
+};
+
+const std::unordered_map<std::string, uint32_t> depthSourceModes = {
+    { "G_ZS_PIXEL", G_ZS_PIXEL },
+    { "G_ZS_PRIM", G_ZS_PRIM },
+};
+
+const std::unordered_map<std::string, uint32_t> alphaCompareModes = {
+    { "G_AC_NONE", G_AC_NONE },
+    { "G_AC_THRESHOLD", G_AC_THRESHOLD },
+    { "G_AC_DITHER", G_AC_DITHER },
+};
+
+const std::unordered_map<std::string, uint32_t> alphaDitherModes = {
+    { "G_AD_PATTERN", G_AD_PATTERN },
+    { "G_AD_NOTPATTERN", G_AD_NOTPATTERN },
+    { "G_AD_NOISE", G_AD_NOISE },
+    { "G_AD_DISABLE", G_AD_DISABLE },
+};
+
+const std::unordered_map<std::string, uint32_t> colorDitherModes = {
+    { "G_CD_MAGICSQ", G_CD_MAGICSQ }, { "G_CD_BAYER", G_CD_BAYER },     { "G_CD_NOISE", G_CD_NOISE },
+    { "G_CD_ENABLE", G_CD_ENABLE },   { "G_CD_DISABLE", G_CD_DISABLE },
+};
+
+const std::unordered_map<std::string, uint32_t> combineKeyModes = {
+    { "G_CK_NONE", G_CK_NONE },
+    { "G_CK_KEY", G_CK_KEY },
+};
+
+const std::unordered_map<std::string, uint32_t> textureFilterModes = {
+    { "G_TF_POINT", G_TF_POINT },
+    { "G_TF_AVERAGE", G_TF_AVERAGE },
+    { "G_TF_BILERP", G_TF_BILERP },
+};
+
+const std::unordered_map<std::string, uint32_t> textureLodModes = {
+    { "G_TL_TILE", G_TL_TILE },
+    { "G_TL_LOD", G_TL_LOD },
+};
+
+const std::unordered_map<std::string, uint32_t> textureDetailModes = {
+    { "G_TD_CLAMP", G_TD_CLAMP },
+    { "G_TD_SHARPEN", G_TD_SHARPEN },
+    { "G_TD_DETAIL", G_TD_DETAIL },
+};
+
+const std::unordered_map<std::string, uint32_t> texturePerspModes = {
+    { "G_TP_NONE", G_TP_NONE },
+    { "G_TP_PERSP", G_TP_PERSP },
+};
+
+const std::unordered_map<std::string, uint32_t> scissorModes = {
+    { "G_SC_NON_INTERLACE", G_SC_NON_INTERLACE },
+    { "G_SC_ODD_INTERLACE", G_SC_ODD_INTERLACE },
+    { "G_SC_EVEN_INTERLACE", G_SC_EVEN_INTERLACE },
+};
+
+const std::unordered_map<std::string, uint32_t> objectRenderModes = {
+    { "G_OBJRM_NOTXCLAMP", G_OBJRM_NOTXCLAMP },
+    { "G_OBJRM_XLU", G_OBJRM_XLU },
+    { "G_OBJRM_ANTIALIAS", G_OBJRM_ANTIALIAS },
+    { "G_OBJRM_BILERP", G_OBJRM_BILERP },
+    { "G_OBJRM_SHRINKSIZE_1", G_OBJRM_SHRINKSIZE_1 },
+    { "G_OBJRM_SHRINKSIZE_2", G_OBJRM_SHRINKSIZE_2 },
+    { "G_OBJRM_WIDEN", G_OBJRM_WIDEN },
+};
+
 static Gfx GsSpVertexOtR2P1(char* filePathPtr) {
     Gfx g;
     g.words.w0 = G_VTX_OTR_FILEPATH << 24;
@@ -58,18 +138,18 @@ static Gfx GsSpVertexOtR2P2(int vtxCnt, int vtxBufOffset, int vtxDataOffset) {
     return g;
 }
 
-static void GsSPPushShader(std::vector<Gfx>& gfx, const char* shader) {
-    Gfx g0;
-    g0.words.w0 = (uintptr_t)(_SHIFTL(G_PUSH_SHADER, 24, 8));
-    g0.words.w1 = (uintptr_t)(shader);
-    gfx.push_back(g0);
+static Gfx GsSPPushShader(const char* shader) {
+    Gfx g;
+    g.words.w0 = (uintptr_t)(_SHIFTL(G_PUSH_SHADER, 24, 8));
+    g.words.w1 = (uintptr_t)(shader);
+    return g;
 }
 
-static void GsSPPopShader(std::vector<Gfx>& gfx) {
-    Gfx g0;
-    g0.words.w0 = (uintptr_t)(_SHIFTL(G_POP_SHADER, 24, 8));
-    g0.words.w1 = (uintptr_t)(nullptr);
-    gfx.push_back(g0);
+static Gfx GsSPPopShader() {
+    Gfx g;
+    g.words.w0 = (uintptr_t)(_SHIFTL(G_POP_SHADER, 24, 8));
+    g.words.w1 = (uintptr_t)(nullptr);
+    return g;
 }
 
 uint32_t ResourceFactoryDisplayList::GetCombineLERPValue(const char* valStr) {
@@ -197,7 +277,7 @@ ResourceFactoryBinaryDisplayListV0::ReadResource(std::shared_ptr<Ship::File> fil
         // These are 128-bit commands, so read an extra 64 bits...
         if (isExpanded) {
 #ifdef USE_GBI_TRACE
-            command.words.trace.file = initData->Identifier.GetPath().c_str();
+            command.words.trace.file = initData->Path.c_str();
             command.words.trace.idx = idx++;
             command.words.trace.valid = true;
 #endif
@@ -207,7 +287,7 @@ ResourceFactoryBinaryDisplayListV0::ReadResource(std::shared_ptr<Ship::File> fil
         }
 
 #ifdef USE_GBI_TRACE
-        command.words.trace.file = initData->Identifier.GetPath().c_str();
+        command.words.trace.file = initData->Path.c_str();
         command.words.trace.idx = idx++;
         command.words.trace.valid = true;
 #endif
@@ -240,14 +320,34 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
 
         if (childName == "PipeSync") {
             g = gsDPPipeSync();
+        } else if (childName == "FullSync") {
+            g = gsDPFullSync();
+        } else if (childName == "NoOp") {
+            g = gsDPNoOpTag(child->UnsignedAttribute("Tag"));
+        } else if (childName == "SPNoOp") {
+            g = gsSPNoOp();
         } else if (childName == "Texture") {
             g = gsSPTexture(child->IntAttribute("S"), child->IntAttribute("T"), child->IntAttribute("Level"),
                             child->IntAttribute("Tile"), child->IntAttribute("On"));
+        } else if (childName == "TextureL") {
+            g = gsSPTextureL(child->IntAttribute("S"), child->IntAttribute("T"), child->IntAttribute("Level"),
+                             child->IntAttribute("XParam"), child->IntAttribute("Tile"), child->IntAttribute("On"));
         } else if (childName == "SetPrimColor") {
             g = gsDPSetPrimColor(child->IntAttribute("M"), child->IntAttribute("L"), child->IntAttribute("R"),
                                  child->IntAttribute("G"), child->IntAttribute("B"), child->IntAttribute("A"));
         } else if (childName == "SetPrimDepth") {
             g = gsDPSetPrimDepth(child->IntAttribute("Z"), child->IntAttribute("DZ"));
+        } else if (childName == "SetColorImage") {
+            std::string fmt = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            std::string siz = child->Attribute("Size") != nullptr ? child->Attribute("Size") : "0";
+            auto fmtEntry = imageFormats.find(fmt);
+            auto sizEntry = imageSizes.find(siz);
+            uint32_t fmtVal = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmt, nullptr, 0);
+            uint32_t sizVal = sizEntry != imageSizes.end() ? sizEntry->second : std::stoul(siz, nullptr, 0);
+            g = gsDPSetColorImage(fmtVal, sizVal, child->UnsignedAttribute("Width"),
+                                  child->UnsignedAttribute("Address"));
+        } else if (childName == "SetDepthImage" || childName == "SetMaskImage") {
+            g = gsDPSetDepthImage(child->UnsignedAttribute("Address"));
         } else if (childName == "SetFillColor") {
             g = gsDPSetFillColor(child->IntAttribute("C"));
         } else if (childName == "SetFogColor") {
@@ -265,23 +365,41 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
             g = gsDPSetGrayscaleColor(child->IntAttribute("R"), child->IntAttribute("G"), child->IntAttribute("B"),
                                       child->IntAttribute("A"));
         } else if (childName == "SetDepthSource") {
-            g = gsDPSetDepthSource(child->IntAttribute("Mode"));
+            std::string value = child->Attribute("Mode") != nullptr ? child->Attribute("Mode") : "0";
+            auto entry = depthSourceModes.find(value);
+            g = gsDPSetDepthSource(entry != depthSourceModes.end() ? entry->second : std::stoul(value, nullptr, 0));
         } else if (childName == "SetAlphaCompare") {
-            g = gsDPSetAlphaCompare(child->IntAttribute("Mode"));
+            std::string value = child->Attribute("Mode") != nullptr ? child->Attribute("Mode") : "0";
+            auto entry = alphaCompareModes.find(value);
+            g = gsDPSetAlphaCompare(entry != alphaCompareModes.end() ? entry->second : std::stoul(value, nullptr, 0));
         } else if (childName == "SetAlphaDither") {
-            g = gsDPSetAlphaDither(child->IntAttribute("Type"));
+            std::string value = child->Attribute("Type") != nullptr ? child->Attribute("Type") : "0";
+            auto entry = alphaDitherModes.find(value);
+            g = gsDPSetAlphaDither(entry != alphaDitherModes.end() ? entry->second : std::stoul(value, nullptr, 0));
         } else if (childName == "SetColorDither") {
-            g = gsDPSetColorDither(child->IntAttribute("Type"));
+            std::string value = child->Attribute("Type") != nullptr ? child->Attribute("Type") : "0";
+            auto entry = colorDitherModes.find(value);
+            g = gsDPSetColorDither(entry != colorDitherModes.end() ? entry->second : std::stoul(value, nullptr, 0));
         } else if (childName == "SetCombineKey") {
-            g = gsDPSetCombineKey(child->IntAttribute("Type"));
+            std::string value = child->Attribute("Type") != nullptr ? child->Attribute("Type") : "0";
+            auto entry = combineKeyModes.find(value);
+            g = gsDPSetCombineKey(entry != combineKeyModes.end() ? entry->second : std::stoul(value, nullptr, 0));
         } else if (childName == "SetTextureFilter") {
-            g = gsDPSetTextureFilter(child->IntAttribute("Mode"));
+            std::string value = child->Attribute("Mode") != nullptr ? child->Attribute("Mode") : "0";
+            auto entry = textureFilterModes.find(value);
+            g = gsDPSetTextureFilter(entry != textureFilterModes.end() ? entry->second : std::stoul(value, nullptr, 0));
         } else if (childName == "SetTextureLOD") {
-            g = gsDPSetTextureLOD(child->IntAttribute("Mode"));
+            std::string value = child->Attribute("Mode") != nullptr ? child->Attribute("Mode") : "0";
+            auto entry = textureLodModes.find(value);
+            g = gsDPSetTextureLOD(entry != textureLodModes.end() ? entry->second : std::stoul(value, nullptr, 0));
         } else if (childName == "SetTextureDetail") {
-            g = gsDPSetTextureDetail(child->IntAttribute("Type"));
+            std::string value = child->Attribute("Type") != nullptr ? child->Attribute("Type") : "0";
+            auto entry = textureDetailModes.find(value);
+            g = gsDPSetTextureDetail(entry != textureDetailModes.end() ? entry->second : std::stoul(value, nullptr, 0));
         } else if (childName == "SetTexturePersp") {
-            g = gsDPSetTexturePersp(child->IntAttribute("Enable"));
+            std::string value = child->Attribute("Enable") != nullptr ? child->Attribute("Enable") : "0";
+            auto entry = texturePerspModes.find(value);
+            g = gsDPSetTexturePersp(entry != texturePerspModes.end() ? entry->second : std::stoul(value, nullptr, 0));
         } else if (childName == "PerspNormalize") {
             g = gsSPPerspNormalize(child->IntAttribute("S"));
         } else if (childName == "FogPosition") {
@@ -292,18 +410,74 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
             g = gsSPNumLights(child->IntAttribute("Lites"));
         } else if (childName == "Segment") {
             g = gsSPSegment(child->IntAttribute("Seg"), child->IntAttribute("Base"));
-        }
-        /*else if (childName == "Line3D")
-        {
-                g = gsSPLine3D(child->IntAttribute("V0"), child->IntAttribute("V1"), child->IntAttribute("Flag"));
-        }
-        */
-        /*else if (childName == "Hilite2Tile")
-        {
-                g = gsDPSetHilite2Tile(child->IntAttribute("Tile"), child->IntAttribute("Hilite"),
-        child->IntAttribute("Width"), child->IntAttribute("Height"));
-        }*/
-        else if (childName == "Matrix") {
+            /*else if (childName == "Line3D")
+            {
+                    g = gsSPLine3D(child->IntAttribute("V0"), child->IntAttribute("V1"), child->IntAttribute("Flag"));
+            }
+            */
+            /*else if (childName == "Hilite2Tile")
+            {
+                    g = gsDPSetHilite2Tile(child->IntAttribute("Tile"), child->IntAttribute("Hilite"),
+            child->IntAttribute("Width"), child->IntAttribute("Height"));
+            }*/
+        } else if (childName == "Viewport") {
+            g = gsSPViewport(static_cast<uintptr_t>(child->Unsigned64Attribute("Address")));
+        } else if (childName == "Light") {
+            g = gsSPLight(static_cast<uintptr_t>(child->Unsigned64Attribute("Address")),
+                          child->UnsignedAttribute("Number"));
+        } else if (childName == "SetLights0" || childName == "SetLights1" || childName == "SetLights2" ||
+                   childName == "SetLights3" || childName == "SetLights4" || childName == "SetLights5" ||
+                   childName == "SetLights6" || childName == "SetLights7") {
+            const uint32_t lightCount = static_cast<uint32_t>(childName.back() - '0');
+            const uint32_t directionalCount = lightCount == 0 ? 1 : lightCount;
+            const uintptr_t address = static_cast<uintptr_t>(child->Unsigned64Attribute("Address"));
+
+            dl->Instructions.push_back(gsSPNumLights(directionalCount));
+            for (uint32_t i = 0; i < directionalCount; i++) {
+                dl->Instructions.push_back(gsSPLight(address + sizeof(Ambient) + i * sizeof(Light), i + 1));
+            }
+            g = gsSPLight(address, directionalCount + 1);
+        } else if (childName == "LookAtX") {
+            g = gsSPLookAtX(static_cast<uintptr_t>(child->Unsigned64Attribute("Address")));
+        } else if (childName == "LookAtY") {
+            g = gsSPLookAtY(static_cast<uintptr_t>(child->Unsigned64Attribute("Address")));
+        } else if (childName == "LookAt") {
+            uintptr_t address = child->Unsigned64Attribute("Address");
+            Gfx g2[2] = { gsSPLookAt(address) };
+            dl->Instructions.push_back(g2[0]);
+            g = g2[1];
+        } else if (childName == "SetHilite1Tile" || childName == "SetHilite2Tile") {
+            const int32_t x = child->IntAttribute("X");
+            const int32_t y = child->IntAttribute("Y");
+            const int32_t width = child->IntAttribute("Width");
+            const int32_t height = child->IntAttribute("Height");
+            g = gsDPSetTileSize(child->UnsignedAttribute("Tile"), x & 0xFFF, y & 0xFFF, (((width - 1) * 4) + x) & 0xFFF,
+                                (((height - 1) * 4) + y) & 0xFFF);
+        } else if (childName == "ForceMatrix") {
+            uintptr_t address = child->Unsigned64Attribute("Address");
+#ifdef F3DEX_GBI_2
+            Gfx g2[2] = { gsSPForceMatrix(address) };
+            dl->Instructions.push_back(g2[0]);
+            g = g2[1];
+#else
+            Gfx g2[4] = { gsSPForceMatrix(address) };
+            dl->Instructions.push_back(g2[0]);
+            dl->Instructions.push_back(g2[1]);
+            dl->Instructions.push_back(g2[2]);
+            g = g2[3];
+#endif
+        } else if (childName == "MoveWord") {
+            g = gsMoveWd(child->UnsignedAttribute("Index"), child->UnsignedAttribute("Offset"),
+                         child->UnsignedAttribute("Data"));
+        } else if (childName == "MoveMem") {
+            uintptr_t address = child->Unsigned64Attribute("Address");
+#ifdef F3DEX_GBI_2
+            g = gsDma2p(G_MOVEMEM, address, child->UnsignedAttribute("Length"), child->UnsignedAttribute("Index"),
+                        child->UnsignedAttribute("Offset"));
+#else
+            g = gsDma1p(G_MOVEMEM, address, child->UnsignedAttribute("Length"), child->UnsignedAttribute("Index"));
+#endif
+        } else if (childName == "Matrix") {
             std::string fName = child->Attribute("Path");
             std::string param = child->Attribute("Param");
 
@@ -336,6 +510,30 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
                 dl->Strings.push_back(str);
                 strcpy((char*)g.words.w1, fName.data());
             }
+        } else if (childName == "PopMatrix") {
+            std::string param = child->Attribute("Param");
+
+            uint8_t paramInt = 0;
+
+            if (param == "G_MTX_MODELVIEW") {
+                paramInt = G_MTX_MODELVIEW;
+            } else if (param == "G_MTX_PROJECTION") {
+                paramInt = G_MTX_PROJECTION;
+            }
+
+            g = gsSPPopMatrix(paramInt);
+        } else if (childName == "PopMatrixN") {
+            std::string param = child->Attribute("Param");
+            uint8_t paramInt = param == "G_MTX_PROJECTION" ? G_MTX_PROJECTION : G_MTX_MODELVIEW;
+            uint32_t count = child->UnsignedAttribute("Count");
+#ifdef F3DEX_GBI_2
+            g = gsSPPopMatrixN(paramInt, count);
+#else
+            for (uint32_t i = 1; i < count; i++) {
+                dl->Instructions.push_back(gsSPPopMatrix(paramInt));
+            }
+            g = gsSPPopMatrix(paramInt);
+#endif
         } else if (childName == "SetCycleType") {
             uint32_t param = 0;
 
@@ -378,6 +576,31 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
             uint32_t lrt = child->IntAttribute("Lrt");
 
             g = gsDPLoadTile(t, uls, ult, lrs, lrt);
+        } else if (childName == "FillRectangle") {
+            g = gsDPFillRectangle(child->UnsignedAttribute("Ulx"), child->UnsignedAttribute("Uly"),
+                                  child->UnsignedAttribute("Lrx"), child->UnsignedAttribute("Lry"));
+        } else if (childName == "SetScissor") {
+            std::string value = child->Attribute("Mode") != nullptr ? child->Attribute("Mode") : "0";
+            auto entry = scissorModes.find(value);
+            uint32_t mode = entry != scissorModes.end() ? entry->second : std::stoul(value, nullptr, 0);
+            g = gsDPSetScissor(mode, child->UnsignedAttribute("Ulx"), child->UnsignedAttribute("Uly"),
+                               child->UnsignedAttribute("Lrx"), child->UnsignedAttribute("Lry"));
+        } else if (childName == "SetScissorFrac") {
+            std::string value = child->Attribute("Mode") != nullptr ? child->Attribute("Mode") : "0";
+            auto entry = scissorModes.find(value);
+            uint32_t mode = entry != scissorModes.end() ? entry->second : std::stoul(value, nullptr, 0);
+            g = gsDPSetScissorFrac(mode, child->UnsignedAttribute("Ulx"), child->UnsignedAttribute("Uly"),
+                                   child->UnsignedAttribute("Lrx"), child->UnsignedAttribute("Lry"));
+        } else if (childName == "SetConvert") {
+            g = gsDPSetConvert(child->IntAttribute("K0"), child->IntAttribute("K1"), child->IntAttribute("K2"),
+                               child->IntAttribute("K3"), child->IntAttribute("K4"), child->IntAttribute("K5"));
+        } else if (childName == "SetKeyR") {
+            g = gsDPSetKeyR(child->UnsignedAttribute("Center"), child->UnsignedAttribute("Scale"),
+                            child->UnsignedAttribute("Width"));
+        } else if (childName == "SetKeyGB") {
+            g = gsDPSetKeyGB(child->UnsignedAttribute("CenterG"), child->UnsignedAttribute("ScaleG"),
+                             child->UnsignedAttribute("WidthG"), child->UnsignedAttribute("CenterB"),
+                             child->UnsignedAttribute("ScaleB"), child->UnsignedAttribute("WidthB"));
         } else if (childName == "SetTextureLUT") {
             std::string mode = child->Attribute("Mode");
             uint32_t modeVal = 0;
@@ -396,6 +619,34 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
             uint32_t count = child->IntAttribute("Count");
 
             g = gsDPLoadTLUTCmd(tile, count);
+        } else if (childName == "LoadTLUT" || childName == "LoadTLUTPal16" || childName == "LoadTLUTPal128" ||
+                   childName == "LoadTLUTPal256") {
+            Gfx g2[6];
+            if (childName == "LoadTLUT") {
+                Gfx g3[6] = { gsDPLoadTLUT(child->UnsignedAttribute("Count"), child->UnsignedAttribute("TMem"), 0) };
+                memcpy(g2, g3, sizeof(g2));
+            } else if (childName == "LoadTLUTPal16") {
+                Gfx g3[6] = { gsDPLoadTLUT_pal16(child->UnsignedAttribute("Palette"), 0) };
+                memcpy(g2, g3, sizeof(g2));
+            } else if (childName == "LoadTLUTPal128") {
+                Gfx g3[6] = { gsDPLoadTLUT(128, 256 + ((child->UnsignedAttribute("Palette") & 1) * 128), 0) };
+                memcpy(g2, g3, sizeof(g2));
+            } else {
+                Gfx g3[6] = { gsDPLoadTLUT_pal256(0) };
+                memcpy(g2, g3, sizeof(g2));
+            }
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            dl->Strings.push_back(str);
+            strcpy(str, path.c_str());
+            g2[0].words.w0 = (g2[0].words.w0 & 0x00FFFFFF) | _SHIFTL(G_SETTIMG_OTR_FILEPATH, 24, 8);
+            g2[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+
+            for (int i = 0; i < 5; i++) {
+                dl->Instructions.push_back(g2[i]);
+            }
+            g = g2[5];
         } else if (childName == "SetCombineLERP") {
             const char* a0 = child->Attribute("A0", 0);
             const char* b0 = child->Attribute("B0", 0);
@@ -424,6 +675,24 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
                 GetCombineLERPValue(aa1), GetCombineLERPValue(ab1), GetCombineLERPValue(ac1), GetCombineLERPValue(ad1));
         } else if (childName == "LoadSync") {
             g = gsDPLoadSync();
+        } else if (childName == "TextureRectangle" || childName == "TextureRectangleFlip") {
+            Gfx g2[3];
+            if (childName == "TextureRectangle") {
+                Gfx g3[3] = { gsSPTextureRectangle(
+                    child->IntAttribute("Xl"), child->IntAttribute("Yl"), child->IntAttribute("Xh"),
+                    child->IntAttribute("Yh"), child->IntAttribute("Tile"), child->IntAttribute("S"),
+                    child->IntAttribute("T"), child->IntAttribute("Dsdx"), child->IntAttribute("Dtdy")) };
+                memcpy(g2, g3, sizeof(g2));
+            } else {
+                Gfx g3[3] = { gsSPTextureRectangleFlip(
+                    child->IntAttribute("Xl"), child->IntAttribute("Yl"), child->IntAttribute("Xh"),
+                    child->IntAttribute("Yh"), child->IntAttribute("Tile"), child->IntAttribute("S"),
+                    child->IntAttribute("T"), child->IntAttribute("Dsdx"), child->IntAttribute("Dtdy")) };
+                memcpy(g2, g3, sizeof(g2));
+            }
+            dl->Instructions.push_back(g2[0]);
+            dl->Instructions.push_back(g2[1]);
+            g = g2[2];
         } else if (childName == "LoadBlock") {
             uint32_t tile = child->IntAttribute("Tile");
             uint32_t uls = child->IntAttribute("Uls");
@@ -443,37 +712,62 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
             dl->Instructions.push_back(g2[0]);
             g = g2[1];
         } else if (childName == "Triangle1") {
-            int v00 = child->IntAttribute("V00");
-            int v01 = child->IntAttribute("V01");
-            int v02 = child->IntAttribute("V02");
-
-            g = gsSP1TriangleOTR(v00, v01, v02, child->IntAttribute("Flag0"));
-            g.words.w0 &= 0xFF000000;
-            g.words.w0 |= v00;
-            g.words.w1 |= v01 << 16;
-            g.words.w1 |= v02 << 0;
+            const uint32_t vertices[3] = { child->UnsignedAttribute("V00"), child->UnsignedAttribute("V01"),
+                                           child->UnsignedAttribute("V02") };
+            const uint32_t flag = child->UnsignedAttribute("Flag0");
+            const uint32_t first = flag == 0 ? 0 : flag == 1 ? 1 : 2;
+            g.words.w0 = _SHIFTL(G_TRI1_OTR, 24, 8) | vertices[first];
+            g.words.w1 = _SHIFTL(vertices[(first + 1) % 3], 16, 16) | _SHIFTL(vertices[(first + 2) % 3], 0, 16);
         } else if (childName == "Triangles2") {
 #ifdef F3DEX_GBI_2
             g = gsSP2Triangles(child->IntAttribute("V00"), child->IntAttribute("V01"), child->IntAttribute("V02"),
                                child->IntAttribute("Flag0"), child->IntAttribute("V10"), child->IntAttribute("V11"),
                                child->IntAttribute("V12"), child->IntAttribute("Flag1"));
 #else
-            g = gsSP1TriangleOTR(child->IntAttribute("V00"), child->IntAttribute("V01"), child->IntAttribute("V02"),
-                                 child->IntAttribute("Flag0"));
-            g.words.w0 &= 0xFF000000;
-            g.words.w0 |= child->IntAttribute("V00");
-            g.words.w1 |= child->IntAttribute("V01") << 16;
-            g.words.w1 |= child->IntAttribute("V02") << 0;
-
+            const uint32_t vertices0[3] = { child->UnsignedAttribute("V00"), child->UnsignedAttribute("V01"),
+                                            child->UnsignedAttribute("V02") };
+            const uint32_t flag0 = child->UnsignedAttribute("Flag0");
+            const uint32_t first0 = flag0 == 0 ? 0 : flag0 == 1 ? 1 : 2;
+            g.words.w0 = _SHIFTL(G_TRI1_OTR, 24, 8) | vertices0[first0];
+            g.words.w1 = _SHIFTL(vertices0[(first0 + 1) % 3], 16, 16) | _SHIFTL(vertices0[(first0 + 2) % 3], 0, 16);
             dl->Instructions.push_back(g);
-
-            g = gsSP1TriangleOTR(child->IntAttribute("V10"), child->IntAttribute("V11"), child->IntAttribute("V12"),
-                                 child->IntAttribute("Flag1"));
-            g.words.w0 &= 0xFF000000;
-            g.words.w0 |= child->IntAttribute("V10");
-            g.words.w1 |= child->IntAttribute("V11") << 16;
-            g.words.w1 |= child->IntAttribute("V12") << 0;
+            const uint32_t vertices1[3] = { child->UnsignedAttribute("V10"), child->UnsignedAttribute("V11"),
+                                            child->UnsignedAttribute("V12") };
+            const uint32_t flag1 = child->UnsignedAttribute("Flag1");
+            const uint32_t first1 = flag1 == 0 ? 0 : flag1 == 1 ? 1 : 2;
+            g.words.w0 = _SHIFTL(G_TRI1_OTR, 24, 8) | vertices1[first1];
+            g.words.w1 = _SHIFTL(vertices1[(first1 + 1) % 3], 16, 16) | _SHIFTL(vertices1[(first1 + 2) % 3], 0, 16);
 #endif
+        } else if (childName == "Quadrangle") {
+            const uint32_t vertices[4] = { child->UnsignedAttribute("V0"), child->UnsignedAttribute("V1"),
+                                           child->UnsignedAttribute("V2"), child->UnsignedAttribute("V3") };
+            const uint32_t flag = child->UnsignedAttribute("Flag");
+            const uint32_t first = flag < 3 ? flag : 3;
+            Gfx firstTriangle;
+            firstTriangle.words.w0 = _SHIFTL(G_TRI1_OTR, 24, 8) | vertices[first];
+            firstTriangle.words.w1 =
+                _SHIFTL(vertices[(first + 1) & 3], 16, 16) | _SHIFTL(vertices[(first + 2) & 3], 0, 16);
+            dl->Instructions.push_back(firstTriangle);
+            g.words.w0 = _SHIFTL(G_TRI1_OTR, 24, 8) | vertices[first];
+            g.words.w1 = _SHIFTL(vertices[(first + 2) & 3], 16, 16) | _SHIFTL(vertices[(first + 3) & 3], 0, 16);
+        } else if (childName == "ModifyVertex") {
+            std::string where = child->Attribute("Where");
+            uint32_t whereValue = 0;
+
+            if (where == "G_MWO_POINT_RGBA") {
+                whereValue = G_MWO_POINT_RGBA;
+            } else if (where == "G_MWO_POINT_ST") {
+                whereValue = G_MWO_POINT_ST;
+            } else if (where == "G_MWO_POINT_XYSCREEN") {
+                whereValue = G_MWO_POINT_XYSCREEN;
+            } else if (where == "G_MWO_POINT_ZSCREEN") {
+                whereValue = G_MWO_POINT_ZSCREEN;
+            } else {
+                whereValue = std::stoul(where, nullptr, 0);
+            }
+
+            uint32_t value = std::stoul(child->Attribute("Value"), nullptr, 0);
+            g = gsSPModifyVertex(child->IntAttribute("Vertex"), whereValue, value);
         } else if (childName == "LoadVertices") {
             std::string fName = child->Attribute("Path");
             // fName = ">" + fName;
@@ -909,9 +1203,43 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
             }
 
             g = gsSPSetOtherMode(cmdVal, sft, length, data);
+        } else if (childName == "SetRDPOtherMode") {
+            g = gsDPSetOtherMode(child->UnsignedAttribute("Mode0"), child->UnsignedAttribute("Mode1"));
         } else if (childName == "LoadTextureBlock") {
-            uint32_t fmt = child->IntAttribute("Format");
-            uint32_t siz = child->IntAttribute("Size");
+            const char* fmtAttribute = child->Attribute("Format");
+            std::string fmt = fmtAttribute != nullptr ? fmtAttribute : "0";
+            uint32_t fmtVal = G_IM_FMT_RGBA;
+
+            if (fmt == "G_IM_FMT_I") {
+                fmtVal = G_IM_FMT_I;
+            } else if (fmt == "G_IM_FMT_IA") {
+                fmtVal = G_IM_FMT_IA;
+            } else if (fmt == "G_IM_FMT_CI") {
+                fmtVal = G_IM_FMT_CI;
+            } else if (fmt == "G_IM_FMT_YUV") {
+                fmtVal = G_IM_FMT_YUV;
+            } else if (fmt == "G_IM_FMT_RGBA") {
+                fmtVal = G_IM_FMT_RGBA;
+            } else {
+                fmtVal = std::stoul(fmt, nullptr, 0);
+            }
+
+            const char* sizAttribute = child->Attribute("Size");
+            std::string siz = sizAttribute != nullptr ? sizAttribute : "0";
+            uint32_t sizVal = G_IM_SIZ_32b;
+
+            if (siz == "G_IM_SIZ_4b") {
+                sizVal = G_IM_SIZ_4b;
+            } else if (siz == "G_IM_SIZ_8b") {
+                sizVal = G_IM_SIZ_8b;
+            } else if (siz == "G_IM_SIZ_16b") {
+                sizVal = G_IM_SIZ_16b;
+            } else if (siz == "G_IM_SIZ_32b") {
+                sizVal = G_IM_SIZ_32b;
+            } else {
+                sizVal = std::stoul(siz, nullptr, 0);
+            }
+
             uint32_t width = child->IntAttribute("Width");
             uint32_t height = child->IntAttribute("Height");
             uint32_t maskS = child->IntAttribute("MaskS");
@@ -953,44 +1281,559 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
                 cmt |= G_TX_CLAMP;
             }
 
-            std::string fName = child->Attribute("Path");
-            // fName = ">" + fName;
-
             Gfx g2[7];
 
-            if (siz == 0) {
-                Gfx g3[7] = { gsDPLoadTextureBlock(0, fmt, G_IM_SIZ_4b, width, height, 0, cms, cmt, maskS, maskT,
+            if (sizVal == G_IM_SIZ_4b) {
+                Gfx g3[7] = { gsDPLoadTextureBlock_4b(0, fmtVal, width, height, 0, cms, cmt, maskS, maskT, shiftS,
+                                                      shiftT) };
+                memcpy(g2, g3, 7 * sizeof(Gfx));
+            } else if (sizVal == G_IM_SIZ_8b) {
+                Gfx g3[7] = { gsDPLoadTextureBlock(0, fmtVal, G_IM_SIZ_8b, width, height, 0, cms, cmt, maskS, maskT,
                                                    shiftS, shiftT) };
                 memcpy(g2, g3, 7 * sizeof(Gfx));
-            } else if (siz == 1) {
-                Gfx g3[7] = { gsDPLoadTextureBlock(0, fmt, G_IM_SIZ_8b, width, height, 0, cms, cmt, maskS, maskT,
+            } else if (sizVal == G_IM_SIZ_16b) {
+                Gfx g3[7] = { gsDPLoadTextureBlock(0, fmtVal, G_IM_SIZ_16b, width, height, 0, cms, cmt, maskS, maskT,
                                                    shiftS, shiftT) };
                 memcpy(g2, g3, 7 * sizeof(Gfx));
-            } else if (siz == 2) {
-                Gfx g3[7] = { gsDPLoadTextureBlock(0, fmt, G_IM_SIZ_16b, width, height, 0, cms, cmt, maskS, maskT,
-                                                   shiftS, shiftT) };
-                memcpy(g2, g3, 7 * sizeof(Gfx));
-            } else if (siz == 3) {
-                Gfx g3[7] = { gsDPLoadTextureBlock(0, fmt, G_IM_SIZ_32b, width, height, 0, cms, cmt, maskS, maskT,
+            } else if (sizVal == G_IM_SIZ_32b) {
+                Gfx g3[7] = { gsDPLoadTextureBlock(0, fmtVal, G_IM_SIZ_32b, width, height, 0, cms, cmt, maskS, maskT,
                                                    shiftS, shiftT) };
                 memcpy(g2, g3, 7 * sizeof(Gfx));
             }
 
-            g = { gsDPSetTextureImage(fmt, siz, width, 0) };
-            g.words.w0 &= 0x00FFFFFF;
-            g.words.w0 += (G_SETTIMG_OTR_FILEPATH << 24);
+            std::string fName = child->Attribute("Path");
             char* str = (char*)malloc(fName.size() + 1);
             dl->Strings.push_back(str);
-            g.words.w1 = (uintptr_t)str;
-            strcpy((char*)g.words.w1, fName.data());
+            strcpy(str, fName.data());
 
-            dl->Instructions.push_back(g);
+            g2[0].words.w0 = (g2[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            g2[0].words.w1 = (uintptr_t)str;
 
-            for (int j = 1; j < 7; j++) {
+            for (int j = 0; j < 6; j++) {
                 dl->Instructions.push_back(g2[j]);
             }
 
-            g = gsDPPipeSync();
+            g = g2[6];
+        } else if (childName == "LoadTextureBlockS") {
+            std::string fmtName = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            std::string sizName = child->Attribute("Size") != nullptr ? child->Attribute("Size") : "0";
+            auto fmtEntry = imageFormats.find(fmtName);
+            auto sizEntry = imageSizes.find(sizName);
+            uint32_t fmt = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmtName, nullptr, 0);
+            uint32_t siz = sizEntry != imageSizes.end() ? sizEntry->second : std::stoul(sizName, nullptr, 0);
+            uint32_t width = child->IntAttribute("Width");
+            uint32_t height = child->IntAttribute("Height");
+            uint32_t palette = child->UnsignedAttribute("Palette");
+            uint32_t maskS = child->IntAttribute("MaskS");
+            uint32_t maskT = child->IntAttribute("MaskT");
+            uint32_t shiftS = child->IntAttribute("ShiftS");
+            uint32_t shiftT = child->IntAttribute("ShiftT");
+            uint32_t cms = (child->Attribute("CMS_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMS_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMS_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMS_TXClamp", 0) ? G_TX_CLAMP : 0);
+            uint32_t cmt = (child->Attribute("CMT_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMT_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMT_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMT_TXClamp", 0) ? G_TX_CLAMP : 0);
+            Gfx commands[7] = {};
+
+            if (siz == G_IM_SIZ_8b) {
+                Gfx generatedCommands[7] = { gsDPLoadTextureBlockS(0, fmt, G_IM_SIZ_8b, width, height, palette, cms,
+                                                                   cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generatedCommands, sizeof(commands));
+            } else if (siz == G_IM_SIZ_16b) {
+                Gfx generatedCommands[7] = { gsDPLoadTextureBlockS(0, fmt, G_IM_SIZ_16b, width, height, palette, cms,
+                                                                   cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generatedCommands, sizeof(commands));
+            } else if (siz == G_IM_SIZ_32b) {
+                Gfx generatedCommands[7] = { gsDPLoadTextureBlockS(0, fmt, G_IM_SIZ_32b, width, height, palette, cms,
+                                                                   cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generatedCommands, sizeof(commands));
+            }
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            strcpy(str, path.c_str());
+            dl->Strings.push_back(str);
+            commands[0].words.w0 = (commands[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            commands[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+            for (int i = 0; i < 6; i++) {
+                dl->Instructions.push_back(commands[i]);
+            }
+            g = commands[6];
+        } else if (childName == "LoadTextureBlock4bS") {
+            std::string fmtName = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            auto fmtEntry = imageFormats.find(fmtName);
+            uint32_t fmt = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmtName, nullptr, 0);
+            uint32_t width = child->IntAttribute("Width");
+            uint32_t height = child->IntAttribute("Height");
+            uint32_t palette = child->UnsignedAttribute("Palette");
+            uint32_t maskS = child->IntAttribute("MaskS");
+            uint32_t maskT = child->IntAttribute("MaskT");
+            uint32_t shiftS = child->IntAttribute("ShiftS");
+            uint32_t shiftT = child->IntAttribute("ShiftT");
+            uint32_t cms = (child->Attribute("CMS_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMS_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMS_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMS_TXClamp", 0) ? G_TX_CLAMP : 0);
+            uint32_t cmt = (child->Attribute("CMT_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMT_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMT_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMT_TXClamp", 0) ? G_TX_CLAMP : 0);
+            Gfx commands[7] = { gsDPLoadTextureBlock_4bS(0, fmt, width, height, palette, cms, cmt, maskS, maskT, shiftS,
+                                                         shiftT) };
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            strcpy(str, path.c_str());
+            dl->Strings.push_back(str);
+            commands[0].words.w0 = (commands[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            commands[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+            for (int i = 0; i < 6; i++) {
+                dl->Instructions.push_back(commands[i]);
+            }
+            g = commands[6];
+        } else if (childName == "LoadMultiBlock") {
+            std::string fmtName = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            std::string sizName = child->Attribute("Size") != nullptr ? child->Attribute("Size") : "0";
+            auto fmtEntry = imageFormats.find(fmtName);
+            auto sizEntry = imageSizes.find(sizName);
+            uint32_t fmt = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmtName, nullptr, 0);
+            uint32_t siz = sizEntry != imageSizes.end() ? sizEntry->second : std::stoul(sizName, nullptr, 0);
+            uint32_t width = child->IntAttribute("Width");
+            uint32_t height = child->IntAttribute("Height");
+            uint32_t palette = child->UnsignedAttribute("Palette");
+            uint32_t tmem = child->UnsignedAttribute("TMem");
+            uint32_t renderTile = child->UnsignedAttribute("RenderTile");
+            uint32_t maskS = child->IntAttribute("MaskS");
+            uint32_t maskT = child->IntAttribute("MaskT");
+            uint32_t shiftS = child->IntAttribute("ShiftS");
+            uint32_t shiftT = child->IntAttribute("ShiftT");
+            uint32_t cms = (child->Attribute("CMS_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMS_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMS_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMS_TXClamp", 0) ? G_TX_CLAMP : 0);
+            uint32_t cmt = (child->Attribute("CMT_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMT_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMT_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMT_TXClamp", 0) ? G_TX_CLAMP : 0);
+            Gfx commands[7] = {};
+
+            if (siz == G_IM_SIZ_8b) {
+                Gfx generated[7] = { gsDPLoadMultiBlock(0, tmem, renderTile, fmt, G_IM_SIZ_8b, width, height, palette,
+                                                        cms, cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generated, sizeof(commands));
+            } else if (siz == G_IM_SIZ_16b) {
+                Gfx generated[7] = { gsDPLoadMultiBlock(0, tmem, renderTile, fmt, G_IM_SIZ_16b, width, height, palette,
+                                                        cms, cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generated, sizeof(commands));
+            } else if (siz == G_IM_SIZ_32b) {
+                Gfx generated[7] = { gsDPLoadMultiBlock(0, tmem, renderTile, fmt, G_IM_SIZ_32b, width, height, palette,
+                                                        cms, cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generated, sizeof(commands));
+            }
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            strcpy(str, path.c_str());
+            dl->Strings.push_back(str);
+            commands[0].words.w0 = (commands[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            commands[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+            for (int i = 0; i < 6; i++) {
+                dl->Instructions.push_back(commands[i]);
+            }
+            g = commands[6];
+        } else if (childName == "LoadMultiBlockS") {
+            std::string fmtName = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            std::string sizName = child->Attribute("Size") != nullptr ? child->Attribute("Size") : "0";
+            auto fmtEntry = imageFormats.find(fmtName);
+            auto sizEntry = imageSizes.find(sizName);
+            uint32_t fmt = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmtName, nullptr, 0);
+            uint32_t siz = sizEntry != imageSizes.end() ? sizEntry->second : std::stoul(sizName, nullptr, 0);
+            uint32_t width = child->IntAttribute("Width");
+            uint32_t height = child->IntAttribute("Height");
+            uint32_t palette = child->UnsignedAttribute("Palette");
+            uint32_t tmem = child->UnsignedAttribute("TMem");
+            uint32_t renderTile = child->UnsignedAttribute("RenderTile");
+            uint32_t maskS = child->IntAttribute("MaskS");
+            uint32_t maskT = child->IntAttribute("MaskT");
+            uint32_t shiftS = child->IntAttribute("ShiftS");
+            uint32_t shiftT = child->IntAttribute("ShiftT");
+            uint32_t cms = (child->Attribute("CMS_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMS_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMS_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMS_TXClamp", 0) ? G_TX_CLAMP : 0);
+            uint32_t cmt = (child->Attribute("CMT_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMT_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMT_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMT_TXClamp", 0) ? G_TX_CLAMP : 0);
+            Gfx commands[7] = {};
+
+            if (siz == G_IM_SIZ_8b) {
+                Gfx generated[7] = { gsDPLoadMultiBlockS(0, tmem, renderTile, fmt, G_IM_SIZ_8b, width, height, palette,
+                                                         cms, cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generated, sizeof(commands));
+            } else if (siz == G_IM_SIZ_16b) {
+                Gfx generated[7] = { gsDPLoadMultiBlockS(0, tmem, renderTile, fmt, G_IM_SIZ_16b, width, height, palette,
+                                                         cms, cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generated, sizeof(commands));
+            } else if (siz == G_IM_SIZ_32b) {
+                Gfx generated[7] = { gsDPLoadMultiBlockS(0, tmem, renderTile, fmt, G_IM_SIZ_32b, width, height, palette,
+                                                         cms, cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generated, sizeof(commands));
+            }
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            strcpy(str, path.c_str());
+            dl->Strings.push_back(str);
+            commands[0].words.w0 = (commands[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            commands[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+            for (int i = 0; i < 6; i++) {
+                dl->Instructions.push_back(commands[i]);
+            }
+            g = commands[6];
+        } else if (childName == "LoadMultiBlock4b") {
+            std::string fmtName = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            auto fmtEntry = imageFormats.find(fmtName);
+            uint32_t fmt = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmtName, nullptr, 0);
+            uint32_t width = child->IntAttribute("Width");
+            uint32_t height = child->IntAttribute("Height");
+            uint32_t palette = child->UnsignedAttribute("Palette");
+            uint32_t tmem = child->UnsignedAttribute("TMem");
+            uint32_t renderTile = child->UnsignedAttribute("RenderTile");
+            uint32_t maskS = child->IntAttribute("MaskS");
+            uint32_t maskT = child->IntAttribute("MaskT");
+            uint32_t shiftS = child->IntAttribute("ShiftS");
+            uint32_t shiftT = child->IntAttribute("ShiftT");
+            uint32_t cms = (child->Attribute("CMS_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMS_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMS_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMS_TXClamp", 0) ? G_TX_CLAMP : 0);
+            uint32_t cmt = (child->Attribute("CMT_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMT_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMT_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMT_TXClamp", 0) ? G_TX_CLAMP : 0);
+            Gfx commands[7] = { gsDPLoadMultiBlock_4b(0, tmem, renderTile, fmt, width, height, palette, cms, cmt, maskS,
+                                                      maskT, shiftS, shiftT) };
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            strcpy(str, path.c_str());
+            dl->Strings.push_back(str);
+            commands[0].words.w0 = (commands[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            commands[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+            for (int i = 0; i < 6; i++) {
+                dl->Instructions.push_back(commands[i]);
+            }
+            g = commands[6];
+        } else if (childName == "LoadMultiBlock4bS") {
+            std::string fmtName = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            auto fmtEntry = imageFormats.find(fmtName);
+            uint32_t fmt = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmtName, nullptr, 0);
+            uint32_t width = child->IntAttribute("Width");
+            uint32_t height = child->IntAttribute("Height");
+            uint32_t palette = child->UnsignedAttribute("Palette");
+            uint32_t tmem = child->UnsignedAttribute("TMem");
+            uint32_t renderTile = child->UnsignedAttribute("RenderTile");
+            uint32_t maskS = child->IntAttribute("MaskS");
+            uint32_t maskT = child->IntAttribute("MaskT");
+            uint32_t shiftS = child->IntAttribute("ShiftS");
+            uint32_t shiftT = child->IntAttribute("ShiftT");
+            uint32_t cms = (child->Attribute("CMS_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMS_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMS_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMS_TXClamp", 0) ? G_TX_CLAMP : 0);
+            uint32_t cmt = (child->Attribute("CMT_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMT_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMT_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMT_TXClamp", 0) ? G_TX_CLAMP : 0);
+            Gfx commands[7] = { gsDPLoadMultiBlock_4bS(0, tmem, renderTile, fmt, width, height, palette, cms, cmt,
+                                                       maskS, maskT, shiftS, shiftT) };
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            strcpy(str, path.c_str());
+            dl->Strings.push_back(str);
+            commands[0].words.w0 = (commands[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            commands[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+            for (int i = 0; i < 6; i++) {
+                dl->Instructions.push_back(commands[i]);
+            }
+            g = commands[6];
+        } else if (childName == "LoadTextureTile") {
+            std::string fmtName = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            std::string sizName = child->Attribute("Size") != nullptr ? child->Attribute("Size") : "0";
+            auto fmtEntry = imageFormats.find(fmtName);
+            auto sizEntry = imageSizes.find(sizName);
+            uint32_t fmt = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmtName, nullptr, 0);
+            uint32_t siz = sizEntry != imageSizes.end() ? sizEntry->second : std::stoul(sizName, nullptr, 0);
+            uint32_t width = child->IntAttribute("Width");
+            uint32_t height = child->IntAttribute("Height");
+            uint32_t uls = child->UnsignedAttribute("Uls");
+            uint32_t ult = child->UnsignedAttribute("Ult");
+            uint32_t lrs = child->UnsignedAttribute("Lrs");
+            uint32_t lrt = child->UnsignedAttribute("Lrt");
+            uint32_t palette = child->UnsignedAttribute("Palette");
+            uint32_t maskS = child->IntAttribute("MaskS");
+            uint32_t maskT = child->IntAttribute("MaskT");
+            uint32_t shiftS = child->IntAttribute("ShiftS");
+            uint32_t shiftT = child->IntAttribute("ShiftT");
+            uint32_t cms = (child->Attribute("CMS_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMS_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMS_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMS_TXClamp", 0) ? G_TX_CLAMP : 0);
+            uint32_t cmt = (child->Attribute("CMT_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMT_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMT_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMT_TXClamp", 0) ? G_TX_CLAMP : 0);
+            Gfx commands[7] = {};
+
+            if (siz == G_IM_SIZ_8b) {
+                Gfx generated[7] = { gsDPLoadTextureTile(0, fmt, G_IM_SIZ_8b, width, height, uls, ult, lrs, lrt,
+                                                         palette, cms, cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generated, sizeof(commands));
+            } else if (siz == G_IM_SIZ_16b) {
+                Gfx generated[7] = { gsDPLoadTextureTile(0, fmt, G_IM_SIZ_16b, width, height, uls, ult, lrs, lrt,
+                                                         palette, cms, cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generated, sizeof(commands));
+            } else if (siz == G_IM_SIZ_32b) {
+                Gfx generated[7] = { gsDPLoadTextureTile(0, fmt, G_IM_SIZ_32b, width, height, uls, ult, lrs, lrt,
+                                                         palette, cms, cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generated, sizeof(commands));
+            }
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            strcpy(str, path.c_str());
+            dl->Strings.push_back(str);
+            commands[0].words.w0 = (commands[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            commands[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+            for (int i = 0; i < 6; i++) {
+                dl->Instructions.push_back(commands[i]);
+            }
+            g = commands[6];
+        } else if (childName == "LoadTextureTile4b") {
+            std::string fmtName = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            auto fmtEntry = imageFormats.find(fmtName);
+            uint32_t fmt = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmtName, nullptr, 0);
+            uint32_t width = child->IntAttribute("Width");
+            uint32_t height = child->IntAttribute("Height");
+            uint32_t uls = child->UnsignedAttribute("Uls");
+            uint32_t ult = child->UnsignedAttribute("Ult");
+            uint32_t lrs = child->UnsignedAttribute("Lrs");
+            uint32_t lrt = child->UnsignedAttribute("Lrt");
+            uint32_t palette = child->UnsignedAttribute("Palette");
+            uint32_t maskS = child->IntAttribute("MaskS");
+            uint32_t maskT = child->IntAttribute("MaskT");
+            uint32_t shiftS = child->IntAttribute("ShiftS");
+            uint32_t shiftT = child->IntAttribute("ShiftT");
+            uint32_t cms = (child->Attribute("CMS_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMS_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMS_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMS_TXClamp", 0) ? G_TX_CLAMP : 0);
+            uint32_t cmt = (child->Attribute("CMT_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMT_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMT_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMT_TXClamp", 0) ? G_TX_CLAMP : 0);
+            Gfx commands[7] = { gsDPLoadTextureTile_4b(0, fmt, width, height, uls, ult, lrs, lrt, palette, cms, cmt,
+                                                       maskS, maskT, shiftS, shiftT) };
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            strcpy(str, path.c_str());
+            dl->Strings.push_back(str);
+            commands[0].words.w0 = (commands[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            commands[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+            for (int i = 0; i < 6; i++) {
+                dl->Instructions.push_back(commands[i]);
+            }
+            g = commands[6];
+        } else if (childName == "LoadMultiTile") {
+            std::string fmtName = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            std::string sizName = child->Attribute("Size") != nullptr ? child->Attribute("Size") : "0";
+            auto fmtEntry = imageFormats.find(fmtName);
+            auto sizEntry = imageSizes.find(sizName);
+            uint32_t fmt = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmtName, nullptr, 0);
+            uint32_t siz = sizEntry != imageSizes.end() ? sizEntry->second : std::stoul(sizName, nullptr, 0);
+            uint32_t width = child->IntAttribute("Width");
+            uint32_t height = child->IntAttribute("Height");
+            uint32_t uls = child->UnsignedAttribute("Uls");
+            uint32_t ult = child->UnsignedAttribute("Ult");
+            uint32_t lrs = child->UnsignedAttribute("Lrs");
+            uint32_t lrt = child->UnsignedAttribute("Lrt");
+            uint32_t palette = child->UnsignedAttribute("Palette");
+            uint32_t tmem = child->UnsignedAttribute("TMem");
+            uint32_t renderTile = child->UnsignedAttribute("RenderTile");
+            uint32_t maskS = child->IntAttribute("MaskS");
+            uint32_t maskT = child->IntAttribute("MaskT");
+            uint32_t shiftS = child->IntAttribute("ShiftS");
+            uint32_t shiftT = child->IntAttribute("ShiftT");
+            uint32_t cms = (child->Attribute("CMS_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMS_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMS_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMS_TXClamp", 0) ? G_TX_CLAMP : 0);
+            uint32_t cmt = (child->Attribute("CMT_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMT_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMT_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMT_TXClamp", 0) ? G_TX_CLAMP : 0);
+            Gfx commands[7] = {};
+
+            if (siz == G_IM_SIZ_8b) {
+                Gfx generated[7] = { gsDPLoadMultiTile(0, tmem, renderTile, fmt, G_IM_SIZ_8b, width, height, uls, ult,
+                                                       lrs, lrt, palette, cms, cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generated, sizeof(commands));
+            } else if (siz == G_IM_SIZ_16b) {
+                Gfx generated[7] = { gsDPLoadMultiTile(0, tmem, renderTile, fmt, G_IM_SIZ_16b, width, height, uls, ult,
+                                                       lrs, lrt, palette, cms, cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generated, sizeof(commands));
+            } else if (siz == G_IM_SIZ_32b) {
+                Gfx generated[7] = { gsDPLoadMultiTile(0, tmem, renderTile, fmt, G_IM_SIZ_32b, width, height, uls, ult,
+                                                       lrs, lrt, palette, cms, cmt, maskS, maskT, shiftS, shiftT) };
+                memcpy(commands, generated, sizeof(commands));
+            }
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            strcpy(str, path.c_str());
+            dl->Strings.push_back(str);
+            commands[0].words.w0 = (commands[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            commands[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+            for (int i = 0; i < 6; i++) {
+                dl->Instructions.push_back(commands[i]);
+            }
+            g = commands[6];
+        } else if (childName == "LoadMultiTile4b") {
+            std::string fmtName = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            auto fmtEntry = imageFormats.find(fmtName);
+            uint32_t fmt = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmtName, nullptr, 0);
+            uint32_t width = child->IntAttribute("Width");
+            uint32_t height = child->IntAttribute("Height");
+            uint32_t uls = child->UnsignedAttribute("Uls");
+            uint32_t ult = child->UnsignedAttribute("Ult");
+            uint32_t lrs = child->UnsignedAttribute("Lrs");
+            uint32_t lrt = child->UnsignedAttribute("Lrt");
+            uint32_t palette = child->UnsignedAttribute("Palette");
+            uint32_t tmem = child->UnsignedAttribute("TMem");
+            uint32_t renderTile = child->UnsignedAttribute("RenderTile");
+            uint32_t maskS = child->IntAttribute("MaskS");
+            uint32_t maskT = child->IntAttribute("MaskT");
+            uint32_t shiftS = child->IntAttribute("ShiftS");
+            uint32_t shiftT = child->IntAttribute("ShiftT");
+            uint32_t cms = (child->Attribute("CMS_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMS_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMS_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMS_TXClamp", 0) ? G_TX_CLAMP : 0);
+            uint32_t cmt = (child->Attribute("CMT_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMT_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMT_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMT_TXClamp", 0) ? G_TX_CLAMP : 0);
+            Gfx commands[7] = { gsDPLoadMultiTile_4b(0, tmem, renderTile, fmt, width, height, uls, ult, lrs, lrt,
+                                                     palette, cms, cmt, maskS, maskT, shiftS, shiftT) };
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            strcpy(str, path.c_str());
+            dl->Strings.push_back(str);
+            commands[0].words.w0 = (commands[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            commands[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+            for (int i = 0; i < 6; i++) {
+                dl->Instructions.push_back(commands[i]);
+            }
+            g = commands[6];
+        } else if (childName == "LoadTextureBlockYuv") {
+            std::string fmtName = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            std::string sizName = child->Attribute("Size") != nullptr ? child->Attribute("Size") : "0";
+            auto fmtEntry = imageFormats.find(fmtName);
+            auto sizEntry = imageSizes.find(sizName);
+            uint32_t fmt = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmtName, nullptr, 0);
+            uint32_t siz = sizEntry != imageSizes.end() ? sizEntry->second : std::stoul(sizName, nullptr, 0);
+            uint32_t width = child->IntAttribute("Width");
+            uint32_t height = child->IntAttribute("Height");
+            uint32_t palette = child->UnsignedAttribute("Palette");
+            uint32_t maskS = child->IntAttribute("MaskS");
+            uint32_t maskT = child->IntAttribute("MaskT");
+            uint32_t shiftS = child->IntAttribute("ShiftS");
+            uint32_t shiftT = child->IntAttribute("ShiftT");
+            uint32_t cms = (child->Attribute("CMS_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMS_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMS_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMS_TXClamp", 0) ? G_TX_CLAMP : 0);
+            uint32_t cmt = (child->Attribute("CMT_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMT_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMT_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMT_TXClamp", 0) ? G_TX_CLAMP : 0);
+            Gfx commands[7] = {};
+            Gfx* command = commands;
+
+            if (siz == G_IM_SIZ_8b) {
+                gDPLoadTextureBlockYuv(command++, 0, fmt, G_IM_SIZ_8b, width, height, palette, cms, cmt, maskS, maskT,
+                                       shiftS, shiftT);
+            } else if (siz == G_IM_SIZ_16b) {
+                gDPLoadTextureBlockYuv(command++, 0, fmt, G_IM_SIZ_16b, width, height, palette, cms, cmt, maskS, maskT,
+                                       shiftS, shiftT);
+            } else if (siz == G_IM_SIZ_32b) {
+                gDPLoadTextureBlockYuv(command++, 0, fmt, G_IM_SIZ_32b, width, height, palette, cms, cmt, maskS, maskT,
+                                       shiftS, shiftT);
+            }
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            strcpy(str, path.c_str());
+            dl->Strings.push_back(str);
+            commands[0].words.w0 = (commands[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            commands[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+            for (int i = 0; i < 6; i++) {
+                dl->Instructions.push_back(commands[i]);
+            }
+            g = commands[6];
+        } else if (childName == "LoadTextureBlockYuvS") {
+            std::string fmtName = child->Attribute("Format") != nullptr ? child->Attribute("Format") : "0";
+            std::string sizName = child->Attribute("Size") != nullptr ? child->Attribute("Size") : "0";
+            auto fmtEntry = imageFormats.find(fmtName);
+            auto sizEntry = imageSizes.find(sizName);
+            uint32_t fmt = fmtEntry != imageFormats.end() ? fmtEntry->second : std::stoul(fmtName, nullptr, 0);
+            uint32_t siz = sizEntry != imageSizes.end() ? sizEntry->second : std::stoul(sizName, nullptr, 0);
+            uint32_t width = child->IntAttribute("Width");
+            uint32_t height = child->IntAttribute("Height");
+            uint32_t palette = child->UnsignedAttribute("Palette");
+            uint32_t maskS = child->IntAttribute("MaskS");
+            uint32_t maskT = child->IntAttribute("MaskT");
+            uint32_t shiftS = child->IntAttribute("ShiftS");
+            uint32_t shiftT = child->IntAttribute("ShiftT");
+            uint32_t cms = (child->Attribute("CMS_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMS_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMS_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMS_TXClamp", 0) ? G_TX_CLAMP : 0);
+            uint32_t cmt = (child->Attribute("CMT_TXMirror", 0) ? G_TX_MIRROR : 0) |
+                           (child->Attribute("CMT_TXNoMirror", 0) ? G_TX_NOMIRROR : 0) |
+                           (child->Attribute("CMT_TXWrap", 0) ? G_TX_WRAP : 0) |
+                           (child->Attribute("CMT_TXClamp", 0) ? G_TX_CLAMP : 0);
+            Gfx commands[7] = {};
+            Gfx* command = commands;
+
+            if (siz == G_IM_SIZ_8b) {
+                gDPLoadTextureBlockYuvS(command++, 0, fmt, G_IM_SIZ_8b, width, height, palette, cms, cmt, maskS, maskT,
+                                        shiftS, shiftT);
+            } else if (siz == G_IM_SIZ_16b) {
+                gDPLoadTextureBlockYuvS(command++, 0, fmt, G_IM_SIZ_16b, width, height, palette, cms, cmt, maskS, maskT,
+                                        shiftS, shiftT);
+            } else if (siz == G_IM_SIZ_32b) {
+                gDPLoadTextureBlockYuvS(command++, 0, fmt, G_IM_SIZ_32b, width, height, palette, cms, cmt, maskS, maskT,
+                                        shiftS, shiftT);
+            }
+
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            strcpy(str, path.c_str());
+            dl->Strings.push_back(str);
+            commands[0].words.w0 = (commands[0].words.w0 & 0x00FFFFFF) | (G_SETTIMG_OTR_FILEPATH << 24);
+            commands[0].words.w1 = reinterpret_cast<uintptr_t>(str);
+            for (int i = 0; i < 6; i++) {
+                dl->Instructions.push_back(commands[i]);
+            }
+            g = commands[6];
         } else if (childName == "EndDisplayList") {
             g = gsSPEndDisplayList();
         } else if (childName == "CullDisplayList") {
@@ -1029,10 +1872,10 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
                 } break;
             }
 
-            for (int j = 0; j < 4; j++) {
+            for (int j = 0; j < 3; j++) {
                 dl->Instructions.push_back(g2[j]);
             }
-
+            g = g2[3];
         } else if (childName == "JumpToDisplayList") {
             std::string dlPath = (char*)child->Attribute("Path");
             if (dlPath[0] == '>' && dlPath[1] == '0' && (dlPath[2] == 'x' || dlPath[2] == 'X')) {
@@ -1057,6 +1900,23 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
 
                 g = gsSPDisplayListOTRFilePath(dlPath2);
             }
+        } else if (childName == "GeometryMode") {
+            const uint32_t clear = child->UnsignedAttribute("Clear");
+            const uint32_t set = child->UnsignedAttribute("Set");
+#ifdef F3DEX_GBI_2
+            g = gsSPGeometryMode(clear, set);
+#else
+            dl->Instructions.push_back(gsSPClearGeometryMode(clear));
+            g = gsSPSetGeometryMode(set);
+#endif
+        } else if (childName == "LoadGeometryMode") {
+            const uint32_t mode = child->UnsignedAttribute("Mode");
+#ifdef F3DEX_GBI_2
+            g = gsSPLoadGeometryMode(mode);
+#else
+            dl->Instructions.push_back(gsSPClearGeometryMode(UINT32_MAX));
+            g = gsSPSetGeometryMode(mode);
+#endif
         } else if (childName == "ClearGeometryMode" || childName == "SetGeometryMode") {
             uint64_t clearData = 0;
 
@@ -1150,19 +2010,172 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
                 } break;
             }
 
-            for (int j = 0; j < 2; j++) {
-                dl->Instructions.push_back(g2[j]);
-            }
-
+            dl->Instructions.push_back(g2[0]);
+            g = g2[1];
         } else if (childName == "SetRenderMode") {
             std::string rawMode1 = child->Attribute("Mode1");
             std::string rawMode2 = child->Attribute("Mode2");
             g = gsDPSetRenderMode(renderModes[rawMode1], renderModes[rawMode2]);
+        } else if (childName == "SetFramebuffer") {
+            gsSPSetFB(&g, child->UnsignedAttribute("Id"));
+        } else if (childName == "ResetFramebuffer") {
+            gsSPResetFB(&g);
+        } else if (childName == "SetTextureImageFramebuffer") {
+            gDPSetTextureImageFB(&g, 0, 0, 1, child->UnsignedAttribute("Id"));
+        } else if (childName == "InvalidateTextureCache") {
+            __gSPInvalidateTexCache(&g, child->Unsigned64Attribute("Address"));
+        } else if (childName == "ExtraGeometryMode") {
+            gSPExtraGeometryMode(&g, child->UnsignedAttribute("Clear"), child->UnsignedAttribute("Set"));
+        } else if (childName == "SetInterpolationTarget") {
+            gDPSetInterpolation(&g, child->UnsignedAttribute("Index"));
+        } else if (childName == "SetTileSizeInterpolated") {
+            Gfx g2[3];
+            __gDPSetTileSizeInterp(g2, child->UnsignedAttribute("Tile"), child->UnsignedAttribute("Uls"),
+                                   child->UnsignedAttribute("Ult"), child->UnsignedAttribute("Lrs"),
+                                   child->UnsignedAttribute("Lrt"));
+            float coords[4] = { child->FloatAttribute("UlsFloat"), child->FloatAttribute("UltFloat"),
+                                child->FloatAttribute("LrsFloat"), child->FloatAttribute("LrtFloat") };
+            memcpy(&g2[1].words.w0, &coords[0], sizeof(float));
+            memcpy(&g2[1].words.w1, &coords[1], sizeof(float));
+            memcpy(&g2[2].words.w0, &coords[2], sizeof(float));
+            memcpy(&g2[2].words.w1, &coords[3], sizeof(float));
+            dl->Instructions.push_back(g2[0]);
+            dl->Instructions.push_back(g2[1]);
+            g = g2[2];
+        } else if (childName == "WideTextureRectangle") {
+            Gfx g2[3] = { gsSPWideTextureRectangle(
+                child->IntAttribute("Xl"), child->IntAttribute("Yl"), child->IntAttribute("Xh"),
+                child->IntAttribute("Yh"), child->IntAttribute("Tile"), child->IntAttribute("S"),
+                child->IntAttribute("T"), child->IntAttribute("Dsdx"), child->IntAttribute("Dtdy")) };
+            dl->Instructions.push_back(g2[0]);
+            dl->Instructions.push_back(g2[1]);
+            g = g2[2];
+        } else if (childName == "FillWideRectangle") {
+            Gfx g2[2];
+            g2[0].words.w0 = _SHIFTL(G_FILLWIDERECT, 24, 8) | _SHIFTL(child->IntAttribute("Lrx"), 2, 22);
+            g2[0].words.w1 = _SHIFTL(child->IntAttribute("Lry"), 2, 22);
+            g2[1].words.w0 = _SHIFTL(child->IntAttribute("Ulx"), 2, 22);
+            g2[1].words.w1 = _SHIFTL(child->IntAttribute("Uly"), 2, 22);
+            dl->Instructions.push_back(g2[0]);
+            g = g2[1];
+        } else if (childName == "ImageRectangle") {
+            Gfx g2[3];
+            g2[0].words.w0 = _SHIFTL(G_IMAGERECT, 24, 8) | _SHIFTL(child->IntAttribute("Tile"), 0, 3);
+            g2[0].words.w1 =
+                _SHIFTL(child->IntAttribute("ImageWidth"), 16, 16) | _SHIFTL(child->IntAttribute("ImageHeight"), 0, 16);
+            g2[1].words.w0 = _SHIFTL(child->IntAttribute("X0"), 16, 16) | _SHIFTL(child->IntAttribute("Y0"), 0, 16);
+            g2[1].words.w1 = _SHIFTL(child->IntAttribute("S0"), 16, 16) | _SHIFTL(child->IntAttribute("T0"), 0, 16);
+            g2[2].words.w0 = _SHIFTL(child->IntAttribute("X1"), 16, 16) | _SHIFTL(child->IntAttribute("Y1"), 0, 16);
+            g2[2].words.w1 = _SHIFTL(child->IntAttribute("S1"), 16, 16) | _SHIFTL(child->IntAttribute("T1"), 0, 16);
+            dl->Instructions.push_back(g2[0]);
+            dl->Instructions.push_back(g2[1]);
+            g = g2[2];
+        } else if (childName == "BackgroundCopy" || childName == "Background1Cycle" || childName == "ObjectRectangle" ||
+                   childName == "ObjectRectangleR") {
+            uintptr_t address = child->Unsigned64Attribute("Address");
+            if (childName == "BackgroundCopy") {
+                g = gsSPBgRectCopy(address);
+            } else if (childName == "Background1Cycle") {
+                g = gsSPBgRect1Cyc(address);
+            } else if (childName == "ObjectRectangle") {
+                g = gsSPObjRectangle(address);
+            } else {
+                g = gsSPObjRectangleR(address);
+            }
+        } else if (childName == "ObjectRenderMode") {
+            std::string modes = child->Attribute("Mode") != nullptr ? child->Attribute("Mode") : "0";
+            uint32_t modeValue = 0;
+            size_t position = 0;
+
+            while (position <= modes.size()) {
+                size_t separator = modes.find('|', position);
+                std::string mode = modes.substr(position, separator - position);
+                size_t first = mode.find_first_not_of(" \t");
+                size_t last = mode.find_last_not_of(" \t");
+                mode = first == std::string::npos ? "0" : mode.substr(first, last - first + 1);
+                auto entry = objectRenderModes.find(mode);
+                modeValue |= entry != objectRenderModes.end() ? entry->second : std::stoul(mode, nullptr, 0);
+
+                if (separator == std::string::npos) {
+                    break;
+                }
+                position = separator + 1;
+            }
+
+            g = gsSPObjRenderMode(modeValue);
+        } else if (childName == "LoadVerticesWide") {
+            const uint32_t count = child->UnsignedAttribute("Count");
+            const uint32_t v0 = child->UnsignedAttribute("VertexBufferIndex");
+            g.words.w0 = _SHIFTL(G_VTX_WIDE, 24, 8) | _SHIFTL(count, 12, 8) | _SHIFTL(v0 + count, 1, 7);
+            g.words.w1 = child->Unsigned64Attribute("Address");
+        } else if (childName == "DisplayListMarker") {
+            Gfx header;
+            header.words.w0 = _SHIFTL(G_MARKER, 24, 8);
+            header.words.w1 = 0;
+            dl->Instructions.push_back(header);
+            const uint64_t hash = CRC64(child->Attribute("Path"));
+            g.words.w0 = static_cast<uint32_t>(hash >> 32);
+            g.words.w1 = static_cast<uint32_t>(hash);
+        } else if (childName == "BranchLessZHash") {
+            Gfx header;
+            header.words.w0 = _SHIFTL(G_BRANCH_Z_OTR, 24, 8) | _SHIFTL(child->UnsignedAttribute("Vertex"), 0, 12);
+            header.words.w1 = child->UnsignedAttribute("ZValue");
+            dl->Instructions.push_back(header);
+            const uint64_t hash = CRC64(child->Attribute("Path"));
+            g.words.w0 = static_cast<uint32_t>(hash >> 32);
+            g.words.w1 = static_cast<uint32_t>(hash);
+        } else if (childName == "MoveMemHash") {
+            Gfx header;
+            header.words.w0 = _SHIFTL(G_MOVEMEM_OTR, 24, 8);
+            header.words.w1 = _SHIFTL(child->UnsignedAttribute("Index"), 24, 8) |
+                              _SHIFTL(child->UnsignedAttribute("Offset"), 16, 8) |
+                              _SHIFTL(child->BoolAttribute("HasOffset"), 8, 8);
+            dl->Instructions.push_back(header);
+            const uint64_t hash = CRC64(child->Attribute("Path"));
+            g.words.w0 = static_cast<uint32_t>(hash >> 32);
+            g.words.w1 = static_cast<uint32_t>(hash);
+        } else if (childName == "PushCurrentDirectory") {
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            dl->Strings.push_back(str);
+            strcpy(str, path.c_str());
+            gsSPPushCD(&g, str);
+        } else if (childName == "CopyFramebuffer") {
+            gDPCopyFB(&g, child->UnsignedAttribute("Destination"), child->UnsignedAttribute("Source"),
+                      child->BoolAttribute("Once"), child->Unsigned64Attribute("CopiedAddress"));
+        } else if (childName == "ReadFramebuffer") {
+            Gfx header;
+            header.words.w0 = _SHIFTL(G_READFB, 24, 8) | _SHIFTL(child->BoolAttribute("ByteSwap"), 8, 1) |
+                              _SHIFTL(child->UnsignedAttribute("Source"), 0, 8);
+            header.words.w1 = child->Unsigned64Attribute("DestinationAddress");
+            dl->Instructions.push_back(header);
+            g.words.w0 =
+                _SHIFTL(child->UnsignedAttribute("Uly"), 16, 16) | _SHIFTL(child->UnsignedAttribute("Ulx"), 0, 16);
+            g.words.w1 =
+                _SHIFTL(child->UnsignedAttribute("Height"), 16, 16) | _SHIFTL(child->UnsignedAttribute("Width"), 0, 16);
+        } else if (childName == "RegisterBlendedTexture") {
+            Gfx header;
+            header.words.w0 = _SHIFTL(G_REGBLENDEDTEX, 24, 8);
+            std::string path = child->Attribute("Path");
+            char* str = static_cast<char*>(malloc(path.size() + 1));
+            dl->Strings.push_back(str);
+            strcpy(str, path.c_str());
+            header.words.w1 = reinterpret_cast<uintptr_t>(str);
+            dl->Instructions.push_back(header);
+            g.words.w0 = child->Unsigned64Attribute("MaskAddress");
+            g.words.w1 = child->Unsigned64Attribute("ReplacementAddress");
         } else if (childName == "PushShader") {
             const char* shader = child->Attribute("Shader", nullptr);
-            GsSPPushShader(dl->Instructions, shader);
+            if (shader == nullptr) {
+                printf("DisplayListXML: PushShader is missing its Shader attribute\n");
+            } else {
+                char* shaderCopy = (char*)malloc(strlen(shader) + 1);
+                dl->Strings.push_back(shaderCopy);
+                strcpy(shaderCopy, shader);
+                g = GsSPPushShader(shaderCopy);
+            }
         } else if (childName == "PopShader") {
-            GsSPPopShader(dl->Instructions);
+            g = GsSPPopShader();
         } else {
             printf("DisplayListXML: Unknown node %s\n", childName.c_str());
             g = gsDPPipeSync();


### PR DESCRIPTION
accidentally cooked the last pr trying to retarget so just opened a new one bc its easier

alot of xml conversions of displaylist gbi commands were missing from the dl factory, this just adds them
list of new added commands:
`FullSync`
`NoOp`
`SPNoOp`
`TextureL`
`SetColorImage`
`SetDepthImage`
`SetMaskImage`
`Viewport`
`Light`
`SetLights0`
`SetLights1`
`SetLights2`
`SetLights3`
`SetLights4`
`SetLights5`
`SetLights6`
`SetLights7`
`LookAtX`
`LookAtY`
`LookAt`
`SetHilite1Tile`
`SetHilite2Tile`
`ForceMatrix`
`MoveWord`
`MoveMem`
`PopMatrixN`
`FillRectangle`
`SetScissor`
`SetScissorFrac`
`SetConvert`
`SetKeyR`
`SetKeyGB`
`LoadTLUT`
`LoadTLUTPal16`
`LoadTLUTPal128`
`LoadTLUTPal256`
`TextureRectangle`
`TextureRectangleFlip`
`Quadrangle`
`ModifyVertex`
`SetRDPOtherMode`
`LoadTextureBlockS`
`LoadTextureBlock4bS`
`LoadMultiBlock`
`LoadMultiBlockS`
`LoadMultiBlock4b`
`LoadMultiBlock4bS`
`LoadTextureTile`
`LoadTextureTile4b`
`LoadMultiTile`
`LoadMultiTile4b`
`LoadTextureBlockYuv`
`LoadTextureBlockYuvS`
`GeometryMode`
`LoadGeometryMode`
`SetFramebuffer`
`ResetFramebuffer`
`SetTextureImageFramebuffer`
`InvalidateTextureCache`
`ExtraGeometryMode`
`SetInterpolationTarget`
`SetTileSizeInterpolated`
`SetTileSizeLerp`
`WideTextureRectangle`
`FillWideRectangle`
`ImageRectangle`
`BackgroundCopy`
`Background1Cycle`
`ObjectRectangle`
`ObjectRectangleR`
`ObjectRenderMode`
`LoadVerticesWide`
`DisplayListMarker`
`BranchLessZHash`
`MoveMemHash`
`PushCurrentDirectory`
`CopyFramebuffer`
`ReadFramebuffer`
`RegisterBlendedTexture`

changes were also made to a couple existing commands because they were not programmed correctly and had innaccuracies
`Triangle1` and `Triangles2` were ignoring their flag field, which is used to determine the vertice of the triangle controls the normals when smooth shading is disabled. this is fixed

the `LoadTextureBlock` macro command was emitting an extra `PipeSync` at the end, and was using the wrong load block size, of 16b on 4b and 8b textures causing masking values to be malformed, this is fixed