### PR TITLE
Add G_SETTIMG_PAL, G_INVAL_TEX_BY_PAL, gDPReadFBToI8 and G_SET_STRICT_DECAL opcodes

### DIFF
--- a/include/fast/backends/gfx_direct3d_common.h
+++ b/include/fast/backends/gfx_direct3d_common.h
@@ -132,6 +132,7 @@ class GfxRenderingAPIDX11 final : public GfxRenderingAPI {
     void SetDepthTestAndMask(bool depth_test, bool z_upd) override;
     void SetCurrentPrimDepth(float depth) override;
     void SetZmodeDecal(bool decal) override;
+    void SetStrictDecal(bool on) override;
     void SetViewport(int x, int y, int width, int height) override;
     void SetScissor(int x, int y, int width, int height) override;
     void SetUseAlpha(bool useAlpha) override;

--- a/include/fast/backends/gfx_metal.h
+++ b/include/fast/backends/gfx_metal.h
@@ -126,6 +126,7 @@ struct FramebufferMetal {
     int8_t mLastDepthTest = -1;
     int8_t mLastDepthMask = -1;
     int8_t mLastZmodeDecal = -1;
+    int8_t mLastStrictDecal = -1;
 
     // When true, command buffer is created on the readback queue (no enqueue ordering).
     // First ReadFramebufferToCPU returns zeros and flips this; real data from frame 2+.
@@ -175,6 +176,7 @@ class GfxRenderingAPIMetal final : public GfxRenderingAPI {
     void SetDepthTestAndMask(bool depth_test, bool z_upd) override;
     void SetCurrentPrimDepth(float depth) override;
     void SetZmodeDecal(bool decal) override;
+    void SetStrictDecal(bool on) override;
     void SetViewport(int x, int y, int width, int height) override;
     void SetScissor(int x, int y, int width, int height) override;
     void SetUseAlpha(bool useAlpha) override;

--- a/include/fast/backends/gfx_opengl.h
+++ b/include/fast/backends/gfx_opengl.h
@@ -102,6 +102,7 @@ class GfxRenderingAPIOGL final : public GfxRenderingAPI {
     void SetDepthTestAndMask(bool depth_test, bool z_upd) override;
     void SetCurrentPrimDepth(float depth) override;
     void SetZmodeDecal(bool decal) override;
+    void SetStrictDecal(bool on) override;
     void SetViewport(int x, int y, int width, int height) override;
     void SetScissor(int x, int y, int width, int height) override;
     void SetUseAlpha(bool useAlpha) override;

--- a/include/fast/backends/gfx_rendering_api.h
+++ b/include/fast/backends/gfx_rendering_api.h
@@ -45,6 +45,7 @@ class GfxRenderingAPI {
     virtual void SetSamplerParameters(int sampler, bool linear_filter, uint32_t cms, uint32_t cmt) = 0;
     virtual void SetDepthTestAndMask(bool depth_test, bool z_upd) = 0;
     virtual void SetZmodeDecal(bool decal) = 0;
+    virtual void SetStrictDecal(bool on) = 0;
     virtual void SetViewport(int x, int y, int width, int height) = 0;
     virtual void SetScissor(int x, int y, int width, int height) = 0;
     virtual void SetUseAlpha(bool useAlpha) = 0;
@@ -84,9 +85,11 @@ class GfxRenderingAPI {
     int8_t mCurrentDepthTest = 0;
     int8_t mCurrentDepthMask = 0;
     int8_t mCurrentZmodeDecal = 0;
+    int8_t mCurrentStrictDecal = 0;
     int8_t mLastDepthTest = -1;
     int8_t mLastDepthMask = -1;
     int8_t mLastZmodeDecal = -1;
+    int8_t mLastStrictDecal = -1;
     bool mSrgbMode = false;
     float mCurrentPrimDepth = 0.0f;
     bool mPrimDepthDirty = true;

--- a/include/fast/interpreter.h
+++ b/include/fast/interpreter.h
@@ -433,6 +433,7 @@ class Interpreter {
     std::shared_ptr<Ship::IResource> ResolveResourceCached(const char* path);
     bool TextureCacheLookup(int i, const TextureCacheKey& key);
     void TextureCacheDelete(const uint8_t* origAddr);
+    void TextureCacheDeleteByPalette(const uint8_t* palAddr);
     void ImportTextureRgba16(int tile, bool importReplacement);
     void ImportTextureRgba32(int tile, bool importReplacement);
     void ImportTextureIA4(int tile, bool importReplacement);

--- a/include/fast/lus_gbi.h
+++ b/include/fast/lus_gbi.h
@@ -77,6 +77,7 @@ constexpr int8_t RDP_G_VTX_WIDE = OPCODE(0x48);
 constexpr int8_t RDP_G_TRI1_WIDE = OPCODE(0x49);
 constexpr int8_t RDP_G_SETTILESIZE_LERP = OPCODE(0x4a);
 constexpr int8_t OTR_G_INVAL_TEX_BY_PAL = OPCODE(0x4C);
+constexpr int8_t OTR_G_SET_STRICT_DECAL = OPCODE(0x4B);
 
 /*
  * The following commands are the "generated" RDP commands; the user

--- a/include/fast/lus_gbi.h
+++ b/include/fast/lus_gbi.h
@@ -66,6 +66,7 @@ constexpr int8_t OTR_G_DL_INDEX = OPCODE(0x3d);
 constexpr int8_t OTR_G_READFB = OPCODE(0x3e);
 constexpr int8_t OTR_G_REGBLENDEDTEX = OPCODE(0x3f);
 constexpr int8_t OTR_G_SETINTENSITY = OPCODE(0x40);
+constexpr int8_t OTR_G_SETTIMG_PAL = OPCODE(0x41);
 constexpr int8_t OTR_G_MOVEMEM_HASH = OPCODE(0x42);
 constexpr int8_t OTR_G_PUSH_SHADER = OPCODE(0x43);
 constexpr int8_t OTR_G_POP_SHADER = OPCODE(0x44);
@@ -75,6 +76,7 @@ constexpr int8_t RDP_G_LOADBLOCK_WIDE = OPCODE(0x47);
 constexpr int8_t RDP_G_VTX_WIDE = OPCODE(0x48);
 constexpr int8_t RDP_G_TRI1_WIDE = OPCODE(0x49);
 constexpr int8_t RDP_G_SETTILESIZE_LERP = OPCODE(0x4a);
+constexpr int8_t OTR_G_INVAL_TEX_BY_PAL = OPCODE(0x4C);
 
 /*
  * The following commands are the "generated" RDP commands; the user

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -191,12 +191,14 @@
 #define G_IMAGERECT 0x3c
 #define G_DL_INDEX 0x3d
 #define G_READFB 0x3e
+#define G_SETTIMG_PAL 0x41
 #define G_SETINTENSITY 0x40
 #define G_PUSH_SHADER 0x43
 #define G_POP_SHADER 0x44
 #define G_SETTILESIZE_INTERP 0x45
 #define G_SETTARGETINTERPINDEX 0x46
 #define G_SETTILESIZE_LERP 0x4a
+#define G_INVAL_TEX_BY_PAL 0x4C
 
 /*
  * The following commands are the "generated" RDP commands; the user
@@ -2805,6 +2807,22 @@ typedef union Gfx {
         _g0->words.w1 = (uintptr_t)rgba16buf;                                                 \
         _g1->words.w0 = _SHIFTL(uly, 16, 16) | _SHIFTL(ulx, 0, 16);                           \
         _g1->words.w1 = _SHIFTL(height, 16, 16) | _SHIFTL(width, 0, 16);                      \
+    }
+
+#define gDPSetTextureImagePal(pkt, tile, palSlot)                                \
+    {                                                                            \
+        Gfx* _g = (Gfx*)(pkt);                                                  \
+                                                                                 \
+        _g->words.w0 = _SHIFTL(G_SETTIMG_PAL, 24, 8) | _SHIFTL(tile, 8, 8) |   \
+                       _SHIFTL(palSlot, 0, 8);                                   \
+        _g->words.w1 = 0;                                                        \
+    }
+
+#define gDPInvalTexByPalette(pkt, palAddr)                                       \
+    {                                                                            \
+        Gfx* _g = (Gfx*)(pkt);                                                  \
+        _g->words.w0 = _SHIFTL(G_INVAL_TEX_BY_PAL, 24, 8);                     \
+        _g->words.w1 = (uintptr_t)(palAddr);                                    \
     }
 
 #define gDPImageRectangle(pkt, x0, y0, s0, t0, x1, y1, s1, t1, tile, iw, ih) \

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -2809,6 +2809,17 @@ typedef union Gfx {
         _g1->words.w1 = _SHIFTL(height, 16, 16) | _SHIFTL(width, 0, 16);                      \
     }
 
+#define gDPReadFBToI8(pkt, src, buf, ulx, uly, width, height, bswap)                          \
+    {                                                                                         \
+        Gfx *_g0 = (Gfx*)(pkt), *_g1 = (Gfx*)(pkt);                                           \
+                                                                                              \
+        _g0->words.w0 = _SHIFTL(G_READFB, 24, 8) | _SHIFTL(1, 9, 1) |                         \
+                        _SHIFTL(bswap, 8, 1) | _SHIFTL(src, 0, 8);                            \
+        _g0->words.w1 = (uintptr_t)(buf);                                                     \
+        _g1->words.w0 = _SHIFTL(uly, 16, 16) | _SHIFTL(ulx, 0, 16);                           \
+        _g1->words.w1 = _SHIFTL(height, 16, 16) | _SHIFTL(width, 0, 16);                      \
+    }
+
 #define gDPSetTextureImagePal(pkt, tile, palSlot)                                \
     {                                                                            \
         Gfx* _g = (Gfx*)(pkt);                                                  \

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -199,6 +199,7 @@
 #define G_SETTARGETINTERPINDEX 0x46
 #define G_SETTILESIZE_LERP 0x4a
 #define G_INVAL_TEX_BY_PAL 0x4C
+#define G_SET_STRICT_DECAL 0x4B
 
 /*
  * The following commands are the "generated" RDP commands; the user
@@ -2834,6 +2835,15 @@ typedef union Gfx {
         Gfx* _g = (Gfx*)(pkt);                                                  \
         _g->words.w0 = _SHIFTL(G_INVAL_TEX_BY_PAL, 24, 8);                     \
         _g->words.w1 = (uintptr_t)(palAddr);                                    \
+    }
+
+// Toggles strict (depth-equal) decal compare for subsequent ZMODE_DEC draws,
+// restoring N64 coverage semantics. Reset to 0 after the affected draws.
+#define gSPSetStrictDecal(pkt, on)                                               \
+    {                                                                            \
+        Gfx* _g = (Gfx*)(pkt);                                                  \
+        _g->words.w0 = _SHIFTL(G_SET_STRICT_DECAL, 24, 8);                     \
+        _g->words.w1 = (uintptr_t)(on);                                         \
     }
 
 #define gDPImageRectangle(pkt, x0, y0, s0, t0, x1, y1, s1, t1, tile, iw, ih) \

--- a/include/libultraship/libultra/gbi.h
+++ b/include/libultraship/libultra/gbi.h
@@ -2810,40 +2810,38 @@ typedef union Gfx {
         _g1->words.w1 = _SHIFTL(height, 16, 16) | _SHIFTL(width, 0, 16);                      \
     }
 
-#define gDPReadFBToI8(pkt, src, buf, ulx, uly, width, height, bswap)                          \
-    {                                                                                         \
-        Gfx *_g0 = (Gfx*)(pkt), *_g1 = (Gfx*)(pkt);                                           \
-                                                                                              \
-        _g0->words.w0 = _SHIFTL(G_READFB, 24, 8) | _SHIFTL(1, 9, 1) |                         \
-                        _SHIFTL(bswap, 8, 1) | _SHIFTL(src, 0, 8);                            \
-        _g0->words.w1 = (uintptr_t)(buf);                                                     \
-        _g1->words.w0 = _SHIFTL(uly, 16, 16) | _SHIFTL(ulx, 0, 16);                           \
-        _g1->words.w1 = _SHIFTL(height, 16, 16) | _SHIFTL(width, 0, 16);                      \
+#define gDPReadFBToI8(pkt, src, buf, ulx, uly, width, height, bswap)                                             \
+    {                                                                                                            \
+        Gfx *_g0 = (Gfx*)(pkt), *_g1 = (Gfx*)(pkt);                                                              \
+                                                                                                                 \
+        _g0->words.w0 = _SHIFTL(G_READFB, 24, 8) | _SHIFTL(1, 9, 1) | _SHIFTL(bswap, 8, 1) | _SHIFTL(src, 0, 8); \
+        _g0->words.w1 = (uintptr_t)(buf);                                                                        \
+        _g1->words.w0 = _SHIFTL(uly, 16, 16) | _SHIFTL(ulx, 0, 16);                                              \
+        _g1->words.w1 = _SHIFTL(height, 16, 16) | _SHIFTL(width, 0, 16);                                         \
     }
 
-#define gDPSetTextureImagePal(pkt, tile, palSlot)                                \
-    {                                                                            \
-        Gfx* _g = (Gfx*)(pkt);                                                  \
-                                                                                 \
-        _g->words.w0 = _SHIFTL(G_SETTIMG_PAL, 24, 8) | _SHIFTL(tile, 8, 8) |   \
-                       _SHIFTL(palSlot, 0, 8);                                   \
-        _g->words.w1 = 0;                                                        \
+#define gDPSetTextureImagePal(pkt, tile, palSlot)                                                    \
+    {                                                                                                \
+        Gfx* _g = (Gfx*)(pkt);                                                                       \
+                                                                                                     \
+        _g->words.w0 = _SHIFTL(G_SETTIMG_PAL, 24, 8) | _SHIFTL(tile, 8, 8) | _SHIFTL(palSlot, 0, 8); \
+        _g->words.w1 = 0;                                                                            \
     }
 
-#define gDPInvalTexByPalette(pkt, palAddr)                                       \
-    {                                                                            \
-        Gfx* _g = (Gfx*)(pkt);                                                  \
-        _g->words.w0 = _SHIFTL(G_INVAL_TEX_BY_PAL, 24, 8);                     \
-        _g->words.w1 = (uintptr_t)(palAddr);                                    \
+#define gDPInvalTexByPalette(pkt, palAddr)                 \
+    {                                                      \
+        Gfx* _g = (Gfx*)(pkt);                             \
+        _g->words.w0 = _SHIFTL(G_INVAL_TEX_BY_PAL, 24, 8); \
+        _g->words.w1 = (uintptr_t)(palAddr);               \
     }
 
 // Toggles strict (depth-equal) decal compare for subsequent ZMODE_DEC draws,
 // restoring N64 coverage semantics. Reset to 0 after the affected draws.
-#define gSPSetStrictDecal(pkt, on)                                               \
-    {                                                                            \
-        Gfx* _g = (Gfx*)(pkt);                                                  \
-        _g->words.w0 = _SHIFTL(G_SET_STRICT_DECAL, 24, 8);                     \
-        _g->words.w1 = (uintptr_t)(on);                                         \
+#define gSPSetStrictDecal(pkt, on)                         \
+    {                                                      \
+        Gfx* _g = (Gfx*)(pkt);                             \
+        _g->words.w0 = _SHIFTL(G_SET_STRICT_DECAL, 24, 8); \
+        _g->words.w1 = (uintptr_t)(on);                    \
     }
 
 #define gDPImageRectangle(pkt, x0, y0, s0, t0, x1, y1, s1, t1, tile, iw, ih) \

--- a/src/fast/backends/gfx_direct3d11.cpp
+++ b/src/fast/backends/gfx_direct3d11.cpp
@@ -645,6 +645,10 @@ void GfxRenderingAPIDX11::SetZmodeDecal(bool zmode_decal) {
     mCurrentZmodeDecal = zmode_decal;
 }
 
+void GfxRenderingAPIDX11::SetStrictDecal(bool on) {
+    mCurrentStrictDecal = on;
+}
+
 void GfxRenderingAPIDX11::SetViewport(int x, int y, int width, int height) {
     D3D11_VIEWPORT viewport;
     viewport.TopLeftX = x;
@@ -673,9 +677,11 @@ void GfxRenderingAPIDX11::SetUseAlpha(bool use_alpha) {
 
 void GfxRenderingAPIDX11::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, size_t buf_vbo_num_tris) {
 
-    if (mLastDepthTest != mCurrentDepthTest || mLastDepthMask != mCurrentDepthMask) {
+    if (mLastDepthTest != mCurrentDepthTest || mLastDepthMask != mCurrentDepthMask ||
+        mLastStrictDecal != mCurrentStrictDecal || mLastZmodeDecal != mCurrentZmodeDecal) {
         mLastDepthTest = mCurrentDepthTest;
         mLastDepthMask = mCurrentDepthMask;
+        mLastStrictDecal = mCurrentStrictDecal;
 
         mDepthStencilState.Reset();
 
@@ -685,9 +691,11 @@ void GfxRenderingAPIDX11::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, siz
         depth_stencil_desc.DepthEnable = mCurrentDepthTest || mCurrentDepthMask;
         depth_stencil_desc.DepthWriteMask =
             mCurrentDepthMask ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
-        depth_stencil_desc.DepthFunc = mCurrentDepthTest
-                                           ? (mCurrentZmodeDecal ? D3D11_COMPARISON_LESS_EQUAL : D3D11_COMPARISON_LESS)
-                                           : D3D11_COMPARISON_ALWAYS;
+        depth_stencil_desc.DepthFunc =
+            mCurrentDepthTest
+                ? (mCurrentZmodeDecal ? (mCurrentStrictDecal ? D3D11_COMPARISON_EQUAL : D3D11_COMPARISON_LESS_EQUAL)
+                                      : D3D11_COMPARISON_LESS)
+                : D3D11_COMPARISON_ALWAYS;
         depth_stencil_desc.StencilEnable = false;
 
         ThrowIfFailed(mDevice->CreateDepthStencilState(&depth_stencil_desc, mDepthStencilState.GetAddressOf()));
@@ -723,7 +731,7 @@ void GfxRenderingAPIDX11::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, siz
             default:
                 SSDB = -2;
         }
-        rasterizer_desc.SlopeScaledDepthBias = mCurrentZmodeDecal ? SSDB : 0.0f;
+        rasterizer_desc.SlopeScaledDepthBias = (mCurrentZmodeDecal && !mCurrentStrictDecal) ? SSDB : 0.0f;
         rasterizer_desc.DepthBiasClamp = 0.0f;
         rasterizer_desc.DepthClipEnable = false;
         rasterizer_desc.ScissorEnable = true;

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -422,6 +422,10 @@ void GfxRenderingAPIMetal::SetZmodeDecal(bool zmode_decal) {
     mCurrentZmodeDecal = zmode_decal;
 }
 
+void GfxRenderingAPIMetal::SetStrictDecal(bool on) {
+    mCurrentStrictDecal = on;
+}
+
 void GfxRenderingAPIMetal::SetViewport(int x, int y, int width, int height) {
     FramebufferMetal& fb = mFramebuffers[mCurrentFramebuffer];
 
@@ -459,14 +463,19 @@ void GfxRenderingAPIMetal::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, si
     auto& current_framebuffer = mFramebuffers[mCurrentFramebuffer];
 
     if (current_framebuffer.mLastDepthTest != mCurrentDepthTest ||
-        current_framebuffer.mLastDepthMask != mCurrentDepthMask) {
+        current_framebuffer.mLastDepthMask != mCurrentDepthMask ||
+        current_framebuffer.mLastStrictDecal != mCurrentStrictDecal ||
+        current_framebuffer.mLastZmodeDecal != mCurrentZmodeDecal) {
         current_framebuffer.mLastDepthTest = mCurrentDepthTest;
         current_framebuffer.mLastDepthMask = mCurrentDepthMask;
+        current_framebuffer.mLastStrictDecal = mCurrentStrictDecal;
 
         MTL::DepthStencilDescriptor* depth_descriptor = MTL::DepthStencilDescriptor::alloc()->init();
         depth_descriptor->setDepthWriteEnabled(mCurrentDepthMask);
         depth_descriptor->setDepthCompareFunction(
-            mCurrentDepthTest ? (mCurrentZmodeDecal ? MTL::CompareFunctionLessEqual : MTL::CompareFunctionLess)
+            mCurrentDepthTest ? (mCurrentZmodeDecal
+                                     ? (mCurrentStrictDecal ? MTL::CompareFunctionEqual : MTL::CompareFunctionLessEqual)
+                                     : MTL::CompareFunctionLess)
                               : MTL::CompareFunctionAlways);
 
         MTL::DepthStencilState* depth_stencil_state = mDevice->newDepthStencilState(depth_descriptor);
@@ -498,7 +507,8 @@ void GfxRenderingAPIMetal::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, si
             default:
                 SSDB = -2;
         }
-        current_framebuffer.mCommandEncoder->setDepthBias(0, mCurrentZmodeDecal ? SSDB : 0, 0);
+        current_framebuffer.mCommandEncoder->setDepthBias(0, (mCurrentZmodeDecal && !mCurrentStrictDecal) ? SSDB : 0,
+                                                          0);
     }
 
     MTL::Buffer* vertex_buffer = mVertexBufferPool[mCurrentVertexBufferPoolIndex];
@@ -665,6 +675,7 @@ void GfxRenderingAPIMetal::EndFrame() {
         fb.mLastDepthTest = -1;
         fb.mLastDepthMask = -1;
         fb.mLastZmodeDecal = -1;
+        fb.mLastStrictDecal = -1;
     }
 
     mFrameAutoreleasePool->release();
@@ -969,6 +980,7 @@ void GfxRenderingAPIMetal::ClearFramebuffer(bool color, bool depth) {
     framebuffer.mLastDepthTest = -1;
     framebuffer.mLastDepthMask = -1;
     framebuffer.mLastZmodeDecal = -1;
+    framebuffer.mLastStrictDecal = -1;
 }
 
 void GfxRenderingAPIMetal::ResolveMSAAColorBuffer(int fb_id_target, int fb_id_source) {
@@ -1180,6 +1192,7 @@ void GfxRenderingAPIMetal::CopyFramebuffer(int fb_dst_id, int fb_src_id, int src
     source_framebuffer.mLastDepthTest = -1;
     source_framebuffer.mLastDepthMask = -1;
     source_framebuffer.mLastZmodeDecal = -1;
+    source_framebuffer.mLastStrictDecal = -1;
 }
 
 void GfxRenderingAPIMetal::ReadFramebufferToCPU(int fb_id, uint32_t width, uint32_t height, uint16_t* rgba16_buf) {

--- a/src/fast/backends/gfx_opengl.cpp
+++ b/src/fast/backends/gfx_opengl.cpp
@@ -636,6 +636,10 @@ void GfxRenderingAPIOGL::SetZmodeDecal(bool zmode_decal) {
     mCurrentZmodeDecal = zmode_decal;
 }
 
+void GfxRenderingAPIOGL::SetStrictDecal(bool on) {
+    mCurrentStrictDecal = on;
+}
+
 void GfxRenderingAPIOGL::SetViewport(int x, int y, int width, int height) {
     glViewport(x, y, width, height);
 }
@@ -657,14 +661,18 @@ void GfxRenderingAPIOGL::SetUseAlpha(bool use_alpha) {
 }
 
 void GfxRenderingAPIOGL::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, size_t buf_vbo_num_tris) {
-    if (mCurrentDepthTest != mLastDepthTest || mCurrentDepthMask != mLastDepthMask) {
+    if (mCurrentDepthTest != mLastDepthTest || mCurrentDepthMask != mLastDepthMask ||
+        mCurrentStrictDecal != mLastStrictDecal || mCurrentZmodeDecal != mLastZmodeDecal) {
         mLastDepthTest = mCurrentDepthTest;
         mLastDepthMask = mCurrentDepthMask;
+        mLastStrictDecal = mCurrentStrictDecal;
 
         if (mCurrentDepthTest || mLastDepthMask) {
             glEnable(GL_DEPTH_TEST);
             glDepthMask(mLastDepthMask ? GL_TRUE : GL_FALSE);
-            glDepthFunc(mCurrentDepthTest ? (mCurrentZmodeDecal ? GL_LEQUAL : GL_LESS) : GL_ALWAYS);
+            glDepthFunc(mCurrentDepthTest
+                            ? (mCurrentZmodeDecal ? (mCurrentStrictDecal ? GL_EQUAL : GL_LEQUAL) : GL_LESS)
+                            : GL_ALWAYS);
         } else {
             glDisable(GL_DEPTH_TEST);
         }
@@ -672,7 +680,7 @@ void GfxRenderingAPIOGL::DrawTriangles(float buf_vbo[], size_t buf_vbo_len, size
 
     if (mCurrentZmodeDecal != mLastZmodeDecal) {
         mLastZmodeDecal = mCurrentZmodeDecal;
-        if (mCurrentZmodeDecal) {
+        if (mCurrentZmodeDecal && !mCurrentStrictDecal) {
             // SSDB = SlopeScaledDepthBias 120 leads to -2 at 240p which is the same as N64 mode which has very little
             // fighting
             const int n64modeFactor = 120;

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -575,7 +575,7 @@ void Interpreter::TextureCacheDelete(const uint8_t* origAddr) {
 // command encoder would otherwise let earlier draws sample the later draw's
 // replaceRegion'd content when a texture_id is reused.
 void Interpreter::TextureCacheDeleteByPalette(const uint8_t* palAddr) {
-    for (auto it = mTextureCache.map.begin(); it != mTextureCache.map.end(); ) {
+    for (auto it = mTextureCache.map.begin(); it != mTextureCache.map.end();) {
         if (it->first.palette_addrs[0] == palAddr || it->first.palette_addrs[1] == palAddr) {
             for (int j = 0; j < SHADER_MAX_TEXTURES; j++) {
                 if (mRenderingState.mTextures[j] == &*it)
@@ -4187,9 +4187,8 @@ bool gfx_set_timg_pal_handler_custom(F3DGfx** cmd0) {
     // Use palette_dram_addr (the game-side pointer) as the texture address.
     // Cache key uniqueness: palette_dram_addr changes per sprite, preventing
     // stale texture cache hits (palette_staging is always the same pointer).
-    const uint8_t* texAddr = gfx->mRdp->palette_dram_addr[palSlot] != nullptr
-                                 ? gfx->mRdp->palette_dram_addr[palSlot]
-                                 : gfx->mRdp->palettes[palSlot];
+    const uint8_t* texAddr = gfx->mRdp->palette_dram_addr[palSlot] != nullptr ? gfx->mRdp->palette_dram_addr[palSlot]
+                                                                              : gfx->mRdp->palettes[palSlot];
     uint32_t lineSizeBytes = gfx->mRdp->texture_tile[tile].line_size_bytes;
     if (lineSizeBytes == 0) {
         lineSizeBytes = 256;
@@ -4233,6 +4232,14 @@ bool gfx_inval_tex_by_pal_handler_custom(F3DGfx** cmd0) {
     if (palAddr != nullptr) {
         gfx->TextureCacheDeleteByPalette(palAddr);
     }
+    return false;
+}
+
+bool gfx_set_strict_decal_handler_custom(F3DGfx** cmd0) {
+    Interpreter* gfx = mInstance.lock().get();
+    F3DGfx* cmd = *cmd0;
+    gfx->Flush();
+    gfx->mRapi->SetStrictDecal(cmd->words.w1 != 0);
     return false;
 }
 
@@ -4847,7 +4854,7 @@ static constexpr UcodeHandler otrHandlers = {
     { OTR_G_REGBLENDEDTEX,
       { "G_REGBLENDEDTEX", gfx_register_blended_texture_handler_custom } },         // G_REGBLENDEDTEX (0x3f)
     { OTR_G_SETINTENSITY, { "G_SETINTENSITY", gfx_set_intensity_handler_custom } }, // G_SETINTENSITY (0x40)
-    { OTR_G_SETTIMG_PAL, { "G_SETTIMG_PAL", gfx_set_timg_pal_handler_custom } },  // G_SETTIMG_PAL (0x41)
+    { OTR_G_SETTIMG_PAL, { "G_SETTIMG_PAL", gfx_set_timg_pal_handler_custom } },    // G_SETTIMG_PAL (0x41)
     { OTR_G_MOVEMEM_HASH, { "OTR_G_MOVEMEM_HASH", gfx_movemem_handler_otr } },      // OTR_G_MOVEMEM_HASH
     { OTR_G_PUSH_SHADER, { "G_PUSH_SHADER", gfx_push_shader } },
     { OTR_G_POP_SHADER, { "G_POP_SHADER", gfx_pop_shader } },
@@ -4855,6 +4862,7 @@ static constexpr UcodeHandler otrHandlers = {
     { RDP_G_VTX_WIDE, { "G_VTX_WIDE", gfx_vtx_handler_f3dex2 } },                      // RDP_G_VTX_WIDE (-16)
     { RDP_G_TRI1_WIDE, { "G_TRI1_WIDE", gfx_tri1_handler_f3dex2 } },                   // RDP_G_TRI1_WIDE (-17)
     { OTR_G_INVAL_TEX_BY_PAL, { "G_INVAL_TEX_BY_PAL", gfx_inval_tex_by_pal_handler_custom } },
+    { OTR_G_SET_STRICT_DECAL, { "G_SET_STRICT_DECAL", gfx_set_strict_decal_handler_custom } },
 };
 
 static constexpr UcodeHandler f3dex2Handlers = {

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -4287,6 +4287,7 @@ bool gfx_read_fb_handler_custom(F3DGfx** cmd0) {
     uint16_t* rgba16Buffer = (uint16_t*)cmd->words.w1;
     int fbId = C0(0, 8);
     bool bswap = C0(8, 1);
+    bool toI8 = C0(9, 1);
     ++(*cmd0);
     cmd = *cmd0;
     // Specifying the upper left origin value is unused and unsupported at the renderer level
@@ -4306,6 +4307,16 @@ bool gfx_read_fb_handler_custom(F3DGfx** cmd0) {
         }
     }
 #endif
+
+    if (toI8) {
+        uint8_t* dst = (uint8_t*)rgba16Buffer;
+        size_t count = (size_t)width * height;
+        for (size_t i = 0; i < count; i++) {
+            uint16_t px = rgba16Buffer[i];
+            uint8_t r5 = (px >> 11) & 0x1F;
+            dst[i] = (r5 << 3) | (r5 >> 2); // 5-bit → 8-bit
+        }
+    }
 
     return false;
 }

--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -570,6 +570,25 @@ void Interpreter::TextureCacheDelete(const uint8_t* origAddr) {
     }
 }
 
+// Invalidate cache entries whose key references the given palette DRAM addr.
+// Note: skips the free_texture_ids recycle by design — Metal's deferred
+// command encoder would otherwise let earlier draws sample the later draw's
+// replaceRegion'd content when a texture_id is reused.
+void Interpreter::TextureCacheDeleteByPalette(const uint8_t* palAddr) {
+    for (auto it = mTextureCache.map.begin(); it != mTextureCache.map.end(); ) {
+        if (it->first.palette_addrs[0] == palAddr || it->first.palette_addrs[1] == palAddr) {
+            for (int j = 0; j < SHADER_MAX_TEXTURES; j++) {
+                if (mRenderingState.mTextures[j] == &*it)
+                    mRenderingState.mTextures[j] = nullptr;
+            }
+            mTextureCache.lru.erase(it->second.lru_location);
+            it = mTextureCache.map.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
 // Pick the per-line byte width for texture decode. Prefer the DRAM stride from
 // loaded_texture when it looks like real per-line info (differs from total size).
 // Fall back to the TMEM tile stride when loaded sizes match total (LoadBlock with
@@ -4150,6 +4169,73 @@ bool gfx_set_timg_otr_filepath_handler_custom(F3DGfx** cmd0) {
     return false;
 }
 
+// G_SETTIMG_PAL: Expose palette_staging data as a texture source
+bool gfx_set_timg_pal_handler_custom(F3DGfx** cmd0) {
+    Interpreter* gfx = mInstance.lock().get();
+    F3DGfx* cmd = *cmd0;
+
+    uint8_t tile = C0(8, 8);
+    uint8_t palSlot = C0(0, 8);
+
+    if (palSlot > 1 || gfx->mRdp->palettes[palSlot] == nullptr) {
+        SPDLOG_WARN("G_SETTIMG_PAL: invalid palSlot={} or null palette", palSlot);
+        return false;
+    }
+
+    uint32_t tmemIndex = gfx->mRdp->texture_tile[tile].tmem_index;
+
+    // Use palette_dram_addr (the game-side pointer) as the texture address.
+    // Cache key uniqueness: palette_dram_addr changes per sprite, preventing
+    // stale texture cache hits (palette_staging is always the same pointer).
+    const uint8_t* texAddr = gfx->mRdp->palette_dram_addr[palSlot] != nullptr
+                                 ? gfx->mRdp->palette_dram_addr[palSlot]
+                                 : gfx->mRdp->palettes[palSlot];
+    uint32_t lineSizeBytes = gfx->mRdp->texture_tile[tile].line_size_bytes;
+    if (lineSizeBytes == 0) {
+        lineSizeBytes = 256;
+    }
+
+    gfx->TextureCacheDelete(texAddr);
+    if (gfx->mRdp->palettes[palSlot] != texAddr) {
+        gfx->TextureCacheDelete(gfx->mRdp->palettes[palSlot]);
+    }
+
+    gfx->mRdp->loaded_texture[tmemIndex].addr = texAddr;
+    gfx->mRdp->loaded_texture[tmemIndex].size_bytes = lineSizeBytes;
+    gfx->mRdp->loaded_texture[tmemIndex].orig_size_bytes = lineSizeBytes;
+    // GetEffectiveLineSize() falls back to tile.line_size_bytes when size,
+    // line_size, and full_image_line_size are all equal — the tile stride is
+    // configured for palette indexing, not raw-texel sampling, so that fallback
+    // would produce garbage. The +1 on full_image_line_size is a tag that
+    // trips the "line differs from total" check; it only affects the equality
+    // test, never actual reads.
+    gfx->mRdp->loaded_texture[tmemIndex].line_size_bytes = lineSizeBytes;
+    gfx->mRdp->loaded_texture[tmemIndex].full_image_line_size_bytes = lineSizeBytes + 1;
+    gfx->mRdp->loaded_texture[tmemIndex].tex_flags = 0;
+    gfx->mRdp->loaded_texture[tmemIndex].raw_tex_metadata = {};
+    gfx->mRdp->loaded_texture[tmemIndex].masked = false;
+    gfx->mRdp->loaded_texture[tmemIndex].blended = false;
+    gfx->mRdp->textures_changed[0] = true;
+    gfx->mRdp->textures_changed[1] = true;
+
+    return false;
+}
+
+/// G_INVAL_TEX_BY_PAL: invalidate texture-cache entries whose key references
+// the given palette DRAM address. Emit this in the command stream whenever a
+// shared palette buffer gets rewritten between draws — without it, a later
+// draw that shares a texture bitmap with an earlier draw hits the cached GPU
+// upload baked with the earlier palette content.
+bool gfx_inval_tex_by_pal_handler_custom(F3DGfx** cmd0) {
+    Interpreter* gfx = mInstance.lock().get();
+    F3DGfx* cmd = *cmd0;
+    const uint8_t* palAddr = (const uint8_t*)(uintptr_t)cmd->words.w1;
+    if (palAddr != nullptr) {
+        gfx->TextureCacheDeleteByPalette(palAddr);
+    }
+    return false;
+}
+
 bool gfx_set_fb_handler_custom(F3DGfx** cmd0) {
     F3DGfx* cmd = *cmd0;
     Interpreter* gfx = mInstance.lock().get();
@@ -4750,12 +4836,14 @@ static constexpr UcodeHandler otrHandlers = {
     { OTR_G_REGBLENDEDTEX,
       { "G_REGBLENDEDTEX", gfx_register_blended_texture_handler_custom } },         // G_REGBLENDEDTEX (0x3f)
     { OTR_G_SETINTENSITY, { "G_SETINTENSITY", gfx_set_intensity_handler_custom } }, // G_SETINTENSITY (0x40)
+    { OTR_G_SETTIMG_PAL, { "G_SETTIMG_PAL", gfx_set_timg_pal_handler_custom } },  // G_SETTIMG_PAL (0x41)
     { OTR_G_MOVEMEM_HASH, { "OTR_G_MOVEMEM_HASH", gfx_movemem_handler_otr } },      // OTR_G_MOVEMEM_HASH
     { OTR_G_PUSH_SHADER, { "G_PUSH_SHADER", gfx_push_shader } },
     { OTR_G_POP_SHADER, { "G_POP_SHADER", gfx_pop_shader } },
     { RDP_G_LOADBLOCK_WIDE, { "G_LOADBLOCK_WIDE", gfx_load_block_wide_handler_rdp } }, // RDP_G_LOADBLOCK_WIDE (-15)
     { RDP_G_VTX_WIDE, { "G_VTX_WIDE", gfx_vtx_handler_f3dex2 } },                      // RDP_G_VTX_WIDE (-16)
     { RDP_G_TRI1_WIDE, { "G_TRI1_WIDE", gfx_tri1_handler_f3dex2 } },                   // RDP_G_TRI1_WIDE (-17)
+    { OTR_G_INVAL_TEX_BY_PAL, { "G_INVAL_TEX_BY_PAL", gfx_inval_tex_by_pal_handler_custom } },
 };
 
 static constexpr UcodeHandler f3dex2Handlers = {

--- a/src/ship/audio/CoreAudioAudioPlayer.cpp
+++ b/src/ship/audio/CoreAudioAudioPlayer.cpp
@@ -128,8 +128,7 @@ void CoreAudioAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
     size_t r = mRingBufferReadPos.load(std::memory_order_acquire);
     size_t w = mRingBufferWritePos.load(std::memory_order_relaxed);
     // free space leaves one frame reserved so write can never collide with read
-    size_t freeSpace = (w >= r) ? (mRingBufferSize - (w - r) - bytesPerFrame)
-                                : (r - w - bytesPerFrame);
+    size_t freeSpace = (w >= r) ? (mRingBufferSize - (w - r) - bytesPerFrame) : (r - w - bytesPerFrame);
 
     // Preserve producer chunk boundaries. Splitting an audio-engine buffer here
     // drops the tail of already-generated PCM and creates a discontinuity.
@@ -176,8 +175,7 @@ OSStatus CoreAudioAudioPlayer::CoreAudioRenderCallback(void* inRefCon, AudioUnit
                 memcpy(outputBuffer, player->mRingBuffer + r, firstChunk);
                 memcpy(outputBuffer + firstChunk, player->mRingBuffer, bytesToCopy - firstChunk);
             }
-            player->mRingBufferReadPos.store((r + bytesToCopy) % player->mRingBufferSize,
-                                             std::memory_order_release);
+            player->mRingBufferReadPos.store((r + bytesToCopy) % player->mRingBufferSize, std::memory_order_release);
         }
 
         if (bytesToCopy < bytesToWrite) {


### PR DESCRIPTION
Adds four GBI extension opcodes used by ports for texture-pack and decal handling:

- `G_SETTIMG_PAL` / `G_INVAL_TEX_BY_PAL` — set the palette index alongside the image pointer, and invalidate cached textures by palette, so CI textures whose palette changed re-upload correctly.
- `gDPReadFBToI8` — reads the framebuffer back into an I8 texture.
- `G_SET_STRICT_DECAL` — a strict (depth-equal) decal mode for decals that need exact depth matching instead of the SSDB bias.

All opcodes are additive; existing display lists are unaffected.

**Stacked PR** — review and merge bottom-up; until the layers below merge, each PR's diff includes them:
1. **#1257 `port/gbi-opcodes` ← this PR**
2. #1262 `port/renderer-gpu-pipeline`
3. #1263 `port/postprocessing`
4. #1264 `port/texture-streaming`
5. #1265 `port/vulkan-backend`
