### PR TITLE
Platform fixes: iOS build, web paths, dxgi, background throttling

### DIFF
--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -29,9 +29,12 @@ target_sources(ImGui
 
 target_sources(ImGui
     PRIVATE
-    ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
     ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl3.cpp
 )
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    target_sources(ImGui PRIVATE ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp)
+endif()
 
 target_include_directories(ImGui PUBLIC ${imgui_SOURCE_DIR} ${imgui_SOURCE_DIR}/backends)
 

--- a/cmake/dependencies/ios.cmake
+++ b/cmake/dependencies/ios.cmake
@@ -9,6 +9,7 @@ if (NOT ${SDL3_FOUND})
         SDL3
         GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
         GIT_TAG release-3.4.12
+        GIT_SHALLOW TRUE
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(SDL3)
@@ -21,6 +22,7 @@ if (NOT ${nlohmann_json_FOUND})
         nlohmann_json
         GIT_REPOSITORY https://github.com/nlohmann/json.git
         GIT_TAG v3.12.0
+        GIT_SHALLOW TRUE
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(nlohmann_json)
@@ -34,6 +36,7 @@ if (NOT ${tinyxml2_FOUND})
         tinyxml2
         GIT_REPOSITORY https://github.com/leethomason/tinyxml2.git
         GIT_TAG 11.0.0
+        GIT_SHALLOW TRUE
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(tinyxml2)
@@ -46,6 +49,7 @@ if (NOT ${spdlog_FOUND})
         spdlog
         GIT_REPOSITORY https://github.com/gabime/spdlog.git
         GIT_TAG v1.16.0
+        GIT_SHALLOW TRUE
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(spdlog)
@@ -54,7 +58,21 @@ endif()
 #=================== libzip ===================
 find_package(libzip QUIET)
 if (NOT ${libzip_FOUND})
+    # Link-less try_compile (CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY) makes
+    # check_function_exists() false-positive; pin off functions iOS lacks.
+    foreach(_libzip_missing_fn
+            HAVE__CLOSE HAVE__DUP HAVE__FDOPEN HAVE__FILENO HAVE__FSEEKI64
+            HAVE__FSTAT64 HAVE__SETMODE HAVE__STAT64 HAVE__STRDUP HAVE__STRTOI64
+            HAVE__STRTOUI64 HAVE__UNLINK HAVE_GETSECURITYINFO HAVE_MEMCPY_S
+            HAVE_STRERROR_S HAVE_STRERRORLEN_S HAVE_STRICMP HAVE_STRNCPY_S
+            HAVE_EXPLICIT_MEMSET)
+        set(${_libzip_missing_fn} "" CACHE INTERNAL "not available on iOS; pinned (link-less try_compile false-positives)")
+    endforeach()
+
     set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+    # zstd is not in the iOS SDK (the find module would grab the macOS homebrew
+    # one); O2R archives are plain deflate, so it is unneeded.
+    set(ENABLE_ZSTD OFF)
     set(BUILD_TOOLS OFF)
     set(BUILD_REGRESS OFF)
     set(BUILD_EXAMPLES OFF)
@@ -65,6 +83,7 @@ if (NOT ${libzip_FOUND})
         libzip
         GIT_REPOSITORY https://github.com/nih-at/libzip.git
         GIT_TAG v1.11.4
+        GIT_SHALLOW TRUE
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(libzip)
@@ -76,6 +95,7 @@ FetchContent_Declare(
     metalcpp
     GIT_REPOSITORY https://github.com/briaguya-ai/single-header-metal-cpp.git
     GIT_TAG macOS13_iOS16
+    GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(metalcpp)
 list(APPEND ADDITIONAL_LIB_INCLUDES ${metalcpp_SOURCE_DIR})

--- a/include/fast/backends/gfx_sdl.h
+++ b/include/fast/backends/gfx_sdl.h
@@ -51,6 +51,7 @@ class GfxWindowBackendSDL final : public GfxWindowBackend {
     Ship::WindowRect GetPrimaryMonitorRect() override;
     void HandleEvents() override;
     bool IsFrameReady() override;
+    bool IsWindowVisible() override;
     void SwapBuffersBegin() override;
     void SwapBuffersEnd() override;
     double GetTime() override;

--- a/include/fast/backends/gfx_window_manager_api.h
+++ b/include/fast/backends/gfx_window_manager_api.h
@@ -29,6 +29,12 @@ class GfxWindowBackend {
     virtual Ship::WindowRect GetPrimaryMonitorRect() = 0;
     virtual void HandleEvents() = 0;
     virtual bool IsFrameReady() = 0;
+    // Whether the window is currently being displayed. When false (minimized/occluded)
+    // the caller should skip rendering: on some backends (Metal) acquiring a drawable
+    // for a non-visible window stalls. Defaults to true for backends that don't track it.
+    virtual bool IsWindowVisible() {
+        return true;
+    }
     virtual void SwapBuffersBegin() = 0;
     virtual void SwapBuffersEnd() = 0;
     virtual double GetTime() = 0;

--- a/include/ship/utils/macUtils.h
+++ b/include/ship/utils/macUtils.h
@@ -18,6 +18,12 @@ void toggleNativeMacOSFullscreen(SDL_Window* window);
  */
 bool isNativeMacOSFullscreenActive(SDL_Window* window);
 
+/**
+ * @brief Opts the process out of App Nap so it keeps running at full speed (and keeps
+ *        audio playing without stutter) while unfocused or hidden. Call once at startup.
+ */
+void disableMacOSAppNap(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,10 @@ if(ENABLE_SCRIPTING)
     target_compile_definitions(libultraship PUBLIC ENABLE_SCRIPTING)
 endif()
 
+if(DISABLE_DLL_LOADER)
+    target_compile_definitions(libultraship PUBLIC DISABLE_DLL_LOADER)
+endif()
+
 #=================== Compile Options & Defs ===================
 
 target_compile_definitions(libultraship PUBLIC

--- a/src/fast/Fast3dWindow.cpp
+++ b/src/fast/Fast3dWindow.cpp
@@ -43,7 +43,9 @@ Fast3dWindow::Fast3dWindow(std::shared_ptr<Ship::Gui> gui, std::shared_ptr<FastM
         AddAvailableWindowBackend(WindowBackend::FAST3D_SDL_METAL);
     }
 #endif
+#ifdef ENABLE_OPENGL
     AddAvailableWindowBackend(WindowBackend::FAST3D_SDL_OPENGL);
+#endif
 }
 
 Fast3dWindow::Fast3dWindow(std::shared_ptr<Ship::Gui> gui, std::shared_ptr<Ship::Config> config,

--- a/src/fast/Fast3dWindow.cpp
+++ b/src/fast/Fast3dWindow.cpp
@@ -1,5 +1,8 @@
 #include "fast/Fast3dWindow.h"
 
+#include <thread>
+#include <chrono>
+
 #include "ship/core/Context.h"
 #include "ship/config/Config.h"
 #include "ship/controller/controldeck/ControlDeck.h"
@@ -234,6 +237,16 @@ bool Fast3dWindow::IsFrameReady() {
 bool Fast3dWindow::DrawAndRunGraphicsCommands(Gfx* commands, const std::unordered_map<Mtx*, MtxF>& mtxReplacements) {
     // Skip dropped frames
     if (!IsFrameReady()) {
+        return false;
+    }
+
+    // When the window isn't being displayed (minimized/occluded), skip the entire
+    // render + present. Otherwise acquiring a backend drawable can block on the
+    // compositor (Metal's nextDrawable stalls ~1s per frame while occluded), which
+    // looks like the game lagging in the background. Game logic has already run for
+    // this tick; we just don't draw. Yield briefly so the loop doesn't busy-spin.
+    if (!mWindowManagerApi->IsWindowVisible()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(8));
         return false;
     }
 

--- a/src/fast/backends/gfx_dxgi.cpp
+++ b/src/fast/backends/gfx_dxgi.cpp
@@ -17,6 +17,7 @@
 #include <versionhelpers.h>
 
 #include <shellscalingapi.h>
+#include <shellapi.h>
 
 #ifndef _LANGUAGE_C
 #define _LANGUAGE_C

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -694,6 +694,12 @@ int GfxRenderingAPIMetal::CreateFramebuffer() {
 }
 
 void GfxRenderingAPIMetal::SetupScreenFramebuffer(uint32_t width, uint32_t height) {
+#ifdef __IOS__
+    // Keep the layer's drawable size pinned to the pixel viewport.
+    if (mLayer->drawableSize().width != width || mLayer->drawableSize().height != height) {
+        mLayer->setDrawableSize({ CGFloat(width), CGFloat(height) });
+    }
+#endif
     mCurrentDrawable = nullptr;
     mCurrentDrawable = mLayer->nextDrawable();
 

--- a/src/fast/backends/gfx_metal.cpp
+++ b/src/fast/backends/gfx_metal.cpp
@@ -625,7 +625,9 @@ void GfxRenderingAPIMetal::EndFrame() {
         mScreenReadbackRequested = false;
     }
 
-    screen_framebuffer.mCommandBuffer->presentDrawable(mCurrentDrawable);
+    if (mCurrentDrawable != nullptr) {
+        screen_framebuffer.mCommandBuffer->presentDrawable(mCurrentDrawable);
+    }
     mCurrentVertexBufferPoolIndex = (mCurrentVertexBufferPoolIndex + 1) % kMaxVertexBufferPoolSize;
     screen_framebuffer.mCommandBuffer->commit();
 
@@ -709,6 +711,15 @@ void GfxRenderingAPIMetal::SetupScreenFramebuffer(uint32_t width, uint32_t heigh
     TextureDataMetal& tex = mTextures[fb.mTextureId];
 
     NS::AutoreleasePool* autorelease_pool = NS::AutoreleasePool::alloc()->init();
+
+    // Safety net: the visibility gate in Fast3dWindow normally prevents us from
+    // reaching here while occluded, but if the window is occluded mid-frame
+    // nextDrawable can still return null. Don't dereference it (would crash);
+    // keep the previous texture for this frame.
+    if (mCurrentDrawable == nullptr) {
+        autorelease_pool->release();
+        return;
+    }
 
     tex.texture = mCurrentDrawable->texture();
 

--- a/src/fast/backends/gfx_sdl.cpp
+++ b/src/fast/backends/gfx_sdl.cpp
@@ -253,7 +253,7 @@ void GfxWindowBackendSDL::SetFullscreenImpl(bool on, bool call_callback) {
         }
     }
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && !defined(__IOS__)
     // Implement fullscreening with native macOS APIs
     if (on != isNativeMacOSFullscreenActive(mWnd)) {
         toggleNativeMacOSFullscreen(mWnd);
@@ -384,7 +384,7 @@ void GfxWindowBackendSDL::Init(const char* gameName, const char* gfxApiName, boo
     int len = snprintf(title, sizeof(title), "%s (%s)", gameName, gfxApiName);
 
 #ifdef __IOS__
-    Uint32 flags = SDL_WINDOW_BORDERLESS;
+    Uint32 flags = SDL_WINDOW_BORDERLESS | SDL_WINDOW_HIGH_PIXEL_DENSITY;
 #else
     Uint32 flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY;
 #endif
@@ -551,7 +551,7 @@ void GfxWindowBackendSDL::SetMouseCallbacks(bool (*onMouseButtonDown)(int btn), 
 }
 
 void GfxWindowBackendSDL::GetDimensions(uint32_t* width, uint32_t* height, int32_t* posX, int32_t* posY) {
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(__IOS__)
     SDL_GetWindowSize(mWnd, static_cast<int*>((void*)width), static_cast<int*>((void*)height));
 #else
     SDL_GetWindowSizeInPixels(mWnd, static_cast<int*>((void*)width), static_cast<int*>((void*)height));
@@ -657,7 +657,7 @@ void GfxWindowBackendSDL::HandleSingleEvent(SDL_Event& event) {
             break;
 #endif
         case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(__IOS__)
             SDL_GetWindowSize(mWnd, &mWindowWidth, &mWindowHeight);
 #else
             SDL_GetWindowSizeInPixels(mWnd, &mWindowWidth, &mWindowHeight);
@@ -690,7 +690,7 @@ void GfxWindowBackendSDL::HandleEvents() {
     }
 
     // resync fullscreen state
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(__IOS__)
     auto nextFullscreenState = isNativeMacOSFullscreenActive(mWnd);
     if (mFullScreen != nextFullscreenState) {
         mFullScreen = nextFullscreenState;

--- a/src/fast/backends/gfx_sdl.cpp
+++ b/src/fast/backends/gfx_sdl.cpp
@@ -339,6 +339,12 @@ void GfxWindowBackendSDL::Init(const char* gameName, const char* gfxApiName, boo
         return;
     }
 
+#if defined(__APPLE__) && !defined(__IOS__)
+    // Keep running at full speed (and audio playing) while unfocused/hidden by opting
+    // out of App Nap, which otherwise throttles the whole process in the background.
+    disableMacOSAppNap();
+#endif
+
     SDL_SetEventEnabled(SDL_EVENT_DROP_FILE, true);
 
 #if defined(__APPLE__)
@@ -699,6 +705,13 @@ void GfxWindowBackendSDL::HandleEvents() {
         }
     }
 #endif
+}
+
+bool GfxWindowBackendSDL::IsWindowVisible() {
+    // A fully-covered window stops being composited, which stalls Metal's drawable
+    // acquisition; SDL3 tracks that state in SDL_WINDOW_OCCLUDED.
+    const SDL_WindowFlags flags = SDL_GetWindowFlags(mWnd);
+    return (flags & (SDL_WINDOW_MINIMIZED | SDL_WINDOW_HIDDEN | SDL_WINDOW_OCCLUDED)) == 0;
 }
 
 bool GfxWindowBackendSDL::IsFrameReady() {

--- a/src/ship/audio/Audio.cpp
+++ b/src/ship/audio/Audio.cpp
@@ -1,6 +1,6 @@
 #include "ship/audio/Audio.h"
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(__IOS__)
 #include "ship/audio/CoreAudioAudioPlayer.h"
 #endif
 
@@ -22,7 +22,7 @@ void Audio::InitAudioPlayer() {
             mAudioPlayer = std::make_shared<WasapiAudioPlayer>(this->mAudioSettings);
             break;
 #endif
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(__IOS__)
         case AudioBackend::COREAUDIO:
             mAudioPlayer = std::make_shared<CoreAudioAudioPlayer>(this->mAudioSettings);
             break;
@@ -47,7 +47,7 @@ void Audio::OnInit(const nlohmann::json& /*initArgs*/) {
 #ifdef _WIN32
     mAvailableAudioBackends->push_back(AudioBackend::WASAPI);
 #endif
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(__IOS__)
     mAvailableAudioBackends->push_back(AudioBackend::COREAUDIO);
 #endif
     mAvailableAudioBackends->push_back(AudioBackend::SDL);
@@ -80,7 +80,11 @@ AudioBackend Audio::GetSavedAudioBackend() {
     }
 
     if (backendName == "coreaudio") {
+#if defined(__APPLE__) && !defined(__IOS__)
         return AudioBackend::COREAUDIO;
+#else
+        return AudioBackend::SDL;
+#endif
     }
 
     if (backendName == "sdl") {
@@ -97,7 +101,7 @@ AudioBackend Audio::GetSavedAudioBackend() {
     return AudioBackend::WASAPI;
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && !defined(__IOS__)
     return AudioBackend::COREAUDIO;
 #endif
 

--- a/src/ship/core/Context.cpp
+++ b/src/ship/core/Context.cpp
@@ -323,6 +323,10 @@ std::string Context::GetAppDirectoryPath(const std::string& appName) {
     }
 #endif
 
+#ifdef __EMSCRIPTEN__
+    return "/storage";
+#endif
+
 #ifdef __IOS__
     const char* home = getenv("HOME");
     return std::string(home) + "/Documents";

--- a/src/ship/core/Context.cpp
+++ b/src/ship/core/Context.cpp
@@ -261,8 +261,11 @@ std::string Context::GetAppBundlePath() {
 #endif
 
 #ifdef __IOS__
-    const char* home = getenv("HOME");
-    return std::string(home) + "/Documents";
+    // App bundle resources; user files live in Documents (GetAppDirectoryPath).
+    {
+        FolderManager iosBundleFolderManager;
+        return iosBundleFolderManager.getMainBundlePath();
+    }
 #endif
 
 #ifdef NON_PORTABLE

--- a/src/ship/utils/macUtils.mm
+++ b/src/ship/utils/macUtils.mm
@@ -22,4 +22,18 @@ bool isNativeMacOSFullscreenActive(SDL_Window *window) {
     }
     return false;
 }
+
+// Opt out of App Nap. When the app isn't frontmost (unfocused or hidden) macOS
+// otherwise throttles its timers and CPU scheduling across *all* threads, which
+// slows the game loop and starves the audio thread (stutter). Registering a
+// latency-critical activity keeps the process running at full speed in the
+// background. The token is held for the app's lifetime via a strong static (ARC).
+void disableMacOSAppNap(void) {
+    static id<NSObject> sAppNapActivity = nil;
+    if (sAppNapActivity == nil) {
+        sAppNapActivity = [[NSProcessInfo processInfo]
+            beginActivityWithOptions:(NSActivityUserInitiatedAllowingIdleSystemSleep | NSActivityLatencyCritical)
+                              reason:@"libultraship keeps simulating and outputs audio while unfocused"];
+    }
+}
 #endif


### PR DESCRIPTION
A batch of small platform fixes:

- **dxgi**: define `WIN32_LEAN_AND_MEAN` before including Windows headers.
- **Web**: return `/storage` as the app directory under Emscripten.
- **iOS**: build fixes — don't compile the ImGui GL3 backend or advertise the OpenGL window backend on iOS, gate CoreAudio off (SDL audio is used), correct `GetAppBundlePath` to the actual bundle path, pin the Metal layer drawable size to the pixel viewport, libzip cmake pins for link-less `try_compile` false-positives, `GIT_SHALLOW` on FetchContent deps, and a `DISABLE_DLL_LOADER` option for platforms where `dlopen` is not allowed.
- **Unfocused throttling**: skip rendering (but keep simulating) while the window is minimized/hidden/occluded — acquiring a Metal drawable for a non-visible window stalls ~1s per frame, which looked like the game lagging in the background. Occlusion is read from SDL3's `SDL_WINDOW_OCCLUDED`. On macOS the process also opts out of App Nap so audio keeps running at full speed while unfocused.

Originally written against SDL2; re-ported to the SDL3 backend for this PR (the SDL2-era iOS point/pixel ImGui scaling workarounds were dropped — the ImGui SDL3 backend handles display scale itself).

Tested: compiles on macOS (Metal + GL). iOS/web behavior re-verification pending on device.
