### PR TITLE
Fixes name for ShutdownHandler SDL quit event.

### DIFF
--- a/src/ship/debug/CrashHandler.cpp
+++ b/src/ship/debug/CrashHandler.cpp
@@ -218,7 +218,7 @@ static void ErrorHandler(int sig, siginfo_t* sigInfo, void* data) {
 
 static void ShutdownHandler(int sig, siginfo_t* sigInfo, void* data) {
     SDL_Event event;
-    event.type = SDL_QUIT;
+    event.type = SDL_EVENT_QUIT;
     SDL_PushEvent(&event);
 }
 


### PR DESCRIPTION
The SDL_Quit event was renamed to SDL_Event_Quit in SDL3. A PR was merged which uses the old name, so it now needs to be updated to use the new name.