### PR TITLE
Verify and retry the stb_image.h download (port-maintenance)

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -52,7 +52,40 @@ endif()
 
 #=================== STB ===================
 set(STB_DIR ${CMAKE_BINARY_DIR}/_deps/stb)
-file(DOWNLOAD "https://github.com/nothings/stb/raw/0bc88af4de5fb022db643c2d8e549a0927749354/stb_image.h" "${STB_DIR}/stb_image.h")
+set(stb_url "https://github.com/nothings/stb/raw/0bc88af4de5fb022db643c2d8e549a0927749354/stb_image.h")
+set(stb_expected_hash c54b15a689e6a1f32c75e2ec23afa442e3e0e37e894b73c1974d08679b20dd5c)
+
+# file(DOWNLOAD) does not report error pages or truncated bodies, so verify the hash and retry.
+set(stb_verified FALSE)
+if(EXISTS "${STB_DIR}/stb_image.h")
+    file(SHA256 "${STB_DIR}/stb_image.h" stb_actual_hash)
+    if(stb_actual_hash STREQUAL "${stb_expected_hash}")
+        set(stb_verified TRUE)
+    endif()
+endif()
+
+foreach(stb_attempt RANGE 1 4)
+    if(stb_verified)
+        break()
+    endif()
+    if(stb_attempt GREATER 1)
+        message(STATUS "Retrying stb_image.h download (attempt ${stb_attempt})")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 3)
+    endif()
+    file(DOWNLOAD "${stb_url}" "${STB_DIR}/stb_image.h" STATUS stb_status)
+    file(SHA256 "${STB_DIR}/stb_image.h" stb_actual_hash)
+    if(stb_actual_hash STREQUAL "${stb_expected_hash}")
+        set(stb_verified TRUE)
+    else()
+        list(GET stb_status 1 stb_error)
+        message(STATUS "stb_image.h download failed: ${stb_error}")
+    endif()
+endforeach()
+
+if(NOT stb_verified)
+    message(FATAL_ERROR "Failed to download a valid stb_image.h from ${stb_url}")
+endif()
+
 file(WRITE "${STB_DIR}/stb_impl.c" "#define STB_IMAGE_IMPLEMENTATION\n#include \"stb_image.h\"")
 
 add_library(stb STATIC)


### PR DESCRIPTION
Port-maintenance counterpart of #1248.

`file(DOWNLOAD)` without a `STATUS` or hash argument treats an HTTP error page and a truncated body as success. When the raw endpoint hiccups, `stb_image.h` is written empty or half-written, the configure step reports nothing, and the build dies several minutes later on every use of stb:

```
GuiTexture.cpp(9,9): error C3861: 'stbi_image_free': identifier not found
GuiTextureFactory.cpp(20,54): error C2146: syntax error: missing '>' before identifier 'stbi_uc'
```

This has now cost re-runs on unrelated PRs (most recently #1253, twice), and it is confusing every time because the reported errors point at our source rather than at the download.

The fix verifies the file against a known SHA-256 and retries before giving up, so a transient failure no longer needs a human to notice and re-run. A file that is already present and hashes correctly is skipped, which also stops the redundant re-download that happened on every single configure.

### Verified

Against a local server injecting each failure mode:

| scenario | before | after |
| --- | --- | --- |
| healthy download | works | works |
| reconfigure twice | re-downloads every time | 0 re-downloads |
| HTTP 404 | 0-byte header, `libstb.a` links, fails later in the build | fails at configure, names the URL |
| truncated body | 5000-byte header, fails later with `unterminated comment` | fails at configure, names the URL |
| 404, 404, then healthy | broken build | recovers inside the same configure |
| connection refused | 0-byte header, fails later in the build | fails at configure, names the URL |
| corrupted cached file | used as-is | re-downloaded and repaired |

Also confirmed the committed section against the real URL (downloads, hash matches, stb compiles) and that an existing build tree reconfigures without re-fetching.
