### PR TITLE
audio/SDL: pull model with a ring buffer and underrun masking (port-maintenance)

### DIFF
--- a/include/ship/audio/SDLAudioPlayer.h
+++ b/include/ship/audio/SDLAudioPlayer.h
@@ -2,13 +2,21 @@
 #include "AudioPlayer.h"
 #include <SDL2/SDL.h>
 
+#include <atomic>
+#include <mutex>
+#include <vector>
+
 namespace Ship {
 /**
  * @brief AudioPlayer implementation backed by SDL2's audio subsystem.
  *
- * SDLAudioPlayer uses `SDL_OpenAudioDevice` to open a platform audio output, then
- * pushes interleaved PCM samples in DoPlay(). It supports both stereo and 6-channel
- * (5.1) output depending on the AudioChannelsSetting configured in AudioPlayer.
+ * SDLAudioPlayer uses `SDL_OpenAudioDevice` to open a platform audio output and lets SDL pull
+ * from it: SDL owns the audio thread and calls AudioCallback() whenever the device needs more
+ * samples. DoPlay() only writes into a ring buffer, which decouples the game thread's timing
+ * from the device's and keeps the whole latency budget in one place. If the ring runs dry the
+ * callback replays the last burst faded out, which covers a load spike far less audibly than a
+ * hole in the stream. It supports both stereo and 6-channel (5.1) output depending on the
+ * AudioChannelsSetting configured in AudioPlayer.
  *
  * This backend is available on all platforms that Ship supports.
  */
@@ -49,7 +57,33 @@ class SDLAudioPlayer final : public AudioPlayer {
     void DoPlay(const uint8_t* buf, size_t len) override;
 
   private:
+    /**
+     * @brief SDL audio-thread callback: fills the device's request from the ring buffer.
+     * @param userdata The SDLAudioPlayer that opened the device.
+     * @param stream Destination buffer, which must be filled completely.
+     * @param len Length of @p stream in bytes.
+     */
+    static void SDLCALL AudioCallback(void* userdata, Uint8* stream, int len);
+
+    void RingInit(uint32_t bytes);
+    int32_t RingAvailable() const;
+    int32_t RingSpace() const;
+    int32_t RingRead(uint8_t* dst, int32_t bytes);
+    int32_t RingWrite(const uint8_t* src, int32_t bytes);
+
     SDL_AudioDeviceID mDevice = 0; ///< Handle to the opened SDL audio device.
     int32_t mNumChannels = 2;      ///< Number of output channels (2 for stereo, 6 for 5.1).
+
+    std::vector<uint8_t> mRing; ///< Power-of-two sized storage bridging the game and audio threads.
+    uint32_t mRingMask = 0;     ///< mRing.size() - 1, for wrapping the pointers below.
+    int64_t mRingReadPos = 0;   ///< Unbounded read pointer; the difference with the write one is the fill.
+    int64_t mRingWritePos = 0;  ///< Unbounded write pointer.
+
+    std::mutex mMutex;                   ///< Serialises ring access between DoPlay() and the audio thread.
+    std::atomic<bool> mRunning{ false }; ///< False once the device is closing; stops the callback working.
+
+    std::vector<uint8_t> mLastChunk; ///< Last burst played, replayed faded out to cover an underrun.
+    bool mLastChunkValid = false;    ///< False until a burst has actually been played.
+    bool mUnderrunFaded = false;     ///< True once faded, so a sustained underrun does not loop the chunk.
 };
 } // namespace Ship

--- a/src/ship/audio/SDLAudioPlayer.cpp
+++ b/src/ship/audio/SDLAudioPlayer.cpp
@@ -1,6 +1,10 @@
 #include "ship/audio/SDLAudioPlayer.h"
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+#include <bit>
+#include <cstring>
+
 namespace Ship {
 
 SDLAudioPlayer::~SDLAudioPlayer() {
@@ -9,19 +13,80 @@ SDLAudioPlayer::~SDLAudioPlayer() {
     SDL_QuitSubSystem(SDL_INIT_AUDIO);
 }
 
+void SDLAudioPlayer::RingInit(uint32_t bytes) {
+    const uint32_t size = std::bit_ceil(bytes);
+    mRing.assign(size, 0);
+    mRingMask = size - 1;
+    mRingReadPos = mRingWritePos = 0;
+}
+
+int32_t SDLAudioPlayer::RingAvailable() const {
+    return static_cast<int32_t>(mRingWritePos - mRingReadPos);
+}
+
+int32_t SDLAudioPlayer::RingSpace() const {
+    return static_cast<int32_t>(mRing.size()) - RingAvailable();
+}
+
+int32_t SDLAudioPlayer::RingRead(uint8_t* dst, int32_t bytes) {
+    bytes = std::min(bytes, RingAvailable());
+    if (bytes <= 0) {
+        return 0;
+    }
+
+    const uint32_t offset = static_cast<uint32_t>(mRingReadPos) & mRingMask;
+    const uint32_t chunk = std::min(static_cast<uint32_t>(mRing.size()) - offset, static_cast<uint32_t>(bytes));
+
+    std::memcpy(dst, mRing.data() + offset, chunk);
+    if (chunk < static_cast<uint32_t>(bytes)) {
+        std::memcpy(dst + chunk, mRing.data(), bytes - chunk);
+    }
+
+    mRingReadPos += bytes;
+    return bytes;
+}
+
+int32_t SDLAudioPlayer::RingWrite(const uint8_t* src, int32_t bytes) {
+    bytes = std::min(bytes, RingSpace());
+    if (bytes <= 0) {
+        return 0;
+    }
+
+    const uint32_t offset = static_cast<uint32_t>(mRingWritePos) & mRingMask;
+    const uint32_t chunk = std::min(static_cast<uint32_t>(mRing.size()) - offset, static_cast<uint32_t>(bytes));
+
+    std::memcpy(mRing.data() + offset, src, chunk);
+    if (chunk < static_cast<uint32_t>(bytes)) {
+        std::memcpy(mRing.data(), src + chunk, bytes - chunk);
+    }
+
+    mRingWritePos += bytes;
+    return bytes;
+}
+
 void SDLAudioPlayer::DoClose() {
+    mRunning.store(false, std::memory_order_release);
+
     if (mDevice != 0) {
-        // Pause playback first
-        SDL_PauseAudioDevice(mDevice, 1);
-        // Clear any queued audio to prevent glitches when reopening
-        SDL_ClearQueuedAudio(mDevice);
+        // Closing pauses the device and joins SDL's audio thread, so no callback can run past this
+        // point and the buffers below are safe to free.
         SDL_CloseAudioDevice(mDevice);
         mDevice = 0;
     }
+
+    mRing.clear();
+    mRing.shrink_to_fit();
+    mRingMask = 0;
+    mRingReadPos = mRingWritePos = 0;
+
+    mLastChunk.clear();
+    mLastChunk.shrink_to_fit();
+    mLastChunkValid = false;
+    mUnderrunFaded = false;
 }
 
 bool SDLAudioPlayer::DoInit() {
-    if (SDL_Init(SDL_INIT_AUDIO) != 0) {
+    if (SDL_InitSubSystem(SDL_INIT_AUDIO) != 0) {
         SPDLOG_ERROR("SDL init error: {}", SDL_GetError());
         return false;
     }
@@ -29,34 +94,118 @@ bool SDLAudioPlayer::DoInit() {
     // Always open with the correct number of output channels
     mNumChannels = this->GetNumOutputChannels();
 
+    const uint32_t bytesPerFrame = sizeof(int16_t) * static_cast<uint32_t>(mNumChannels);
+    const uint32_t desiredBuffered = static_cast<uint32_t>(this->GetDesiredBuffered());
+
+    // Twice what the game aims to keep buffered, so a burst never meets a full ring during normal
+    // playback. RingInit rounds up to a power of two, which adds a little more headroom.
+    RingInit(desiredBuffered * 2 * bytesPerFrame);
+
+    // Sized for a whole producer chunk; a single device burst is much smaller than that.
+    mLastChunk.assign(desiredBuffered * bytesPerFrame, 0);
+    mLastChunkValid = false;
+    mUnderrunFaded = false;
+
     SDL_AudioSpec want, have;
     SDL_zero(want);
     want.freq = this->GetSampleRate();
     want.format = AUDIO_S16SYS;
     want.channels = mNumChannels;
     want.samples = this->GetSampleLength();
-    want.callback = NULL;
+    want.callback = AudioCallback;
+    want.userdata = this;
 
-    mDevice = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
+    // No allowed changes, so SDL converts internally and `have` matches what was asked for.
+    mDevice = SDL_OpenAudioDevice(nullptr, 0, &want, &have, 0);
     if (mDevice == 0) {
-        SPDLOG_ERROR("SDL_OpenAudio error: {}", SDL_GetError());
+        SPDLOG_ERROR("SDL_OpenAudioDevice error: {}", SDL_GetError());
+        DoClose();
         return false;
     }
 
     SPDLOG_INFO("SDL Audio initialized: {} channels, {} Hz", mNumChannels, this->GetSampleRate());
 
+    mRunning.store(true, std::memory_order_release);
     SDL_PauseAudioDevice(mDevice, 0);
     return true;
 }
 
 int SDLAudioPlayer::Buffered() {
-    return SDL_GetQueuedAudioSize(mDevice) / (sizeof(int16_t) * mNumChannels);
+    std::lock_guard<std::mutex> lock(mMutex);
+    return RingAvailable() / (static_cast<int32_t>(sizeof(int16_t)) * mNumChannels);
 }
 
 void SDLAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
-    if (Buffered() < 6000) {
-        // Don't fill the audio buffer too much in case this happens
-        SDL_QueueAudio(mDevice, buf, len);
+    if (!mRunning.load(std::memory_order_acquire)) {
+        return;
     }
+
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    // Whole chunk or nothing: a partial write would leave a gap mid-chunk, which is audible as a click.
+    if (RingSpace() >= static_cast<int32_t>(len)) {
+        RingWrite(buf, static_cast<int32_t>(len));
+    }
+}
+
+void SDLCALL SDLAudioPlayer::AudioCallback(void* userdata, Uint8* stream, int len) {
+    auto* self = static_cast<SDLAudioPlayer*>(userdata);
+
+    // SDL2 requires the whole buffer to be written, so every path below fills all of `len`.
+    if (len <= 0) {
+        return;
+    }
+    if (!self->mRunning.load(std::memory_order_acquire)) {
+        std::memset(stream, 0, static_cast<size_t>(len));
+        return;
+    }
+
+    // This runs on the audio thread and must never block: if the game thread holds the lock, play
+    // silence for this burst rather than waiting for it.
+    if (!self->mMutex.try_lock()) {
+        std::memset(stream, 0, static_cast<size_t>(len));
+        return;
+    }
+
+    const int32_t stride = static_cast<int32_t>(sizeof(int16_t)) * self->mNumChannels;
+    const int32_t lastChunkSize = static_cast<int32_t>(self->mLastChunk.size());
+
+    if (self->RingAvailable() >= len) {
+        self->RingRead(stream, len);
+        self->mUnderrunFaded = false;
+
+        // Keep it for the underrun path below.
+        if (len <= lastChunkSize) {
+            std::memcpy(self->mLastChunk.data(), stream, static_cast<size_t>(len));
+            self->mLastChunkValid = true;
+        }
+    } else if (self->mLastChunkValid && !self->mUnderrunFaded) {
+        // Underrun: the game thread has not kept up. Replay the last burst faded to zero, which the ear
+        // reads as the sound tailing off rather than as the click a hole in the stream produces.
+        const int32_t copy = std::min(len, lastChunkSize);
+        std::memcpy(stream, self->mLastChunk.data(), static_cast<size_t>(copy));
+        if (copy < len) {
+            std::memset(stream + copy, 0, static_cast<size_t>(len - copy));
+        }
+
+        // SoH always produces S16, which AUDIO_S16SYS in DoInit() matches.
+        const int32_t frames = len / stride;
+        auto* samples = reinterpret_cast<int16_t*>(stream);
+        for (int32_t frame = 0; frame < frames; ++frame) {
+            const float gain = 1.0f - static_cast<float>(frame) / static_cast<float>(frames);
+            for (int32_t channel = 0; channel < self->mNumChannels; ++channel) {
+                auto& sample = samples[frame * self->mNumChannels + channel];
+                sample = static_cast<int16_t>(static_cast<float>(sample) * gain);
+            }
+        }
+
+        // Only the first burst fades; repeating it would turn a stall into a stutter.
+        self->mUnderrunFaded = true;
+    } else {
+        // Nothing played yet, or the fade already ran: stay quiet until the game thread catches up.
+        std::memset(stream, 0, static_cast<size_t>(len));
+    }
+
+    self->mMutex.unlock();
 }
 } // namespace Ship


### PR DESCRIPTION
`SDLAudioPlayer` pushes: `DoPlay()` calls `SDL_QueueAudio` straight from the game thread, so the device is fed on the game's schedule rather than its own. Total latency is our queue plus SDL's plus the device buffer - three buffers, one of them visible, so `DesiredBuffered` does not mean what it says and there is nothing to tune. And once `Buffered()` passes 6000 frames `DoPlay()` throws the buffer away, turning a slow frame into an audible cut.

This passes `SDL_OpenAudioDevice` a callback instead - the mode SDL2's audio API is built around, `SDL_QueueAudio` being the later convenience path:

- SDL owns the audio thread and asks for samples when the device needs them.
- `DoPlay()` only writes into a ring buffer sized at twice `DesiredBuffered`, so the whole latency budget sits in one place we control.
- Writes are whole-chunk-or-nothing; a partial write leaves a gap mid-chunk, which clicks.
- On underrun the callback replays the last burst faded linearly to zero instead of handing SDL silence. Only the first burst fades - repeating it would turn a stall into a stutter.
- The callback never blocks: it `try_lock`s and plays silence for that one burst if the game thread holds the ring. SDL2 gives the destination pointer and an exact length, so nothing is assembled on the audio thread.

**Not a new design for this repo.** `CoreAudioAudioPlayer` already works exactly this way, and exists because the SDL path was not good enough on macOS. This brings SDL to the same architecture with that implementation's rough edges addressed:

| | `CoreAudioAudioPlayer` | here |
| --- | --- | --- |
| lock in the audio callback | blocking `pthread_mutex_lock` | `try_lock`, silence for that burst if contended |
| short ring | partial fill, zero-pad the rest | whole burst or nothing |
| underrun | silence | last burst replayed faded to zero |

### Why it is worth doing

- **Latency on Linux.** SDL2 is the only audio path Linux has here, and owning the buffer is what lets the target actually be a target.
- **Underruns become inaudible rather than merely rarer.** You can substitute samples only if you fill the buffer; `SDL_QueueAudio` offers no such hook.
- **Fewer backends, eventually.** The bespoke WASAPI and CoreAudio backends exist because the SDL path could not compete, and SDL routes to both underneath anyway.

### Scope and relationship to the other PRs

Two files, `SDLAudioPlayer` the only class touched. No new backend, no CMake changes, no interface changes.

- Replaces #1189 and #1226, both closed. #1189 removed the same 6000-frame drop and also doubled `want.samples`; that pulls the other way once this lands, since the ring already absorbs the jitter the doubling compensated for, so `want.samples` stays at `GetSampleLength()`.
- #1250 is the same change against `main`, in SDL3 form. Whichever merges first, the other is a small translation - the ring, the fade and the locking are identical, only the SDL calls differ.

### Testing

The ring buffer, callback and fade come from the SDL3 backend in #1125 (closed), which I have been running on Linux for months. In this exact form - SDL2, this branch - it has not been through a play session, and never on Windows or macOS, where the SDL path is selectable but not the default. Testing there would be welcome, particularly latency against the native backends.
