### PR TITLE
Keep the draw batch when a texture load does not change the binding

### DIFF
--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -210,6 +210,17 @@ struct TextureCacheMapIter {
     TextureCacheMap::iterator it;
 };
 
+// Everything a tile needs to name a texture, with no GPU state touched and no cache entry made.
+struct TextureBinding {
+    TextureCacheKey key;
+    const uint8_t* origAddr; // source address, after the empty-TMEM-slot fallback
+    const uint8_t* fbAddr;   // address the framebuffer-mirror lookup reads, null when replacing
+    uint32_t tmemIndex;
+    uint32_t texFlags;
+    uint8_t fmt, siz;
+    bool fellBackToOtherTmem;
+};
+
 struct RGBA {
     uint8_t r, g, b, a;
 };
@@ -434,6 +445,8 @@ class Interpreter {
     void ImportTextureCi8(int tile, bool importReplacement);
     void ImportTextureRaw(int tile, bool importReplacement);
     void ImportTextureImg(int tile, bool importReplacement);
+    bool BuildTextureBinding(int tile, bool importReplacement, TextureBinding& binding);
+    bool TextureBindingUnchanged(int i, int tile);
     void ImportTexture(int i, int tile, bool importReplacement);
     void ImportTextureMask(int i, int tile);
     void CalculateNormalDir(const F3DLight_t*, float coeffs[3]);

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -1247,92 +1247,131 @@ void Interpreter::ImportTextureRaw(int tile, bool importReplacement) {
     mRapi->UploadTexture(mTexUploadBuffer, uploadWidth, uploadHeight);
 }
 
-void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
-    uint8_t fmt = mRdp->texture_tile[tile].fmt;
-    uint8_t siz = mRdp->texture_tile[tile].siz;
-    uint32_t texFlags = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].tex_flags;
-    uint32_t tmemIdex = mRdp->texture_tile[tile].tmem_index;
-    uint8_t paletteIndex = mRdp->texture_tile[tile].palette;
-    uint32_t origSizeBytes = mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].orig_size_bytes;
+bool Interpreter::BuildTextureBinding(int tile, bool importReplacement, TextureBinding& binding) {
+    const uint32_t tileTmem = mRdp->texture_tile[tile].tmem_index;
+    const uint8_t paletteIndex = mRdp->texture_tile[tile].palette;
+    uint32_t origSizeBytes = mRdp->loaded_texture[tileTmem].orig_size_bytes;
 
-    const RawTexMetadata* metadata = &mRdp->loaded_texture[mRdp->texture_tile[tile].tmem_index].raw_tex_metadata;
-    const uint8_t* origAddr =
+    binding.fmt = mRdp->texture_tile[tile].fmt;
+    binding.siz = mRdp->texture_tile[tile].siz;
+    binding.tmemIndex = tileTmem;
+    binding.texFlags = mRdp->loaded_texture[tileTmem].tex_flags;
+    binding.fellBackToOtherTmem = false;
+
+    const RawTexMetadata* metadata = &mRdp->loaded_texture[tileTmem].raw_tex_metadata;
+    binding.origAddr =
         importReplacement && (metadata->resource != nullptr)
             ? mMaskedTextures.find(GetBaseTexturePath(metadata->resource->GetInitData()->Path))->second.replacementData
-            : mRdp->loaded_texture[tmemIdex].addr;
+            : mRdp->loaded_texture[tileTmem].addr;
 
-    // Check if this texture address is a registered GPU framebuffer mirror.
-    // If so, bind the GPU FB directly — full resolution, no CPU readback needed.
-    if (origAddr != nullptr && !importReplacement) {
-        auto fbIt = mFbTextures.find((uintptr_t)origAddr);
-        if (fbIt != mFbTextures.end()) {
-            Flush();
-            mRapi->SelectTextureFb(fbIt->second);
-            mRdp->textures_changed[i] = false;
-            return;
-        }
-    }
+    binding.fbAddr = importReplacement ? nullptr : binding.origAddr;
 
-    if (origAddr == nullptr) {
+    if (binding.origAddr == nullptr) {
         // Try the other TMEM slot -- some multi-tile setups only load one slot
         // and expect both tiles to reference it.
-        uint32_t otherTmem = tmemIdex ^ 1;
-        origAddr = mRdp->loaded_texture[otherTmem].addr;
-        if (origAddr == nullptr) {
-            SPDLOG_WARN("ImportTexture: null texture address for tile {} (both TMEM slots empty)", tile);
-            return;
+        const uint32_t otherTmem = tileTmem ^ 1;
+        binding.origAddr = mRdp->loaded_texture[otherTmem].addr;
+        if (binding.origAddr == nullptr) {
+            return false;
         }
-        SPDLOG_WARN("ImportTexture: tile {} TMEM slot {} empty, falling back to slot {}", tile, tmemIdex, otherTmem);
-        tmemIdex = otherTmem;
+        binding.fellBackToOtherTmem = true;
+        binding.tmemIndex = otherTmem;
         origSizeBytes = mRdp->loaded_texture[otherTmem].orig_size_bytes;
-        texFlags = mRdp->loaded_texture[otherTmem].tex_flags;
+        binding.texFlags = mRdp->loaded_texture[otherTmem].tex_flags;
     }
 
     // Use palette_dram_addr (the original DRAM source) instead of palettes[]
     // (which always points to the staging buffer) so the same texture drawn
     // with different palettes gets distinct cache entries.
-    TextureCacheKey key;
-    if (fmt == G_IM_FMT_CI) {
-        if (siz == G_IM_SIZ_4b) {
+    if (binding.fmt == G_IM_FMT_CI) {
+        if (binding.siz == G_IM_SIZ_4b) {
             uint8_t palSlot = paletteIndex / 8;
-            key = { origAddr,
-                    { palSlot == 0 ? mRdp->palette_dram_addr[0] : nullptr,
-                      palSlot == 1 ? mRdp->palette_dram_addr[1] : nullptr },
-                    fmt,
-                    siz,
-                    paletteIndex,
-                    origSizeBytes };
+            binding.key = { binding.origAddr,
+                            { palSlot == 0 ? mRdp->palette_dram_addr[0] : nullptr,
+                              palSlot == 1 ? mRdp->palette_dram_addr[1] : nullptr },
+                            binding.fmt,
+                            binding.siz,
+                            paletteIndex,
+                            origSizeBytes };
         } else {
             // CI8 uses both palette halves
-            key = { origAddr,     { mRdp->palette_dram_addr[0], mRdp->palette_dram_addr[1] }, fmt, siz, paletteIndex,
-                    origSizeBytes };
+            binding.key = { binding.origAddr, { mRdp->palette_dram_addr[0], mRdp->palette_dram_addr[1] },
+                            binding.fmt,      binding.siz,
+                            paletteIndex,     origSizeBytes };
         }
     } else {
-        key = { origAddr, {}, fmt, siz, paletteIndex, origSizeBytes };
+        binding.key = { binding.origAddr, {}, binding.fmt, binding.siz, paletteIndex, origSizeBytes };
+    }
+    return true;
+}
+
+// True when slot i already holds exactly the texture this tile names, so the draw needs neither a
+// re-bind nor the batch break that goes with it.
+bool Interpreter::TextureBindingUnchanged(int i, int tile) {
+    if (mRenderingState.mTextures[i] == nullptr || mRdp->loaded_texture[i].masked || mRdp->loaded_texture[i].blended) {
+        return false;
     }
 
-    if (TextureCacheLookup(i, key)) {
+    TextureBinding binding;
+    if (!BuildTextureBinding(tile, false, binding)) {
+        return false;
+    }
+    if (binding.fbAddr != nullptr && mFbTextures.find((uintptr_t)binding.fbAddr) != mFbTextures.end()) {
+        return false;
+    }
+    // Cache keys are unique, so an equal key is the same node the map would have returned.
+    return mRenderingState.mTextures[i]->first == binding.key;
+}
+
+void Interpreter::ImportTexture(int i, int tile, bool importReplacement) {
+    TextureBinding binding;
+    if (!BuildTextureBinding(tile, importReplacement, binding)) {
+        SPDLOG_WARN("ImportTexture: null texture address for tile {} (both TMEM slots empty)", tile);
+        return;
+    }
+
+    // Check if this texture address is a registered GPU framebuffer mirror.
+    // If so, bind the GPU FB directly — full resolution, no CPU readback needed.
+    if (binding.fbAddr != nullptr) {
+        auto fbIt = mFbTextures.find((uintptr_t)binding.fbAddr);
+        if (fbIt != mFbTextures.end()) {
+            Flush();
+            mRapi->SelectTextureFb(fbIt->second);
+            // SelectTextureFb binds outside the texture cache, so the slot no longer holds a node.
+            mRenderingState.mTextures[0] = nullptr;
+            mRdp->textures_changed[i] = false;
+            return;
+        }
+    }
+
+    if (binding.fellBackToOtherTmem) {
+        SPDLOG_WARN("ImportTexture: tile {} TMEM slot {} empty, falling back to slot {}", tile,
+                    mRdp->texture_tile[tile].tmem_index, binding.tmemIndex);
+    }
+
+    if (TextureCacheLookup(i, binding.key)) {
         return;
     }
 
     // Guard against zero-sized textures that would cause divide-by-zero
     // or GPU API errors in UploadTexture.
-    if (mRdp->texture_tile[tile].line_size_bytes == 0 || mRdp->loaded_texture[tmemIdex].size_bytes == 0 ||
-        origAddr == nullptr) {
+    if (mRdp->texture_tile[tile].line_size_bytes == 0 || mRdp->loaded_texture[binding.tmemIndex].size_bytes == 0) {
         return;
     }
 
-    if ((texFlags & TEX_FLAG_LOAD_AS_IMG) != 0) {
+    if ((binding.texFlags & TEX_FLAG_LOAD_AS_IMG) != 0) {
         ImportTextureImg(tile, importReplacement);
         return;
     }
 
     // if load as raw is set then we load_raw();
-    if ((texFlags & TEX_FLAG_LOAD_AS_RAW) != 0) {
+    if ((binding.texFlags & TEX_FLAG_LOAD_AS_RAW) != 0) {
         ImportTextureRaw(tile, importReplacement);
         return;
     }
 
+    const uint8_t fmt = binding.fmt;
+    const uint8_t siz = binding.siz;
     switch (fmt) {
         case G_IM_FMT_RGBA:
             if (siz == G_IM_SIZ_16b) {
@@ -1955,7 +1994,10 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
         effective_tile[i] = tile;
 
         if (comb->usedTextures[i]) {
-            if (mRdp->textures_changed[i]) {
+            // The dirty flag only says a tile command ran, not that the binding moved. A sprite
+            // re-loads the same texture for every copy it draws, so a flush here would end the
+            // batch on every one of them.
+            if (mRdp->textures_changed[i] && !TextureBindingUnchanged(i, tile)) {
                 Flush();
                 ImportTexture(i, tile, false);
                 if (mRdp->loaded_texture[i].masked) {
@@ -1964,8 +2006,8 @@ void Interpreter::GfxSpTri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t vtx3_idx
                 if (mRdp->loaded_texture[i].blended) {
                     ImportTexture(SHADER_FIRST_REPLACEMENT_TEXTURE + i, tile, true);
                 }
-                mRdp->textures_changed[i] = false;
             }
+            mRdp->textures_changed[i] = false;
 
             uint8_t cms = mRdp->texture_tile[tile].cms;
             uint8_t cmt = mRdp->texture_tile[tile].cmt;
@@ -4230,6 +4272,8 @@ bool gfx_set_timg_fb_handler_custom(F3DGfx** cmd0) {
 
     gfx->Flush();
     gfx->mRapi->SelectTextureFb((uint32_t)cmd->words.w1);
+    // SelectTextureFb binds outside the texture cache, so the slot no longer holds a node.
+    gfx->mRenderingState.mTextures[0] = nullptr;
     gfx->mRdp->textures_changed[0] = false;
     gfx->mRdp->textures_changed[1] = false;
     return false;


### PR DESCRIPTION
This fix is a necessary step for optimization on low power or high performance demanding platforms. I found it when building a stereoscopic XR port of a decomp. It can yield a significant reduction in draw calls.

`gDPLoadTextureBlock` expands to `G_SETTIMG` + `G_SETTILE` + `G_LOADBLOCK` + `G_SETTILE` +
`G_SETTILESIZE`, and `GfxDpSetTile`, `GfxDpLoadBlock` and `GfxDpSetTileSize` each set
`mRdp->textures_changed[]` unconditionally. Nothing compares the new tile against the texture
already bound, so the next triangle flushes the batch whenever a tile command ran rather than when
the binding moved. `ImportTexture` then finds the texture in the cache and uploads nothing — the
`Flush()` in front of it is the only thing that cost anything.

N64 display lists re-issue the same load per object, so this is the common case, not a rare one:
sprites, particles, fonts, HUD. A 60-particle emitter on one texture becomes 60 draw calls of two
triangles each, where the batch holds 256.

So compare before flushing, in the shape `LookupOrCreateColorCombiner` already uses.
`BuildTextureBinding` splits the cache-key construction out of `ImportTexture` and touches no GPU
state and no LRU; `TextureBindingUnchanged` builds the key for the slot and compares it against the
node the slot already holds. Keys are unique, so an equal key is the node a lookup would have
returned and the whole block is skipped — no flush, no `SelectTexture`, no LRU move. The early-out
is deliberately narrow: only an unmasked, non-alt-asset-blended tile whose address isn't a
registered framebuffer mirror. Everything else falls through to today's code. `SelectTextureFb`
binds outside the texture cache, so its two call sites now null `mRenderingState.mTextures[0]`.

The dirty flags are left alone. Guarding them in the RDP handlers would be cheaper still, but
`textures_changed` doubles as the general "re-select this slot" trigger, so suppressing it at the
source needs reasoning about consumers that comparing at the point of use doesn't.

Measured on [Lighthouse](https://github.com/HarbourMasters/Lighthouse) via Linux (Release, GL), draws per frame: 213 → 68 in gameplay, 290 → 94 in another scene,
1.8x fewer over a whole session with menus and logos included. A particle burst where each particle
carries its own frame went 902 → 890, which is the point — the guard only removes a flush that
changes nothing, so a scene that really does rebind per object keeps every draw call it has.

Written with AI assistance; the diff and its reasoning were reviewed by hand.