### PR TITLE
Fixes for shader push/pop

### DIFF
--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -1447,8 +1447,8 @@ std::string gfx_direct3d_common_build_shader(size_t& numFloats, const CCFeatures
         path = std::string(shaderName) + ".hlsl";
     }
 
-    auto res = static_pointer_cast<Ship::Shader>(Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(
-        "shaders/directx/default.shader.hlsl", true, init));
+    auto res = static_pointer_cast<Ship::Shader>(
+        Ship::Context::GetRawInstance()->GetResourceManager()->LoadResource(path, true, init));
 
     if (res == nullptr) {
         SPDLOG_ERROR("Failed to load default directx shader, missing f3d.o2r?");

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -3548,7 +3548,9 @@ bool gfx_pop_shader(F3DGfx** cmd0) {
     Interpreter* gfx = mInstance.lock().get();
     F3DGfx* cmd = *cmd0;
 
-    gfx->mShaderStack.pop();
+    if (!gfx->mShaderStack.empty()) {
+        gfx->mShaderStack.pop();
+    }
 
     return false;
 }

--- a/src/fast/resource/factory/DisplayListFactory.cpp
+++ b/src/fast/resource/factory/DisplayListFactory.cpp
@@ -1172,7 +1172,15 @@ ResourceFactoryXMLDisplayListV0::ReadResource(std::shared_ptr<Ship::File> file,
             g = gsDPSetRenderMode(renderModes[rawMode1], renderModes[rawMode2]);
         } else if (childName == "PushShader") {
             const char* shader = child->Attribute("Shader", nullptr);
-            GsSPPushShader(dl->Instructions, shader);
+            if (shader == nullptr) {
+                printf("DisplayListXML: PushShader is missing its Shader attribute\n");
+            } else {
+                char* shaderCopy = (char*)malloc(strlen(shader) + 1);
+                dl->Strings.push_back(shaderCopy);
+                strcpy(shaderCopy, shader);
+
+                GsSPPushShader(dl->Instructions, shaderCopy);
+            }
         } else if (childName == "PopShader") {
             GsSPPopShader(dl->Instructions);
         } else {


### PR DESCRIPTION
DirectX shader always pointed to the default shader, and the shader string in the DL factory was dereferenced which also causes obvious issues.