### PR TITLE
Load TCC-compiled scripts in-memory to avoid antivirus false-positives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(INCLUDE_PROFILING "Enable action and tickable profiling timers" OFF)
 option(COMPONENT_THREAD_SAFE "Enable thread safety for Component parent/child lists" OFF)
 option(DISABLE_DLL_LOADER "Disable dynamic library loading support" OFF)
 option(ENABLE_SCRIPTING "Enable TCC-based C mod compilation and scripting system" OFF)
+option(ENABLE_TCC_COMPILER "Build the TCC compiler for compiling mod C sources at runtime (OFF = prebuilt mod binaries only)" ON)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
     option(SIGN_LIBRARY "Enable xcode signing" OFF)

--- a/cmake/SetupTccRuntime.cmake
+++ b/cmake/SetupTccRuntime.cmake
@@ -23,7 +23,7 @@
 function(lus_setup_tcc_runtime TARGET_NAME)
     cmake_parse_arguments(PARSE_ARGV 1 LUS_TCC "" "RESOURCES_DIR" "")
 
-    if(NOT ENABLE_SCRIPTING)
+    if(NOT ENABLE_SCRIPTING OR NOT ENABLE_TCC_COMPILER)
         return()
     endif()
 

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -153,7 +153,7 @@ target_include_directories(monocypher PUBLIC
 )
 
 #=========== libtcc ===========
-if(ENABLE_SCRIPTING)
+if(ENABLE_SCRIPTING AND ENABLE_TCC_COMPILER)
 
 FetchContent_Declare(
     tinycc

--- a/cmake/dependencies/common.cmake
+++ b/cmake/dependencies/common.cmake
@@ -189,6 +189,19 @@ if(NOT TARGET libtcc)
         endif()
     endif()
 
+    # config.h (included before tcc.h's per-arch auto-detect) hardcodes the host
+    # codegen target, so it applies to every -arch slice. On a universal build that
+    # leaves the non-host slice a non-native cross-compiler with no runtime
+    # (tcc_relocate is compiled out), which breaks linking. Strip the codegen target
+    # so each slice selects its own from __x86_64__/__aarch64__; TCC_TARGET_MACHO and
+    # the CONFIG_* defines are kept.
+    if(APPLE AND EXISTS "${tinycc_SOURCE_DIR}/config.h")
+        file(READ "${tinycc_SOURCE_DIR}/config.h" _tcc_cfg)
+        string(REGEX REPLACE "#define TCC_TARGET_(I386|X86_64|ARM64|ARM|RISCV64|C67) [^\n]*\n" "" _tcc_cfg "${_tcc_cfg}")
+        file(WRITE "${tinycc_SOURCE_DIR}/config.h" "${_tcc_cfg}")
+        unset(_tcc_cfg)
+    endif()
+
     if(CMAKE_CROSSCOMPILING)
         find_program(HOST_C_COMPILER NAMES cc clang gcc REQUIRED)
         set(C2STR_EXE "${tinycc_BINARY_DIR}/tcc_c2str_host")

--- a/include/ship/scripting/LibraryLoader.h
+++ b/include/ship/scripting/LibraryLoader.h
@@ -64,6 +64,24 @@ class LibraryLoader {
     void Init(const std::string& path);
 
     /**
+     * @brief Relocates an in-memory TCC compilation unit and takes ownership of it.
+     *
+     * Used for scripts compiled from source at runtime: instead of writing a
+     * shared library to disk and handing it to the platform dynamic linker
+     * (the "drop and load" pattern that antivirus heuristics flag), the code is
+     * JIT-relocated in-process directly from the TCCState via tcc_relocate().
+     * Nothing is written to disk and neither dlopen() nor LoadLibrary() is called.
+     *
+     * @param tccState An opaque TCCState* that has already had its sources
+     *                 compiled (tcc_compile_string). This LibraryLoader takes
+     *                 ownership: the state is kept alive because it owns the
+     *                 executable memory, and freed (tcc_delete) by Unload().
+     * @throws std::runtime_error if relocation fails.
+     * @note Only available when built with the TCC compiler (not DISABLE_TCC_COMPILER).
+     */
+    void InitInMemory(void* tccState);
+
+    /**
      * @brief Resolves an exported symbol from the loaded library.
      * @param name The symbol name to look up.
      * @return Pointer to the symbol, or nullptr if not found or no library is loaded.
@@ -83,5 +101,8 @@ class LibraryLoader {
   private:
     LibraryHandle_t mHandle;
     std::string mTempFile;
+    // Owned TCCState for in-memory JIT scripts; null for file-loaded libraries.
+    // maybe_unused: referenced only in TCC-enabled builds (not DISABLE_TCC_COMPILER).
+    [[maybe_unused]] void* mTccState = nullptr;
 };
 } // namespace Ship::Scripting

--- a/include/ship/scripting/ScriptLoader.h
+++ b/include/ship/scripting/ScriptLoader.h
@@ -99,20 +99,6 @@ class ScriptLoader : public Component {
     std::vector<std::string> GetLoadersInDependencyOrder() const;
 
     /**
-     * @brief Sets the directory used to cache compiled script binaries.
-     *
-     * When set, ScriptLoader will store compiled .so/.dll files in this
-     * directory keyed by a hash of the archive checksum, code version, and
-     * build options. On subsequent runs the cached binary is loaded directly,
-     * skipping recompilation when the mod has not changed.
-     *
-     * Defaults to empty (caching disabled).
-     *
-     * @param dir Filesystem path to the cache directory (created automatically).
-     */
-    void SetCacheDir(const std::filesystem::path& dir);
-
-    /**
      * @brief Sets the security level for script loading.
      * @param level The SafeLevel policy to enforce.
      */
@@ -128,19 +114,6 @@ class ScriptLoader : public Component {
     std::unordered_map<std::string, std::string> mCompileDefines;
     std::unordered_map<std::string, Scripting::LibraryLoader> mLoadedScripts;
     std::vector<std::shared_ptr<Archive>> mLoadedArchives;
-    std::filesystem::path mCacheDir; ///< Empty = caching disabled.
-
-    /**
-     * @brief Returns the cache file path for an archive, or empty if caching is disabled
-     *        or the archive has no checksum.
-     */
-    std::filesystem::path GetCachePath(const ArchiveManifest& manifest) const;
-
-    /**
-     * @brief Copies @p srcPath into the cache directory using the manifest's cache key.
-     *        Does nothing if caching is disabled or the checksum is empty.
-     */
-    void StoreInCache(const ArchiveManifest& manifest, const std::string& srcPath) const;
     std::shared_ptr<ResourceManager> mResourceManager;
 };
 

--- a/include/ship/scripting/ScriptLoader.h
+++ b/include/ship/scripting/ScriptLoader.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <optional>
 #include <functional>
+#include <filesystem>
 #include <memory>
 
 namespace Ship {
@@ -98,6 +99,20 @@ class ScriptLoader : public Component {
     std::vector<std::string> GetLoadersInDependencyOrder() const;
 
     /**
+     * @brief Sets the directory used to cache compiled script binaries.
+     *
+     * When set, ScriptLoader will store compiled .so/.dll files in this
+     * directory keyed by a hash of the archive checksum, code version, and
+     * build options. On subsequent runs the cached binary is loaded directly,
+     * skipping recompilation when the mod has not changed.
+     *
+     * Defaults to empty (caching disabled).
+     *
+     * @param dir Filesystem path to the cache directory (created automatically).
+     */
+    void SetCacheDir(const std::filesystem::path& dir);
+
+    /**
      * @brief Sets the security level for script loading.
      * @param level The SafeLevel policy to enforce.
      */
@@ -113,6 +128,19 @@ class ScriptLoader : public Component {
     std::unordered_map<std::string, std::string> mCompileDefines;
     std::unordered_map<std::string, Scripting::LibraryLoader> mLoadedScripts;
     std::vector<std::shared_ptr<Archive>> mLoadedArchives;
+    std::filesystem::path mCacheDir; ///< Empty = caching disabled.
+
+    /**
+     * @brief Returns the cache file path for an archive, or empty if caching is disabled
+     *        or the archive has no checksum.
+     */
+    std::filesystem::path GetCachePath(const ArchiveManifest& manifest) const;
+
+    /**
+     * @brief Copies @p srcPath into the cache directory using the manifest's cache key.
+     *        Does nothing if caching is disabled or the checksum is empty.
+     */
+    void StoreInCache(const ArchiveManifest& manifest, const std::string& srcPath) const;
     std::shared_ptr<ResourceManager> mResourceManager;
 };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,8 +135,12 @@ endif()
 target_link_libraries(libultraship PUBLIC prism monocypher)
 
 if(ENABLE_SCRIPTING)
-    target_link_libraries(libultraship PUBLIC libtcc libtcc1)
     target_compile_definitions(libultraship PUBLIC ENABLE_SCRIPTING)
+    if(ENABLE_TCC_COMPILER)
+        target_link_libraries(libultraship PUBLIC libtcc libtcc1)
+    else()
+        target_compile_definitions(libultraship PUBLIC DISABLE_TCC_COMPILER)
+    endif()
 endif()
 
 #=================== Compile Options & Defs ===================

--- a/src/ship/scripting/LibraryLoader.cpp
+++ b/src/ship/scripting/LibraryLoader.cpp
@@ -25,6 +25,10 @@
 
 #include <fstream>
 
+#ifndef DISABLE_TCC_COMPILER
+#include <libtcc.h>
+#endif
+
 namespace Ship::Scripting {
 
 std::string LibraryLoader::GenerateTempFile() {
@@ -174,7 +178,29 @@ void LibraryLoader::Init(const std::string& path) {
 #endif
 }
 
+void LibraryLoader::InitInMemory(void* tccState) {
+#ifndef DISABLE_TCC_COMPILER
+    TCCState* s = static_cast<TCCState*>(tccState);
+    // Relocate the compiled code into executable memory owned by the TCCState.
+    // TCC maps a read/execute region (W^X) and never writes a shared library to
+    // disk, so there is no on-disk artifact and no dlopen()/LoadLibrary() call.
+    if (tcc_relocate(s) < 0) {
+        throw std::runtime_error("Failed to relocate compiled script into memory");
+    }
+    mTccState = tccState;
+#else
+    (void)tccState;
+    throw std::runtime_error(
+        "In-memory script execution requires the TCC compiler (built without DISABLE_TCC_COMPILER).");
+#endif
+}
+
 void* LibraryLoader::GetFunction(const std::string& name) {
+#ifndef DISABLE_TCC_COMPILER
+    if (mTccState != nullptr) {
+        return tcc_get_symbol(static_cast<TCCState*>(mTccState), name.c_str());
+    }
+#endif
 #ifndef DISABLE_DLL_LOADER
     if (!mHandle) {
         return nullptr;
@@ -185,12 +211,19 @@ void* LibraryLoader::GetFunction(const std::string& name) {
     return (void*)dlsym(mHandle, name.c_str());
 #endif
 #else
-    throw std::runtime_error(
-        "DLL loading is disabled. Recompile without DISABLE_DLL_LOADER defined to enable this feature.");
+    return nullptr;
 #endif
 }
 
 void LibraryLoader::Unload() {
+#ifndef DISABLE_TCC_COMPILER
+    if (mTccState != nullptr) {
+        // Frees the JIT code memory owned by the state.
+        tcc_delete(static_cast<TCCState*>(mTccState));
+        mTccState = nullptr;
+        return;
+    }
+#endif
 #ifndef DISABLE_DLL_LOADER
     if (!mHandle) {
         return;

--- a/src/ship/scripting/ScriptLoader.cpp
+++ b/src/ship/scripting/ScriptLoader.cpp
@@ -9,10 +9,14 @@
 #include <optional>
 #include <sstream>
 #include <string_view>
+#ifndef DISABLE_TCC_COMPILER
 #include <libtcc.h>
+#endif
 #include <memory>
 #include <queue>
 #include <unordered_map>
+#include <fstream>
+#include <iomanip>
 
 namespace Ship {
 std::optional<std::vector<uint8_t>> LoadFromO2R(const std::string& path,
@@ -75,6 +79,60 @@ constexpr std::string_view GetPlatform() {
 #endif
 }
 
+void ScriptLoader::SetCacheDir(const std::filesystem::path& dir) {
+    mCacheDir = dir;
+}
+
+std::filesystem::path ScriptLoader::GetCachePath(const ArchiveManifest& manifest) const {
+    if (mCacheDir.empty() || manifest.Checksum.empty()) {
+        return {};
+    }
+
+    // Build a cache key from content identity + compiler configuration.
+    // Any change to the archive bytes, code version, or build flags will
+    // produce a different key and force a recompile.
+    std::string raw = manifest.Checksum + ":" + std::to_string(mCodeVersion) + ":" + mBuildOptions;
+
+    // Fold the string into a 64-bit hash (platform-independent hex string).
+    std::size_t h = 0;
+    for (unsigned char c : raw) {
+        h = h * 31 + c;
+    }
+
+    std::ostringstream oss;
+    oss << std::hex << std::setw(16) << std::setfill('0') << h;
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+    return mCacheDir / (oss.str() + ".dll");
+#elif defined(__APPLE__)
+    return mCacheDir / (oss.str() + ".dylib");
+#else
+    return mCacheDir / (oss.str() + ".so");
+#endif
+}
+
+void ScriptLoader::StoreInCache(const ArchiveManifest& manifest, const std::string& srcPath) const {
+    const auto cachePath = GetCachePath(manifest);
+    if (cachePath.empty()) {
+        return;
+    }
+
+    std::error_code ec;
+    std::filesystem::create_directories(cachePath.parent_path(), ec);
+    if (ec) {
+        SPDLOG_WARN("ScriptLoader: failed to create cache directory {}: {}", cachePath.parent_path().string(),
+                    ec.message());
+        return;
+    }
+
+    std::filesystem::copy_file(srcPath, cachePath, std::filesystem::copy_options::overwrite_existing, ec);
+    if (ec) {
+        SPDLOG_WARN("ScriptLoader: failed to write cache entry {}: {}", cachePath.string(), ec.message());
+    } else {
+        SPDLOG_INFO("ScriptLoader: cached compiled script to {}", cachePath.string());
+    }
+}
+
 void ScriptLoader::Compile(const std::shared_ptr<Archive>& archive) {
     const ArchiveManifest& info = archive->GetManifest();
     constexpr std::string_view platform = GetPlatform();
@@ -121,6 +179,23 @@ void ScriptLoader::Compile(const std::shared_ptr<Archive>& archive) {
     const auto& binaries = info.Binaries;
     const std::string temp = loader.GenerateTempFile();
 
+#ifndef DISABLE_TCC_COMPILER
+    if (info.Binaries.find(std::string(platform)) == info.Binaries.end() && !info.Main.empty()) {
+        const auto cachePath = GetCachePath(info);
+        if (!cachePath.empty() && std::filesystem::exists(cachePath)) {
+            SPDLOG_INFO("ScriptLoader: cache hit for '{}', skipping recompile ({})", info.Name, cachePath.string());
+            std::error_code ec;
+            std::filesystem::copy_file(cachePath, temp, std::filesystem::copy_options::overwrite_existing, ec);
+            if (!ec) {
+                loader.Init(temp);
+                mLoadedScripts[info.Name] = loader;
+                return;
+            }
+            SPDLOG_WARN("ScriptLoader: failed to restore cache entry, recompiling: {}", ec.message());
+        }
+    }
+#endif
+
     if (binaries.contains(std::string(platform))) {
         const std::string& path = binaries.at(std::string(platform));
         auto data = LoadFromO2R(path, archive);
@@ -130,6 +205,12 @@ void ScriptLoader::Compile(const std::shared_ptr<Archive>& archive) {
 
         loader.WriteToTempFile(*data);
     } else if (!info.Main.empty()) {
+#ifdef DISABLE_TCC_COMPILER
+        SPDLOG_WARN("ScriptLoader: '{}' ships C sources but the TCC compiler is disabled; provide a prebuilt "
+                    "binary for this platform",
+                    info.Name);
+        return;
+#else
         const auto data = LoadFromO2R(info.Main, archive);
         if (!data.has_value()) {
             throw std::runtime_error("Failed to load main script: " + info.Main);
@@ -140,12 +221,19 @@ void ScriptLoader::Compile(const std::shared_ptr<Archive>& archive) {
             throw std::runtime_error("Failed to create TCCState");
         }
 
-        tcc_set_error_func(s, nullptr, [](void* opaque, const char* msg) {
+        std::string errorLog;
+
+        tcc_set_error_func(s, &errorLog, [](void* opaque, const char* msg) {
             std::string_view sv(msg);
             if (sv.find("warning") != std::string_view::npos) {
                 SPDLOG_WARN("Compiler: {}", msg);
             } else if (sv.find("error") != std::string_view::npos || sv.find("fatal") != std::string_view::npos) {
                 SPDLOG_ERROR("Compiler: {}", msg);
+                auto* log = static_cast<std::string*>(opaque);
+                if (!log->empty()) {
+                    log->push_back('\n');
+                }
+                *log += msg;
             } else {
                 SPDLOG_INFO("Compiler: {}", msg);
             }
@@ -158,6 +246,18 @@ void ScriptLoader::Compile(const std::shared_ptr<Archive>& archive) {
         }
 
         tcc_set_options(s, mBuildOptions.c_str());
+
+        // Tell TCC where its own includes and libtcc1.a live.
+        // We look for a library path whose parent has an "include" sibling
+        // (the canonical .tcc/ root layout).
+        for (const auto& libPath : mLibraryPaths) {
+            auto tccRoot = std::filesystem::path(libPath).parent_path();
+            if (std::filesystem::exists(tccRoot / "include")) {
+                tcc_set_lib_path(s, tccRoot.string().c_str());
+                break;
+            }
+        }
+
         tcc_set_output_type(s, TCC_OUTPUT_DLL);
 
         for (const std::string& includePath : mIncludePaths) {
@@ -221,14 +321,17 @@ void ScriptLoader::Compile(const std::shared_ptr<Archive>& archive) {
             std::string sourceCode = lineFixer + std::string(buf->begin(), buf->end());
             if (tcc_compile_string(s, sourceCode.c_str()) == -1) {
                 tcc_delete(s);
-                throw std::runtime_error("TCC Error in " + safePath);
+                throw std::runtime_error(errorLog.empty() ? "TCC Error in " + safePath : errorLog);
             }
         }
 
         if (tcc_output_file(s, temp.c_str()) == -1) {
             tcc_delete(s);
-            throw std::runtime_error("Failed to output compiled code for " + temp);
+            throw std::runtime_error(errorLog.empty() ? "Failed to output compiled code for " + temp : errorLog);
         }
+
+        StoreInCache(info, temp);
+#endif // DISABLE_TCC_COMPILER
     }
 
     loader.Init(temp);

--- a/src/ship/scripting/ScriptLoader.cpp
+++ b/src/ship/scripting/ScriptLoader.cpp
@@ -15,8 +15,7 @@
 #include <memory>
 #include <queue>
 #include <unordered_map>
-#include <fstream>
-#include <iomanip>
+#include <filesystem>
 
 namespace Ship {
 std::optional<std::vector<uint8_t>> LoadFromO2R(const std::string& path,
@@ -79,60 +78,6 @@ constexpr std::string_view GetPlatform() {
 #endif
 }
 
-void ScriptLoader::SetCacheDir(const std::filesystem::path& dir) {
-    mCacheDir = dir;
-}
-
-std::filesystem::path ScriptLoader::GetCachePath(const ArchiveManifest& manifest) const {
-    if (mCacheDir.empty() || manifest.Checksum.empty()) {
-        return {};
-    }
-
-    // Build a cache key from content identity + compiler configuration.
-    // Any change to the archive bytes, code version, or build flags will
-    // produce a different key and force a recompile.
-    std::string raw = manifest.Checksum + ":" + std::to_string(mCodeVersion) + ":" + mBuildOptions;
-
-    // Fold the string into a 64-bit hash (platform-independent hex string).
-    std::size_t h = 0;
-    for (unsigned char c : raw) {
-        h = h * 31 + c;
-    }
-
-    std::ostringstream oss;
-    oss << std::hex << std::setw(16) << std::setfill('0') << h;
-
-#if defined(_WIN32) || defined(__CYGWIN__)
-    return mCacheDir / (oss.str() + ".dll");
-#elif defined(__APPLE__)
-    return mCacheDir / (oss.str() + ".dylib");
-#else
-    return mCacheDir / (oss.str() + ".so");
-#endif
-}
-
-void ScriptLoader::StoreInCache(const ArchiveManifest& manifest, const std::string& srcPath) const {
-    const auto cachePath = GetCachePath(manifest);
-    if (cachePath.empty()) {
-        return;
-    }
-
-    std::error_code ec;
-    std::filesystem::create_directories(cachePath.parent_path(), ec);
-    if (ec) {
-        SPDLOG_WARN("ScriptLoader: failed to create cache directory {}: {}", cachePath.parent_path().string(),
-                    ec.message());
-        return;
-    }
-
-    std::filesystem::copy_file(srcPath, cachePath, std::filesystem::copy_options::overwrite_existing, ec);
-    if (ec) {
-        SPDLOG_WARN("ScriptLoader: failed to write cache entry {}: {}", cachePath.string(), ec.message());
-    } else {
-        SPDLOG_INFO("ScriptLoader: cached compiled script to {}", cachePath.string());
-    }
-}
-
 void ScriptLoader::Compile(const std::shared_ptr<Archive>& archive) {
     const ArchiveManifest& info = archive->GetManifest();
     constexpr std::string_view platform = GetPlatform();
@@ -177,24 +122,6 @@ void ScriptLoader::Compile(const std::shared_ptr<Archive>& archive) {
     Scripting::LibraryLoader loader;
 
     const auto& binaries = info.Binaries;
-    const std::string temp = loader.GenerateTempFile();
-
-#ifndef DISABLE_TCC_COMPILER
-    if (info.Binaries.find(std::string(platform)) == info.Binaries.end() && !info.Main.empty()) {
-        const auto cachePath = GetCachePath(info);
-        if (!cachePath.empty() && std::filesystem::exists(cachePath)) {
-            SPDLOG_INFO("ScriptLoader: cache hit for '{}', skipping recompile ({})", info.Name, cachePath.string());
-            std::error_code ec;
-            std::filesystem::copy_file(cachePath, temp, std::filesystem::copy_options::overwrite_existing, ec);
-            if (!ec) {
-                loader.Init(temp);
-                mLoadedScripts[info.Name] = loader;
-                return;
-            }
-            SPDLOG_WARN("ScriptLoader: failed to restore cache entry, recompiling: {}", ec.message());
-        }
-    }
-#endif
 
     if (binaries.contains(std::string(platform))) {
         const std::string& path = binaries.at(std::string(platform));
@@ -203,7 +130,12 @@ void ScriptLoader::Compile(const std::shared_ptr<Archive>& archive) {
             throw std::runtime_error("Failed to load platform-specific binary: " + path);
         }
 
+        // Prebuilt platform binary: written to a temp file and loaded through the
+        // platform dynamic linker. These are real shared libraries the mod author
+        // shipped (and can code-sign), so the loader path is unavoidable here.
+        const std::string temp = loader.GenerateTempFile();
         loader.WriteToTempFile(*data);
+        loader.Init(temp);
     } else if (!info.Main.empty()) {
 #ifdef DISABLE_TCC_COMPILER
         SPDLOG_WARN("ScriptLoader: '{}' ships C sources but the TCC compiler is disabled; provide a prebuilt "
@@ -258,7 +190,10 @@ void ScriptLoader::Compile(const std::shared_ptr<Archive>& archive) {
             }
         }
 
-        tcc_set_output_type(s, TCC_OUTPUT_DLL);
+        // Compile into memory rather than emitting a shared library: the code is
+        // JIT-relocated in-process (see InitInMemory below), so no executable is
+        // written to disk.
+        tcc_set_output_type(s, TCC_OUTPUT_MEMORY);
 
         for (const std::string& includePath : mIncludePaths) {
             if (!std::filesystem::exists(includePath)) {
@@ -325,16 +260,19 @@ void ScriptLoader::Compile(const std::shared_ptr<Archive>& archive) {
             }
         }
 
-        if (tcc_output_file(s, temp.c_str()) == -1) {
+        // Relocate the compiled unit into executable memory and hand ownership of
+        // the TCCState to the loader. No shared library is written to disk and
+        // neither dlopen() nor LoadLibrary() is called, which avoids the
+        // "drop an executable to disk and load it" pattern antivirus flags.
+        try {
+            loader.InitInMemory(s);
+        } catch (...) {
             tcc_delete(s);
-            throw std::runtime_error(errorLog.empty() ? "Failed to output compiled code for " + temp : errorLog);
+            throw;
         }
-
-        StoreInCache(info, temp);
 #endif // DISABLE_TCC_COMPILER
     }
 
-    loader.Init(temp);
     mLoadedScripts[info.Name] = loader;
 };
 


### PR DESCRIPTION
Loads TCC-compiled mod scripts in-memory instead of dropping a shared library to disk and loading it.

**Problem.** Scripts compiled from C source at runtime were written to a temp (or cache) directory as a `.dll`/`.so`/`.dylib` and then handed to `LoadLibrary`/`dlopen`. Writing an executable to disk and loading it is the textbook "drop and load" pattern that antivirus heuristics — and Windows Defender ASR rules — flag, so legitimate mods were getting quarantined. The on-disk compiled-script cache made it worse by leaving a persistent `.dll` for on-access scans.

**Fix.** Compile the sources with `TCC_OUTPUT_MEMORY` and JIT-relocate them in-process via `tcc_relocate()` / `tcc_get_symbol()`. TCC maps the code W^X (a read/execute view; no persistent RWX), nothing is ever written to disk, and `LoadLibrary`/`dlopen` is never called for compiled scripts. `LibraryLoader` owns the `TCCState` for the module's lifetime and frees it (`tcc_delete`) on unload.

**Unchanged.** Prebuilt platform binaries shipped inside a mod (`info.Binaries`) are real shared libraries and still load through the platform dynamic linker — mod authors can code-sign those.

**Cache.** Removes the on-disk compiled-script cache added earlier in the stack: in-memory output is not a cacheable file artifact, and that cache was the main on-disk executable the scanners objected to. TCC recompiles from source each launch (single-digit ms for a typical mod).

**Stacked on** #1261 (`port/script-cache`) — diff includes it until that merges.

Tested: compiles and links on macOS with `-DENABLE_SCRIPTING=ON`, and with `-DENABLE_TCC_COMPILER=OFF` (prebuilt-binary-only config). Runtime mod-load verification on Windows/Linux is the next step — in particular confirming host engine symbols resolve at `tcc_relocate` time (relies on the exported symbols from #1258).
