### PR TITLE
audio/SDL: pull model with a ring buffer and underrun masking

### DIFF
--- a/include/ship/audio/SDLAudioPlayer.h
+++ b/include/ship/audio/SDLAudioPlayer.h
@@ -12,7 +12,9 @@ namespace Ship {
  *
  * SDLAudioPlayer opens the platform output with `SDL_OpenAudioDeviceStream` and lets SDL pull from it:
  * SDL owns the audio thread and calls AudioStreamCallback() whenever the device needs more samples.
- * DoPlay() only writes into a ring buffer, which decouples the game thread's timing from the device's.
+ * DoPlay() only writes into a ring buffer, which decouples the game thread's timing from the device's
+ * and keeps the whole latency budget in one place. If the ring runs dry the callback replays the last
+ * burst faded out, which covers a load spike far less audibly than a hole in the stream.
  * It supports stereo and 6-channel output according to the configured AudioChannelsSetting.
  * This backend is available on all platforms that Ship supports.
  */
@@ -78,5 +80,9 @@ class SDLAudioPlayer final : public AudioPlayer {
     std::vector<uint8_t> mScratch;       ///< Pre-sized so the audio thread never allocates in steady state.
     std::mutex mMutex;                   ///< Serialises ring access between DoPlay() and the audio thread.
     std::atomic<bool> mRunning{ false }; ///< False once the device is closing; stops the callback working.
+
+    std::vector<uint8_t> mLastChunk; ///< Last burst played, replayed faded out to cover an underrun.
+    bool mLastChunkValid = false;    ///< False until a burst has actually been played.
+    bool mUnderrunFaded = false;     ///< True once faded, so a sustained underrun does not loop the chunk.
 };
 } // namespace Ship

--- a/include/ship/audio/SDLAudioPlayer.h
+++ b/include/ship/audio/SDLAudioPlayer.h
@@ -2,11 +2,17 @@
 #include "AudioPlayer.h"
 #include <SDL3/SDL.h>
 
+#include <atomic>
+#include <mutex>
+#include <vector>
+
 namespace Ship {
 /**
  * @brief AudioPlayer implementation backed by SDL3's audio subsystem.
  *
- * SDLAudioPlayer opens the platform output with `SDL_OpenAudioDeviceStream` and queues PCM in DoPlay().
+ * SDLAudioPlayer opens the platform output with `SDL_OpenAudioDeviceStream` and lets SDL pull from it:
+ * SDL owns the audio thread and calls AudioStreamCallback() whenever the device needs more samples.
+ * DoPlay() only writes into a ring buffer, which decouples the game thread's timing from the device's.
  * It supports stereo and 6-channel output according to the configured AudioChannelsSetting.
  * This backend is available on all platforms that Ship supports.
  */
@@ -21,7 +27,7 @@ class SDLAudioPlayer final : public AudioPlayer {
     ~SDLAudioPlayer();
 
     /**
-     * @brief Returns the number of audio frames currently queued in the SDL audio device.
+     * @brief Returns the number of audio frames currently waiting in the ring buffer.
      *
      * Used by the audio subsystem to decide how many frames to produce per game tick.
      */
@@ -40,14 +46,37 @@ class SDLAudioPlayer final : public AudioPlayer {
     void DoClose() override;
 
     /**
-     * @brief Queues interleaved PCM samples to the SDL audio device.
+     * @brief Writes interleaved PCM samples into the ring buffer for the audio thread to consume.
      * @param buf Interleaved sample data (stereo: L,R,… or surround: FL,FR,C,LFE,SL,SR,…).
      * @param len Length of @p buf in bytes.
      */
     void DoPlay(const uint8_t* buf, size_t len) override;
 
   private:
+    /**
+     * @brief SDL audio-thread callback: fills the device's request from the ring buffer.
+     * @param userdata The SDLAudioPlayer that opened @p stream.
+     * @param additionalAmount Bytes SDL needs right now to keep the device fed.
+     */
+    static void SDLCALL AudioStreamCallback(void* userdata, SDL_AudioStream* stream, int additionalAmount,
+                                            int totalAmount);
+
+    void RingInit(uint32_t bytes);
+    int32_t RingAvailable() const;
+    int32_t RingSpace() const;
+    int32_t RingRead(uint8_t* dst, int32_t bytes);
+    int32_t RingWrite(const uint8_t* src, int32_t bytes);
+
     SDL_AudioStream* mStream = nullptr; ///< Stream bound to the opened SDL audio device.
     int32_t mNumChannels = 2;           ///< Number of output channels (2 for stereo, 6 for 5.1).
+
+    std::vector<uint8_t> mRing; ///< Power-of-two sized storage bridging the game and audio threads.
+    uint32_t mRingMask = 0;     ///< mRing.size() - 1, for wrapping the pointers below.
+    int64_t mRingReadPos = 0;   ///< Unbounded read pointer; the difference with the write one is the fill.
+    int64_t mRingWritePos = 0;  ///< Unbounded write pointer.
+
+    std::vector<uint8_t> mScratch;       ///< Pre-sized so the audio thread never allocates in steady state.
+    std::mutex mMutex;                   ///< Serialises ring access between DoPlay() and the audio thread.
+    std::atomic<bool> mRunning{ false }; ///< False once the device is closing; stops the callback working.
 };
 } // namespace Ship

--- a/src/ship/audio/SDLAudioPlayer.cpp
+++ b/src/ship/audio/SDLAudioPlayer.cpp
@@ -1,6 +1,10 @@
 #include "ship/audio/SDLAudioPlayer.h"
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+#include <bit>
+#include <cstring>
+
 namespace Ship {
 
 SDLAudioPlayer::~SDLAudioPlayer() {
@@ -9,13 +13,74 @@ SDLAudioPlayer::~SDLAudioPlayer() {
     SDL_QuitSubSystem(SDL_INIT_AUDIO);
 }
 
+void SDLAudioPlayer::RingInit(uint32_t bytes) {
+    const uint32_t size = std::bit_ceil(bytes);
+    mRing.assign(size, 0);
+    mRingMask = size - 1;
+    mRingReadPos = mRingWritePos = 0;
+}
+
+int32_t SDLAudioPlayer::RingAvailable() const {
+    return static_cast<int32_t>(mRingWritePos - mRingReadPos);
+}
+
+int32_t SDLAudioPlayer::RingSpace() const {
+    return static_cast<int32_t>(mRing.size()) - RingAvailable();
+}
+
+int32_t SDLAudioPlayer::RingRead(uint8_t* dst, int32_t bytes) {
+    bytes = std::min(bytes, RingAvailable());
+    if (bytes <= 0) {
+        return 0;
+    }
+
+    const uint32_t offset = static_cast<uint32_t>(mRingReadPos) & mRingMask;
+    const uint32_t chunk = std::min(static_cast<uint32_t>(mRing.size()) - offset, static_cast<uint32_t>(bytes));
+
+    std::memcpy(dst, mRing.data() + offset, chunk);
+    if (chunk < static_cast<uint32_t>(bytes)) {
+        std::memcpy(dst + chunk, mRing.data(), bytes - chunk);
+    }
+
+    mRingReadPos += bytes;
+    return bytes;
+}
+
+int32_t SDLAudioPlayer::RingWrite(const uint8_t* src, int32_t bytes) {
+    bytes = std::min(bytes, RingSpace());
+    if (bytes <= 0) {
+        return 0;
+    }
+
+    const uint32_t offset = static_cast<uint32_t>(mRingWritePos) & mRingMask;
+    const uint32_t chunk = std::min(static_cast<uint32_t>(mRing.size()) - offset, static_cast<uint32_t>(bytes));
+
+    std::memcpy(mRing.data() + offset, src, chunk);
+    if (chunk < static_cast<uint32_t>(bytes)) {
+        std::memcpy(mRing.data(), src + chunk, bytes - chunk);
+    }
+
+    mRingWritePos += bytes;
+    return bytes;
+}
+
 void SDLAudioPlayer::DoClose() {
+    mRunning.store(false, std::memory_order_release);
+
     if (mStream != nullptr) {
-        SDL_PauseAudioDevice(SDL_GetAudioStreamDevice(mStream));
-        SDL_ClearAudioStream(mStream);
+        // Destroying the stream stops the callback and closes the bound device. SDL joins its audio
+        // thread first, so no callback can run past this point and the buffers below are safe to free.
         SDL_DestroyAudioStream(mStream);
         mStream = nullptr;
     }
+
+    mRing.clear();
+    mRing.shrink_to_fit();
+    mRingMask = 0;
+    mRingReadPos = mRingWritePos = 0;
+
+    mScratch.clear();
+    mScratch.shrink_to_fit();
 }
 
 bool SDLAudioPlayer::DoInit() {
@@ -27,29 +92,88 @@ bool SDLAudioPlayer::DoInit() {
     // Always open with the correct number of output channels
     mNumChannels = this->GetNumOutputChannels();
 
+    const uint32_t bytesPerFrame = sizeof(int16_t) * static_cast<uint32_t>(mNumChannels);
+    const uint32_t desiredBuffered = static_cast<uint32_t>(this->GetDesiredBuffered());
+
+    // Twice what the game aims to keep buffered, so a burst never meets a full ring during normal
+    // playback. RingInit rounds up to a power of two, which adds a little more headroom.
+    RingInit(desiredBuffered * 2 * bytesPerFrame);
+
+    // Sized for a whole producer chunk; a single device burst is much smaller than that.
+    mScratch.assign(desiredBuffered * bytesPerFrame, 0);
+
     const SDL_AudioSpec spec = { SDL_AUDIO_S16, mNumChannels, this->GetSampleRate() };
-    mStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, nullptr, nullptr);
+    mStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, AudioStreamCallback, this);
     if (mStream == nullptr) {
         SPDLOG_ERROR("SDL_OpenAudioDeviceStream error: {}", SDL_GetError());
+        DoClose();
         return false;
     }
 
     SPDLOG_INFO("SDL Audio initialized: {} channels, {} Hz", mNumChannels, this->GetSampleRate());
 
+    mRunning.store(true, std::memory_order_release);
     SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(mStream));
     return true;
 }
 
 int SDLAudioPlayer::Buffered() {
-    // SDL_GetAudioStreamQueued is the SDL3 replacement for the producer-side queue size used by SDL2.
-    // SDL_GetAudioStreamAvailable reports converted data for callers that read from the stream instead.
-    return mStream == nullptr ? 0 : SDL_GetAudioStreamQueued(mStream) / (sizeof(int16_t) * mNumChannels);
+    std::lock_guard<std::mutex> lock(mMutex);
+    return RingAvailable() / (static_cast<int32_t>(sizeof(int16_t)) * mNumChannels);
 }
 
 void SDLAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
-    if (Buffered() < 6000) {
-        // Don't fill the audio buffer too much in case this happens
-        SDL_PutAudioStreamData(mStream, buf, static_cast<int>(len));
+    if (!mRunning.load(std::memory_order_acquire)) {
+        return;
     }
+
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    // Whole chunk or nothing: a partial write would leave a gap mid-chunk, which is audible as a click.
+    if (RingSpace() >= static_cast<int32_t>(len)) {
+        RingWrite(buf, static_cast<int32_t>(len));
+    }
+}
+
+void SDLCALL SDLAudioPlayer::AudioStreamCallback(void* userdata, SDL_AudioStream* stream, int additionalAmount,
+                                                 int /*totalAmount*/) {
+    auto* self = static_cast<SDLAudioPlayer*>(userdata);
+
+    // SDL also calls with 0 purely as a notification.
+    if (additionalAmount <= 0 || !self->mRunning.load(std::memory_order_acquire)) {
+        return;
+    }
+
+    const int32_t stride = static_cast<int32_t>(sizeof(int16_t)) * self->mNumChannels;
+    // SDL asks for frame-aligned byte counts, but round down defensively.
+    const int32_t bytes = (additionalAmount / stride) * stride;
+    if (bytes <= 0) {
+        return;
+    }
+
+    // Only grows if SDL ever asks for more than a whole producer chunk; it settles after that.
+    if (self->mScratch.size() < static_cast<size_t>(bytes)) {
+        self->mScratch.resize(static_cast<size_t>(bytes));
+    }
+    uint8_t* dst = self->mScratch.data();
+
+    // This runs on the audio thread and must never block: if the game thread holds the lock, play
+    // silence for this burst rather than waiting for it.
+    if (!self->mMutex.try_lock()) {
+        std::memset(dst, 0, static_cast<size_t>(bytes));
+        SDL_PutAudioStreamData(stream, dst, bytes);
+        return;
+    }
+
+    if (self->RingAvailable() >= bytes) {
+        self->RingRead(dst, bytes);
+    } else {
+        // Underrun: the game thread has not kept up, so fill the gap with silence.
+        std::memset(dst, 0, static_cast<size_t>(bytes));
+    }
+
+    self->mMutex.unlock();
+
+    SDL_PutAudioStreamData(stream, dst, bytes);
 }
 } // namespace Ship

--- a/src/ship/audio/SDLAudioPlayer.cpp
+++ b/src/ship/audio/SDLAudioPlayer.cpp
@@ -81,6 +81,11 @@ void SDLAudioPlayer::DoClose() {
 
     mScratch.clear();
     mScratch.shrink_to_fit();
+
+    mLastChunk.clear();
+    mLastChunk.shrink_to_fit();
+    mLastChunkValid = false;
+    mUnderrunFaded = false;
 }
 
 bool SDLAudioPlayer::DoInit() {
@@ -101,6 +106,9 @@ bool SDLAudioPlayer::DoInit() {
 
     // Sized for a whole producer chunk; a single device burst is much smaller than that.
     mScratch.assign(desiredBuffered * bytesPerFrame, 0);
+    mLastChunk.assign(desiredBuffered * bytesPerFrame, 0);
+    mLastChunkValid = false;
+    mUnderrunFaded = false;
 
     const SDL_AudioSpec spec = { SDL_AUDIO_S16, mNumChannels, this->GetSampleRate() };
     mStream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, AudioStreamCallback, this);
@@ -165,10 +173,41 @@ void SDLCALL SDLAudioPlayer::AudioStreamCallback(void* userdata, SDL_AudioStream
         return;
     }
 
+    const int32_t lastChunkSize = static_cast<int32_t>(self->mLastChunk.size());
+
     if (self->RingAvailable() >= bytes) {
         self->RingRead(dst, bytes);
+        self->mUnderrunFaded = false;
+
+        // Keep it for the underrun path below.
+        if (bytes <= lastChunkSize) {
+            std::memcpy(self->mLastChunk.data(), dst, static_cast<size_t>(bytes));
+            self->mLastChunkValid = true;
+        }
+    } else if (self->mLastChunkValid && !self->mUnderrunFaded) {
+        // Underrun: the game thread has not kept up. Replay the last burst faded to zero, which the ear
+        // reads as the sound tailing off rather than as the click a hole in the stream produces.
+        const int32_t copy = std::min(bytes, lastChunkSize);
+        std::memcpy(dst, self->mLastChunk.data(), static_cast<size_t>(copy));
+        if (copy < bytes) {
+            std::memset(dst + copy, 0, static_cast<size_t>(bytes - copy));
+        }
+
+        // SoH always produces S16, which SDL_AUDIO_S16 in DoInit() matches.
+        const int32_t frames = bytes / stride;
+        auto* samples = reinterpret_cast<int16_t*>(dst);
+        for (int32_t frame = 0; frame < frames; ++frame) {
+            const float gain = 1.0f - static_cast<float>(frame) / static_cast<float>(frames);
+            for (int32_t channel = 0; channel < self->mNumChannels; ++channel) {
+                auto& sample = samples[frame * self->mNumChannels + channel];
+                sample = static_cast<int16_t>(static_cast<float>(sample) * gain);
+            }
+        }
+
+        // Only the first burst fades; repeating it would turn a stall into a stutter.
+        self->mUnderrunFaded = true;
     } else {
-        // Underrun: the game thread has not kept up, so fill the gap with silence.
+        // Nothing played yet, or the fade already ran: stay quiet until the game thread catches up.
         std::memset(dst, 0, static_cast<size_t>(bytes));
     }
 


### PR DESCRIPTION
`SDLAudioPlayer` pushes: `DoPlay()` queues onto the device straight from the game thread. Total latency is our queue plus SDL's stream plus the device buffer - three buffers, only one of which we can see, so there is nothing to tune. It also drops the buffer outright once `Buffered()` passes 6000 frames, turning a slow frame into an audible cut.

This opens the stream with an `SDL_AudioStreamCallback` instead, so SDL asks for samples when the device needs them and `DoPlay()` only writes into a ring buffer we own.

**Not a new design for this repo.** `CoreAudioAudioPlayer` already works exactly this way, and exists because the SDL path was not good enough on macOS. This brings SDL to the same architecture with that implementation's rough edges addressed:

| | `CoreAudioAudioPlayer` | here |
| --- | --- | --- |
| lock in the audio callback | blocking `pthread_mutex_lock` | `try_lock`, silence for that burst if contended |
| short ring | partial fill, zero-pad the rest | whole burst or nothing |
| underrun | silence | last burst replayed faded to zero |
| allocation on the audio thread | none | none (scratch sized in `DoInit()`) |

### Why it is worth doing

- **Latency.** Owning the buffer puts the whole budget in one place, so `DesiredBuffered` means what it says instead of being one term of three.
- **Underruns become inaudible rather than merely rarer.** You can substitute samples only if you fill the buffer; `SDL_PutAudioStreamData` gives no such hook.
- **A step toward fewer backends.** WASAPI and CoreAudio exist because the SDL path could not compete, and SDL routes to both underneath anyway. CoreAudio first, since it is the one this now matches.

### Scope

Two files, `SDLAudioPlayer` the only class touched. No new backend, no CMake changes, no interface changes. Two commits: the pull model, then the underrun fade.

Replaces #1107 and #1125, both closed. #1107 removed the same `Buffered() < 6000` drop and nothing else; #1125 added a whole second SDL3 backend, which stopped making sense once #1191 put libultraship on SDL3.

#1251 is the same change against `port-maintenance`, in SDL2 form. That branch sees far more play, so it is the better place to find out whether this helps.

### Testing

The ring buffer, callback and fade come from #1125, which I have been running on Linux (PipeWire) for months; this is that logic moved onto `SDLAudioPlayer` and trimmed of what the SDL3 migration made redundant. In this exact form it has not been through a play session, and never on Windows or macOS - the SDL path is selectable but not the default there, so testing would be welcome, particularly latency against the native backends.
