### PR TITLE
Make ConsoleVariable thread-safe

### DIFF
--- a/include/ship/config/ConsoleVariable.h
+++ b/include/ship/config/ConsoleVariable.h
@@ -5,6 +5,7 @@
 #include <nlohmann/json.hpp>
 #include <stdint.h>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <string>
 #include <string_view>
@@ -217,5 +218,7 @@ class ConsoleVariable : public Component {
     };
     std::unordered_map<std::string, std::shared_ptr<CVar>, TransparentStringHash, TransparentStringEqual> mVariables;
     std::shared_ptr<Config> mConfig;
+    // Guards mVariables against concurrent access from the audio thread and the game thread.
+    std::recursive_mutex mVariablesMutex;
 };
 } // namespace Ship

--- a/src/ship/config/ConsoleVariable.cpp
+++ b/src/ship/config/ConsoleVariable.cpp
@@ -23,11 +23,13 @@ ConsoleVariable::~ConsoleVariable() {
 }
 
 std::shared_ptr<CVar> ConsoleVariable::Get(const char* name) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto it = mVariables.find(name);
     return it != mVariables.end() ? it->second : nullptr;
 }
 
 int32_t ConsoleVariable::GetInteger(const char* name, int32_t defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Integer) {
@@ -38,6 +40,7 @@ int32_t ConsoleVariable::GetInteger(const char* name, int32_t defaultValue) {
 }
 
 float ConsoleVariable::GetFloat(const char* name, float defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Float) {
@@ -48,6 +51,7 @@ float ConsoleVariable::GetFloat(const char* name, float defaultValue) {
 }
 
 const char* ConsoleVariable::GetString(const char* name, const char* defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::String) {
@@ -58,6 +62,7 @@ const char* ConsoleVariable::GetString(const char* name, const char* defaultValu
 }
 
 Color_RGBA8 ConsoleVariable::GetColor(const char* name, Color_RGBA8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Color) {
@@ -75,6 +80,7 @@ Color_RGBA8 ConsoleVariable::GetColor(const char* name, Color_RGBA8 defaultValue
 }
 
 Color_RGB8 ConsoleVariable::GetColor24(const char* name, Color_RGB8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Color24) {
@@ -91,6 +97,7 @@ Color_RGB8 ConsoleVariable::GetColor24(const char* name, Color_RGB8 defaultValue
 }
 
 void ConsoleVariable::SetInteger(const char* name, int32_t value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (variable == nullptr) {
         variable = std::make_shared<CVar>();
@@ -101,6 +108,7 @@ void ConsoleVariable::SetInteger(const char* name, int32_t value) {
 }
 
 void ConsoleVariable::SetFloat(const char* name, float value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (variable == nullptr) {
         variable = std::make_shared<CVar>();
@@ -111,6 +119,7 @@ void ConsoleVariable::SetFloat(const char* name, float value) {
 }
 
 void ConsoleVariable::SetString(const char* name, const char* value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (variable == nullptr) {
         variable = std::make_shared<CVar>();
@@ -124,6 +133,7 @@ void ConsoleVariable::SetString(const char* name, const char* value) {
 }
 
 void ConsoleVariable::SetColor(const char* name, Color_RGBA8 value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (!variable) {
         variable = std::make_shared<CVar>();
@@ -134,6 +144,7 @@ void ConsoleVariable::SetColor(const char* name, Color_RGBA8 value) {
 }
 
 void ConsoleVariable::SetColor24(const char* name, Color_RGB8 value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (!variable) {
         variable = std::make_shared<CVar>();
@@ -144,36 +155,42 @@ void ConsoleVariable::SetColor24(const char* name, Color_RGB8 value) {
 }
 
 void ConsoleVariable::RegisterInteger(const char* name, int32_t defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetInteger(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterFloat(const char* name, float defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetFloat(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterString(const char* name, const char* defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetString(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterColor(const char* name, Color_RGBA8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetColor(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterColor24(const char* name, Color_RGB8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetColor24(name, defaultValue);
     }
 }
 
 void ConsoleVariable::ClearVariable(const char* name) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     std::shared_ptr<Config> conf = mConfig;
     if (!conf) {
         return;
@@ -207,6 +224,7 @@ void ConsoleVariable::ClearVariable(const char* name) {
 }
 
 void ConsoleVariable::ClearBlock(const char* name) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     std::shared_ptr<Config> conf = mConfig;
     if (!conf) {
         return;
@@ -216,6 +234,7 @@ void ConsoleVariable::ClearBlock(const char* name) {
 }
 
 void ConsoleVariable::CopyVariable(const char* from, const char* to) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variableFrom = mVariables[from];
     if (!variableFrom) {
         return;
@@ -249,6 +268,7 @@ void ConsoleVariable::CopyVariable(const char* from, const char* to) {
 }
 
 void ConsoleVariable::Save() {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     std::shared_ptr<Config> conf = mConfig;
     if (!conf) {
         return;
@@ -288,6 +308,7 @@ void ConsoleVariable::Save() {
 }
 
 void ConsoleVariable::Load() {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     std::shared_ptr<Config> conf = mConfig;
     if (!conf) {
         return;


### PR DESCRIPTION
## Problem

`ConsoleVariable` stores its CVars in a `std::unordered_map` (`mVariables`) with no synchronisation, but the map is accessed from more than one thread. A consumer that reads CVars from the audio thread while the game thread mutates the store will eventually race.

The failure reproduces reliably when the game thread applies a large batch of CVar writes at once (e.g. loading a settings preset) while the audio thread is reading a CVar per note:

```
Signal: 11  INVALID ACCESS TO STORAGE
  Ship::ConsoleVariable::GetInteger(char const*, int)
  CVarGetInteger
  Audio_InitNoteSub
  Audio_ProcessNotes
  ...
  OTRAudio_Thread()
terminate called after throwing an instance of 'std::bad_alloc'
```

The batch of inserts rehashes the map and frees the old bucket array while the audio thread is mid-`find()`, so the lookup walks freed memory. The resulting heap corruption then surfaces as `std::bad_alloc` on the next allocation.

## Fix

Guard every public accessor of `mVariables` with a `std::recursive_mutex`. It is recursive because the public methods call one another (`Register*` -> `Get` + `Set*`, `Load` -> `LoadFromPath` -> `Set*`), so a single non-recursive lock at each entry point would self-deadlock. The two protected helpers (`LoadFromPath`, `LoadLegacy`) are only reached from `Load` and stay under its lock.

Reads on the audio thread take an uncontended lock (a couple of atomics); a large write burst briefly serialises with them instead of crashing.

`main` counterpart of #1227. The change is the same; the only difference is that the four methods reaching `Config` do so through the Component system's `mConfig` member here, rather than `Context::GetRawInstance()->GetConfig()`.
