### PR TITLE
Export libultra symbols with API_EXPORT

### DIFF
--- a/include/libultraship/libultra/eeprom.h
+++ b/include/libultraship/libultra/eeprom.h
@@ -1,18 +1,11 @@
 #pragma once
 
 #include "message.h"
+#include "ship/Api.h"
 
 #define EEPROM_TYPE_4K 0x01
 #define EEPROM_TYPE_16K 0x02
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-int32_t osEepromProbe(OSMesgQueue*);
-int32_t osEepromLongRead(OSMesgQueue*, uint8_t, uint8_t*, int32_t);
-int32_t osEepromLongWrite(OSMesgQueue*, uint8_t, uint8_t*, int32_t);
-
-#ifdef __cplusplus
-}
-#endif
+API_EXPORT int32_t osEepromProbe(OSMesgQueue*);
+API_EXPORT int32_t osEepromLongRead(OSMesgQueue*, uint8_t, uint8_t*, int32_t);
+API_EXPORT int32_t osEepromLongWrite(OSMesgQueue*, uint8_t, uint8_t*, int32_t);

--- a/include/libultraship/libultra/gu.h
+++ b/include/libultraship/libultra/gu.h
@@ -3,6 +3,7 @@
 #include "types.h"
 #include "gbi.h"
 #include "sptask.h"
+#include "ship/Api.h"
 
 #define GU_PI 3.1415926
 
@@ -55,15 +56,15 @@ extern "C" {
  * Function Prototypes
  */
 
-extern int guLoadTextureBlockMipMap(Gfx** glist, unsigned char* tbuf, Image* im, unsigned char startTile,
-                                    unsigned char pal, unsigned char cms, unsigned char cmt, unsigned char masks,
-                                    unsigned char maskt, unsigned char shifts, unsigned char shiftt, unsigned char cfs,
-                                    unsigned char cft);
+API_EXPORT int guLoadTextureBlockMipMap(Gfx** glist, unsigned char* tbuf, Image* im, unsigned char startTile,
+                                        unsigned char pal, unsigned char cms, unsigned char cmt, unsigned char masks,
+                                        unsigned char maskt, unsigned char shifts, unsigned char shiftt,
+                                        unsigned char cfs, unsigned char cft);
 
-extern int guGetDPLoadTextureTileSz(int ult, int lrt);
-extern void guDPLoadTextureTile(Gfx* glistp, void* timg, int texl_fmt, int texl_size, int img_width, int img_height,
-                                int uls, int ult, int lrs, int lrt, int palette, int cms, int cmt, int masks, int maskt,
-                                int shifts, int shiftt);
+API_EXPORT int guGetDPLoadTextureTileSz(int ult, int lrt);
+API_EXPORT void guDPLoadTextureTile(Gfx* glistp, void* timg, int texl_fmt, int texl_size, int img_width, int img_height,
+                                    int uls, int ult, int lrs, int lrt, int palette, int cms, int cmt, int masks,
+                                    int maskt, int shifts, int shiftt);
 
 /*
  * matrix operations:
@@ -72,61 +73,61 @@ extern void guDPLoadTextureTile(Gfx* glistp, void* timg, int texl_fmt, int texl_
  * to do matrix manipulations and convert to fixed-point at the last
  * minute.
  */
-extern void guMtxIdent(Mtx* m);
-extern void guMtxIdentF(float mf[4][4]);
-extern void guOrtho(Mtx* m, float l, float r, float b, float t, float n, float f, float scale);
-extern void guOrthoF(float mf[4][4], float l, float r, float b, float t, float n, float f, float scale);
-extern void guFrustum(Mtx* m, float l, float r, float b, float t, float n, float f, float scale);
-extern void guFrustumF(float mf[4][4], float l, float r, float b, float t, float n, float f, float scale);
-extern void guPerspective(Mtx* m, u16* perspNorm, float fovy, float aspect, float near, float far, float scale);
-extern void guPerspectiveF(float mf[4][4], u16* perspNorm, float fovy, float aspect, float near, float far,
-                           float scale);
-extern void guLookAt(Mtx* m, float xEye, float yEye, float zEye, float xAt, float yAt, float zAt, float xUp, float yUp,
-                     float zUp);
-extern void guLookAtF(float mf[4][4], float xEye, float yEye, float zEye, float xAt, float yAt, float zAt, float xUp,
-                      float yUp, float zUp);
-extern void guLookAtReflect(Mtx* m, LookAt* l, float xEye, float yEye, float zEye, float xAt, float yAt, float zAt,
-                            float xUp, float yUp, float zUp);
-extern void guLookAtReflectF(float mf[4][4], LookAt* l, float xEye, float yEye, float zEye, float xAt, float yAt,
-                             float zAt, float xUp, float yUp, float zUp);
-extern void guLookAtHilite(Mtx* m, LookAt* l, Hilite* h, float xEye, float yEye, float zEye, float xAt, float yAt,
-                           float zAt, float xUp, float yUp, float zUp, float xl1, float yl1, float zl1, float xl2,
-                           float yl2, float zl2, int twidth, int theight);
-extern void guLookAtHiliteF(float mf[4][4], LookAt* l, Hilite* h, float xEye, float yEye, float zEye, float xAt,
-                            float yAt, float zAt, float xUp, float yUp, float zUp, float xl1, float yl1, float zl1,
-                            float xl2, float yl2, float zl2, int twidth, int theight);
-extern void guLookAtStereo(Mtx* m, float xEye, float yEye, float zEye, float xAt, float yAt, float zAt, float xUp,
-                           float yUp, float zUp, float eyedist);
-extern void guLookAtStereoF(float mf[4][4], float xEye, float yEye, float zEye, float xAt, float yAt, float zAt,
-                            float xUp, float yUp, float zUp, float eyedist);
-extern void guRotate(Mtx* m, float a, float x, float y, float z);
-extern void guRotateF(float mf[4][4], float a, float x, float y, float z);
-extern void guRotateRPY(Mtx* m, float r, float p, float y);
-extern void guRotateRPYF(float mf[4][4], float r, float p, float h);
-extern void guAlign(Mtx* m, float a, float x, float y, float z);
-extern void guAlignF(float mf[4][4], float a, float x, float y, float z);
-extern void guScale(Mtx* m, float x, float y, float z);
-extern void guScaleF(float mf[4][4], float x, float y, float z);
-extern void guTranslate(Mtx* m, float x, float y, float z);
-extern void guTranslateF(float mf[4][4], float x, float y, float z);
-extern void guPosition(Mtx* m, float r, float p, float h, float s, float x, float y, float z);
-extern void guPositionF(float mf[4][4], float r, float p, float h, float s, float x, float y, float z);
-extern void guMtxF2L(float mf[4][4], Mtx* m);
-extern void guMtxL2F(float mf[4][4], Mtx* m);
-extern void guMtxCatF(float m[4][4], float n[4][4], float r[4][4]);
-extern void guMtxCatL(Mtx* m, Mtx* n, Mtx* res);
-extern void guMtxXFMF(float mf[4][4], float x, float y, float z, float* ox, float* oy, float* oz);
-extern void guMtxXFML(Mtx* m, float x, float y, float z, float* ox, float* oy, float* oz);
+API_EXPORT void guMtxIdent(Mtx* m);
+API_EXPORT void guMtxIdentF(float mf[4][4]);
+API_EXPORT void guOrtho(Mtx* m, float l, float r, float b, float t, float n, float f, float scale);
+API_EXPORT void guOrthoF(float mf[4][4], float l, float r, float b, float t, float n, float f, float scale);
+API_EXPORT void guFrustum(Mtx* m, float l, float r, float b, float t, float n, float f, float scale);
+API_EXPORT void guFrustumF(float mf[4][4], float l, float r, float b, float t, float n, float f, float scale);
+API_EXPORT void guPerspective(Mtx* m, u16* perspNorm, float fovy, float aspect, float near, float far, float scale);
+API_EXPORT void guPerspectiveF(float mf[4][4], u16* perspNorm, float fovy, float aspect, float near, float far,
+                               float scale);
+API_EXPORT void guLookAt(Mtx* m, float xEye, float yEye, float zEye, float xAt, float yAt, float zAt, float xUp,
+                         float yUp, float zUp);
+API_EXPORT void guLookAtF(float mf[4][4], float xEye, float yEye, float zEye, float xAt, float yAt, float zAt,
+                          float xUp, float yUp, float zUp);
+API_EXPORT void guLookAtReflect(Mtx* m, LookAt* l, float xEye, float yEye, float zEye, float xAt, float yAt, float zAt,
+                                float xUp, float yUp, float zUp);
+API_EXPORT void guLookAtReflectF(float mf[4][4], LookAt* l, float xEye, float yEye, float zEye, float xAt, float yAt,
+                                 float zAt, float xUp, float yUp, float zUp);
+API_EXPORT void guLookAtHilite(Mtx* m, LookAt* l, Hilite* h, float xEye, float yEye, float zEye, float xAt, float yAt,
+                               float zAt, float xUp, float yUp, float zUp, float xl1, float yl1, float zl1, float xl2,
+                               float yl2, float zl2, int twidth, int theight);
+API_EXPORT void guLookAtHiliteF(float mf[4][4], LookAt* l, Hilite* h, float xEye, float yEye, float zEye, float xAt,
+                                float yAt, float zAt, float xUp, float yUp, float zUp, float xl1, float yl1, float zl1,
+                                float xl2, float yl2, float zl2, int twidth, int theight);
+API_EXPORT void guLookAtStereo(Mtx* m, float xEye, float yEye, float zEye, float xAt, float yAt, float zAt, float xUp,
+                               float yUp, float zUp, float eyedist);
+API_EXPORT void guLookAtStereoF(float mf[4][4], float xEye, float yEye, float zEye, float xAt, float yAt, float zAt,
+                                float xUp, float yUp, float zUp, float eyedist);
+API_EXPORT void guRotate(Mtx* m, float a, float x, float y, float z);
+API_EXPORT void guRotateF(float mf[4][4], float a, float x, float y, float z);
+API_EXPORT void guRotateRPY(Mtx* m, float r, float p, float y);
+API_EXPORT void guRotateRPYF(float mf[4][4], float r, float p, float h);
+API_EXPORT void guAlign(Mtx* m, float a, float x, float y, float z);
+API_EXPORT void guAlignF(float mf[4][4], float a, float x, float y, float z);
+API_EXPORT void guScale(Mtx* m, float x, float y, float z);
+API_EXPORT void guScaleF(float mf[4][4], float x, float y, float z);
+API_EXPORT void guTranslate(Mtx* m, float x, float y, float z);
+API_EXPORT void guTranslateF(float mf[4][4], float x, float y, float z);
+API_EXPORT void guPosition(Mtx* m, float r, float p, float h, float s, float x, float y, float z);
+API_EXPORT void guPositionF(float mf[4][4], float r, float p, float h, float s, float x, float y, float z);
+API_EXPORT void guMtxF2L(float mf[4][4], Mtx* m);
+API_EXPORT void guMtxL2F(float mf[4][4], Mtx* m);
+API_EXPORT void guMtxCatF(float m[4][4], float n[4][4], float r[4][4]);
+API_EXPORT void guMtxCatL(Mtx* m, Mtx* n, Mtx* res);
+API_EXPORT void guMtxXFMF(float mf[4][4], float x, float y, float z, float* ox, float* oy, float* oz);
+API_EXPORT void guMtxXFML(Mtx* m, float x, float y, float z, float* ox, float* oy, float* oz);
 
 /* vector utility: */
-extern void guNormalize(float* x, float* y, float* z);
+API_EXPORT void guNormalize(float* x, float* y, float* z);
 
 /* light utilities: */
-void guPosLight(PositionalLight* pl, Light* l, float xOb, float yOb, float zOb);
-void guPosLightHilite(PositionalLight* pl1, PositionalLight* pl2, Light* l1, Light* l2, LookAt* l, Hilite* h,
-                      float xEye, float yEye, float zEye, float xOb, float yOb, float zOb, float xUp, float yUp,
-                      float zUp, int twidth, int theight);
-extern int guRandom(void);
+API_EXPORT void guPosLight(PositionalLight* pl, Light* l, float xOb, float yOb, float zOb);
+API_EXPORT void guPosLightHilite(PositionalLight* pl1, PositionalLight* pl2, Light* l1, Light* l2, LookAt* l, Hilite* h,
+                                 float xEye, float yEye, float zEye, float xOb, float yOb, float zOb, float xUp,
+                                 float yUp, float zUp, int twidth, int theight);
+API_EXPORT int guRandom(void);
 
 /*
  *  Math functions
@@ -135,7 +136,7 @@ extern int guRandom(void);
 // extern float cosf(float angle);
 // extern signed short sins (unsigned short angle);
 // extern signed short coss (unsigned short angle);
-extern float guSqrtf(float value);
+API_EXPORT float guSqrtf(float value);
 
 /*
  *  Dump routines for low-level display lists
@@ -148,8 +149,8 @@ extern float guSqrtf(float value);
                                 /* GU_PARSEGBI_DUMPOLNY, but this */
                                 /* allows app to use interchangeably */
 
-extern void guParseRdpDL(u64* rdp_dl, u64 nbytes, u8 flags);
-extern void guParseString(char* StringPointer, u64 nbytes);
+API_EXPORT void guParseRdpDL(u64* rdp_dl, u64 nbytes, u8 flags);
+API_EXPORT void guParseString(char* StringPointer, u64 nbytes);
 
 /*
  * NO LONGER SUPPORTED,
@@ -161,8 +162,8 @@ extern void guParseString(char* StringPointer, u64 nbytes);
 #define GU_BLINKRDP_HILITE 1
 #define GU_BLINKRDP_EXTRACT 2
 
-extern void guBlinkRdpDL(u64* rdp_dl_in, u64 nbytes_in, u64* rdp_dl_out, u64* nbytes_out, u32 x, u32 y, u32 radius,
-                         u8 red, u8 green, u8 blue, u8 flags);
+API_EXPORT void guBlinkRdpDL(u64* rdp_dl_in, u64 nbytes_in, u64* rdp_dl_out, u64* nbytes_out, u32 x, u32 y, u32 radius,
+                             u8 red, u8 green, u8 blue, u8 flags);
 
 /* flag values for guParseGbiDL() */
 #define GU_PARSEGBI_ROWMAJOR 1
@@ -175,8 +176,8 @@ extern void guBlinkRdpDL(u64* rdp_dl_in, u64 nbytes_in, u64* rdp_dl_out, u64* nb
 #define GU_PARSEGBI_HANGAFTER		64
 #define GU_PARSEGBI_NOTEXTURES		128
 */
-extern void guParseGbiDL(u64* gbi_dl, u32 nbytes, u8 flags);
-extern void guDumpGbiDL(OSTask* tp, u8 flags);
+API_EXPORT void guParseGbiDL(u64* gbi_dl, u32 nbytes, u8 flags);
+API_EXPORT void guDumpGbiDL(OSTask* tp, u8 flags);
 
 #define GU_PARSE_GBI_TYPE 1
 #define GU_PARSE_RDP_TYPE 2
@@ -192,9 +193,9 @@ typedef struct {
     u32 paddr;
 } guDLPrintCB;
 
-void guSprite2DInit(uSprite* SpritePointer, void* SourceImagePointer, void* TlutPointer, int Stride, int SubImageWidth,
-                    int SubImageHeight, int SourceImageType, int SourceImageBitSize, int SourceImageOffsetS,
-                    int SourceImageOffsetT);
+API_EXPORT void guSprite2DInit(uSprite* SpritePointer, void* SourceImagePointer, void* TlutPointer, int Stride,
+                               int SubImageWidth, int SubImageHeight, int SourceImageType, int SourceImageBitSize,
+                               int SourceImageOffsetS, int SourceImageOffsetT);
 
 #ifdef __cplusplus
 }

--- a/include/libultraship/libultra/message.h
+++ b/include/libultraship/libultra/message.h
@@ -2,6 +2,7 @@
 #define ULTRA64_MESSAGE_H
 
 #include "thread.h"
+#include "ship/Api.h"
 
 #define OS_MESG_NOBLOCK 0
 #define OS_MESG_BLOCK 1
@@ -52,15 +53,10 @@ typedef struct OSMesgQueue {
     /* 0x14 */ OSMesg* msg;
 } OSMesgQueue; // size = 0x18
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-void osCreateMesgQueue(OSMesgQueue* mq, OSMesg* msgBuf, int32_t count);
-int32_t osSendMesg(OSMesgQueue* mq, OSMesg msg, int32_t flag);
-int32_t osJamMesg(OSMesgQueue* mq, OSMesg msg, int32_t flag);
-int32_t osRecvMesg(OSMesgQueue* mq, OSMesg* msg, int32_t flag);
-void osSetEventMesg(OSEvent event, OSMesgQueue* mq, OSMesg msg);
-#ifdef __cplusplus
-}
-#endif
+API_EXPORT void osCreateMesgQueue(OSMesgQueue* mq, OSMesg* msgBuf, int32_t count);
+API_EXPORT int32_t osSendMesg(OSMesgQueue* mq, OSMesg msg, int32_t flag);
+API_EXPORT int32_t osJamMesg(OSMesgQueue* mq, OSMesg msg, int32_t flag);
+API_EXPORT int32_t osRecvMesg(OSMesgQueue* mq, OSMesg* msg, int32_t flag);
+API_EXPORT void osSetEventMesg(OSEvent event, OSMesgQueue* mq, OSMesg msg);
+
 #endif

--- a/include/libultraship/libultra/motor.h
+++ b/include/libultraship/libultra/motor.h
@@ -2,6 +2,7 @@
 #define ULTRA64_MOTOR_H
 
 #include "pfs.h"
+#include "ship/Api.h"
 
 #define MOTOR_START 1
 #define MOTOR_STOP 0
@@ -9,14 +10,7 @@
 #define osMotorStart(x) __osMotorAccess((x), MOTOR_START)
 #define osMotorStop(x) __osMotorAccess((x), MOTOR_STOP)
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+API_EXPORT s32 __osMotorAccess(OSPfs* pfs, u32 vibrate);
+API_EXPORT s32 osMotorInit(OSMesgQueue* ctrlrqueue, OSPfs* pfs, s32 channel);
 
-s32 __osMotorAccess(OSPfs* pfs, u32 vibrate);
-s32 osMotorInit(OSMesgQueue* ctrlrqueue, OSPfs* pfs, s32 channel);
-
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/include/libultraship/libultra/os.h
+++ b/include/libultraship/libultra/os.h
@@ -9,6 +9,7 @@
 #include "time.h"
 #include "pi.h"
 #include "vi.h"
+#include "ship/Api.h"
 
 #ifndef _HW_VERSION_1
 #define MAXCONTROLLERS 4
@@ -98,55 +99,47 @@
 #define EEP16K_MAXBLOCKS 256
 #define EEPROM_BLOCK_SIZE 8
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+API_EXPORT int32_t osContInit(OSMesgQueue* mq, uint8_t* controllerBits, OSContStatus* status);
+API_EXPORT int32_t osContStartReadData(OSMesgQueue* mesg);
+API_EXPORT void osContGetReadData(OSContPad* pad);
+API_EXPORT uint8_t osContGetStatus(uint8_t controller);
 
-int32_t osContInit(OSMesgQueue* mq, uint8_t* controllerBits, OSContStatus* status);
-int32_t osContStartReadData(OSMesgQueue* mesg);
-void osContGetReadData(OSContPad* pad);
-uint8_t osContGetStatus(uint8_t controller);
+API_EXPORT void osWritebackDCacheAll();
+API_EXPORT void osInvalDCache(void* p, int32_t l);
+API_EXPORT void osInvalICache(void* p, int32_t x);
+API_EXPORT void osWritebackDCache(void* p, int32_t x);
 
-void osWritebackDCacheAll();
-void osInvalDCache(void* p, int32_t l);
-void osInvalICache(void* p, int32_t x);
-void osWritebackDCache(void* p, int32_t x);
+API_EXPORT s32 osPiStartDma(OSIoMesg* mb, s32 priority, s32 direction, uintptr_t devAddr, void* vAddr, size_t nbytes,
+                            OSMesgQueue* mq);
+API_EXPORT void osViSwapBuffer(void*);
+API_EXPORT void osViBlack(uint8_t active);
+API_EXPORT void osViFade(u8, u16);
+API_EXPORT void osViRepeatLine(u8);
+API_EXPORT void osViSetXScale(f32);
+API_EXPORT void osViSetYScale(f32);
+API_EXPORT void osViSetSpecialFeatures(u32);
+API_EXPORT void osViSetMode(OSViMode*);
+API_EXPORT void osViSetEvent(OSMesgQueue*, OSMesg, u32);
+API_EXPORT void osCreateViManager(OSPri);
+API_EXPORT void osCreatePiManager(OSPri pri, OSMesgQueue* cmdQ, OSMesg* cmdBuf, s32 cmdMsgCnt);
 
-s32 osPiStartDma(OSIoMesg* mb, s32 priority, s32 direction, uintptr_t devAddr, void* vAddr, size_t nbytes,
-                 OSMesgQueue* mq);
-void osViSwapBuffer(void*);
-void osViBlack(uint8_t active);
-void osViFade(u8, u16);
-void osViRepeatLine(u8);
-void osViSetXScale(f32);
-void osViSetYScale(f32);
-void osViSetSpecialFeatures(u32);
-void osViSetMode(OSViMode*);
-void osViSetEvent(OSMesgQueue*, OSMesg, u32);
-void osCreateViManager(OSPri);
-void osCreatePiManager(OSPri pri, OSMesgQueue* cmdQ, OSMesg* cmdBuf, s32 cmdMsgCnt);
+API_EXPORT void osSetTime(OSTime time);
+API_EXPORT uint64_t osGetTime(void);
+API_EXPORT uint32_t osGetCount(void);
+API_EXPORT s32 osEepromProbe(OSMesgQueue*);
+API_EXPORT s32 osEepromRead(OSMesgQueue*, u8, u8*);
+API_EXPORT s32 osEepromWrite(OSMesgQueue*, u8, u8*);
+API_EXPORT s32 osEepromLongRead(OSMesgQueue*, u8, u8*, int);
+API_EXPORT s32 osEepromLongWrite(OSMesgQueue*, u8, u8*, int);
 
-void osSetTime(OSTime time);
-uint64_t osGetTime(void);
-uint32_t osGetCount(void);
-s32 osEepromProbe(OSMesgQueue*);
-s32 osEepromRead(OSMesgQueue*, u8, u8*);
-s32 osEepromWrite(OSMesgQueue*, u8, u8*);
-s32 osEepromLongRead(OSMesgQueue*, u8, u8*, int);
-s32 osEepromLongWrite(OSMesgQueue*, u8, u8*, int);
+API_EXPORT int osSetTimer(OSTimer* t, OSTime countdown, OSTime interval, OSMesgQueue* mq, OSMesg msg);
 
-int osSetTimer(OSTimer* t, OSTime countdown, OSTime interval, OSMesgQueue* mq, OSMesg msg);
+API_EXPORT s32 osAiSetFrequency(u32 freq);
+API_EXPORT OSPiHandle* osCartRomInit(void);
+API_EXPORT s32 osEPiStartDma(OSPiHandle* pihandle, OSIoMesg* mb, s32 direction);
 
-s32 osAiSetFrequency(u32 freq);
-OSPiHandle* osCartRomInit(void);
-s32 osEPiStartDma(OSPiHandle* pihandle, OSIoMesg* mb, s32 direction);
-
-s32 osAiSetFrequency(u32);
-s32 osAiSetNextBuffer(void*, size_t);
-u32 osAiGetLength(void);
-
-#ifdef __cplusplus
-};
-#endif
+API_EXPORT s32 osAiSetFrequency(u32);
+API_EXPORT s32 osAiSetNextBuffer(void*, size_t);
+API_EXPORT u32 osAiGetLength(void);
 
 #endif


### PR DESCRIPTION
Marks the libultra compatibility functions (`gu*`, `os*` message/eeprom/motor APIs) with `API_EXPORT` so they are exported from the library and resolvable by runtime-loaded code (mod scripting, dynamic libraries).

Header-only change; also normalizes the surrounding formatting to current clang-format output.
