### PR TITLE
Add screen X offset graphics command

### DIFF
--- a/include/fast/lus_gbi.h
+++ b/include/fast/lus_gbi.h
@@ -66,6 +66,7 @@ constexpr int8_t OTR_G_DL_INDEX = OPCODE(0x3d);
 constexpr int8_t OTR_G_READFB = OPCODE(0x3e);
 constexpr int8_t OTR_G_REGBLENDEDTEX = OPCODE(0x3f);
 constexpr int8_t OTR_G_SETINTENSITY = OPCODE(0x40);
+constexpr int8_t OTR_G_SETSCREENXOFFSET = OPCODE(0x41);
 constexpr int8_t OTR_G_MOVEMEM_HASH = OPCODE(0x42);
 constexpr int8_t OTR_G_PUSH_SHADER = OPCODE(0x43);
 constexpr int8_t OTR_G_POP_SHADER = OPCODE(0x44);

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -75,7 +75,6 @@ namespace Fast {
 
 static UcodeHandlers ucode_handler_index = ucode_f3dex2;
 
-
 static float sScreenXOffset = 0.0f;
 const static uint32_t f3dex2AttrHandler[] = {
     F3DEX2_G_MTX_PROJECTION, F3DEX2_G_MTX_LOAD,  F3DEX2_G_MTX_PUSH,  F3DEX_G_MTX_NOPUSH,
@@ -1608,11 +1607,9 @@ void Interpreter::GfxSpVertex(size_t n_vertices, size_t dest_index, const F3DVtx
 
         x = AdjXForAspectRatio(x);
 
-
         if (sScreenXOffset != 0.0f && mNativeDimensions.width > 0) {
             const float aspectScale = AdjXForAspectRatio(1.0f);
-            const float clipShift =
-                (2.0f * sScreenXOffset / (float)mNativeDimensions.width) * aspectScale;
+            const float clipShift = (2.0f * sScreenXOffset / (float)mNativeDimensions.width) * aspectScale;
             x += w * clipShift;
         }
         short U = v->tc[0] * mRsp->texture_scaling_factor.s >> 16;
@@ -4736,7 +4733,7 @@ static constexpr UcodeHandler otrHandlers = {
       { "G_REGBLENDEDTEX", gfx_register_blended_texture_handler_custom } },         // G_REGBLENDEDTEX (0x3f)
     { OTR_G_SETINTENSITY, { "G_SETINTENSITY", gfx_set_intensity_handler_custom } }, // G_SETINTENSITY (0x40)
     { OTR_G_SETSCREENXOFFSET, { "G_SETSCREENXOFFSET", gfx_set_screen_x_offset_handler_custom } },
-    { OTR_G_MOVEMEM_HASH, { "OTR_G_MOVEMEM_HASH", gfx_movemem_handler_otr } },      // OTR_G_MOVEMEM_HASH
+    { OTR_G_MOVEMEM_HASH, { "OTR_G_MOVEMEM_HASH", gfx_movemem_handler_otr } }, // OTR_G_MOVEMEM_HASH
     { OTR_G_PUSH_SHADER, { "G_PUSH_SHADER", gfx_push_shader } },
     { OTR_G_POP_SHADER, { "G_POP_SHADER", gfx_pop_shader } },
     { RDP_G_LOADBLOCK_WIDE, { "G_LOADBLOCK_WIDE", gfx_load_block_wide_handler_rdp } }, // RDP_G_LOADBLOCK_WIDE (-15)

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -75,6 +75,8 @@ namespace Fast {
 
 static UcodeHandlers ucode_handler_index = ucode_f3dex2;
 
+
+static float sScreenXOffset = 0.0f;
 const static uint32_t f3dex2AttrHandler[] = {
     F3DEX2_G_MTX_PROJECTION, F3DEX2_G_MTX_LOAD,  F3DEX2_G_MTX_PUSH,  F3DEX_G_MTX_NOPUSH,
     F3DEX2_G_CULL_FRONT,     F3DEX2_G_CULL_BACK, F3DEX2_G_CULL_BOTH,
@@ -1606,6 +1608,13 @@ void Interpreter::GfxSpVertex(size_t n_vertices, size_t dest_index, const F3DVtx
 
         x = AdjXForAspectRatio(x);
 
+
+        if (sScreenXOffset != 0.0f && mNativeDimensions.width > 0) {
+            const float aspectScale = AdjXForAspectRatio(1.0f);
+            const float clipShift =
+                (2.0f * sScreenXOffset / (float)mNativeDimensions.width) * aspectScale;
+            x += w * clipShift;
+        }
         short U = v->tc[0] * mRsp->texture_scaling_factor.s >> 16;
         short V = v->tc[1] * mRsp->texture_scaling_factor.t >> 16;
 
@@ -4611,6 +4620,13 @@ bool gfx_obj_rectangle_handler_s2dex(F3DGfx** cmd0) {
     return false;
 }
 
+bool gfx_set_screen_x_offset_handler_custom(F3DGfx** cmd0) {
+    F3DGfx* cmd = *(cmd0);
+    const int32_t shiftQ4 = (int32_t)(uint32_t)cmd->words.w1;
+    sScreenXOffset = (float)shiftQ4 / 4.0f;
+    return false;
+}
+
 bool gfx_extra_geometry_mode_handler_custom(F3DGfx** cmd0) {
     Interpreter* gfx = mInstance.lock().get();
     F3DGfx* cmd = *(cmd0);
@@ -4719,6 +4735,7 @@ static constexpr UcodeHandler otrHandlers = {
     { OTR_G_REGBLENDEDTEX,
       { "G_REGBLENDEDTEX", gfx_register_blended_texture_handler_custom } },         // G_REGBLENDEDTEX (0x3f)
     { OTR_G_SETINTENSITY, { "G_SETINTENSITY", gfx_set_intensity_handler_custom } }, // G_SETINTENSITY (0x40)
+    { OTR_G_SETSCREENXOFFSET, { "G_SETSCREENXOFFSET", gfx_set_screen_x_offset_handler_custom } },
     { OTR_G_MOVEMEM_HASH, { "OTR_G_MOVEMEM_HASH", gfx_movemem_handler_otr } },      // OTR_G_MOVEMEM_HASH
     { OTR_G_PUSH_SHADER, { "G_PUSH_SHADER", gfx_push_shader } },
     { OTR_G_POP_SHADER, { "G_POP_SHADER", gfx_pop_shader } },
@@ -4926,6 +4943,7 @@ static void gfx_step() {
 }
 
 void Interpreter::SpReset() {
+    sScreenXOffset = 0.0f;
     while (!mShaderStack.empty()) {
         mShaderStack.pop();
     }

--- a/src/libultraship/window/gui/GfxDebuggerWindow.cpp
+++ b/src/libultraship/window/gui/GfxDebuggerWindow.cpp
@@ -522,6 +522,13 @@ void GfxDebuggerWindow::DrawDisasNode(const F3DGfx* cmd, std::vector<const F3DGf
                 break;
             }
 
+            case OTR_G_SETSCREENXOFFSET: {
+                const int32_t shiftQ4 = (int32_t)(uint32_t)cmd->words.w1;
+                nodeWithText(cmd0, fmt::format("G_SETSCREENXOFFSET: {}", (float)shiftQ4 / 4.0f));
+                cmd++;
+                break;
+            }
+
             case OTR_G_EXTRAGEOMETRYMODE: {
                 uint32_t setBits = (uint32_t)cmd->words.w1;
                 uint32_t clearBits = ~C0(0, 24);


### PR DESCRIPTION
## Summary

Adds a graphics command for temporarily applying a horizontal screen-space offset to projected geometry.

This adds:

- `OTR_G_SETSCREENXOFFSET`
- Interpreter support for applying the offset after aspect-ratio adjustment
- Reset handling for the offset state
- GfxDebugger support for displaying the command

## Motivation

This allows projected geometry to be repositioned horizontally without changing its apparent scale.

Applying the adjustment in screen space avoids unwanted scaling that can occur when position adjustments are made earlier in the projection process.

## Testing

- Builds successfully
- Tested with the Lighthouse 3D HUD fix
- 3D HUD models retain their correct scale while repositioning
- `git diff --check` passes