### PR TITLE
Make ConsoleVariable thread-safe (port-maintenance)

### DIFF
--- a/include/ship/config/ConsoleVariable.h
+++ b/include/ship/config/ConsoleVariable.h
@@ -4,6 +4,7 @@
 #include <nlohmann/json.hpp>
 #include <stdint.h>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <string>
 #include <string_view>
@@ -209,5 +210,7 @@ class ConsoleVariable {
         }
     };
     std::unordered_map<std::string, std::shared_ptr<CVar>, TransparentStringHash, TransparentStringEqual> mVariables;
+    // Guards mVariables against concurrent access from the audio thread and the game thread.
+    std::recursive_mutex mVariablesMutex;
 };
 } // namespace Ship

--- a/src/ship/config/ConsoleVariable.cpp
+++ b/src/ship/config/ConsoleVariable.cpp
@@ -21,11 +21,13 @@ ConsoleVariable::~ConsoleVariable() {
 }
 
 std::shared_ptr<CVar> ConsoleVariable::Get(const char* name) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto it = mVariables.find(name);
     return it != mVariables.end() ? it->second : nullptr;
 }
 
 int32_t ConsoleVariable::GetInteger(const char* name, int32_t defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Integer) {
@@ -36,6 +38,7 @@ int32_t ConsoleVariable::GetInteger(const char* name, int32_t defaultValue) {
 }
 
 float ConsoleVariable::GetFloat(const char* name, float defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Float) {
@@ -46,6 +49,7 @@ float ConsoleVariable::GetFloat(const char* name, float defaultValue) {
 }
 
 const char* ConsoleVariable::GetString(const char* name, const char* defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::String) {
@@ -56,6 +60,7 @@ const char* ConsoleVariable::GetString(const char* name, const char* defaultValu
 }
 
 Color_RGBA8 ConsoleVariable::GetColor(const char* name, Color_RGBA8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Color) {
@@ -73,6 +78,7 @@ Color_RGBA8 ConsoleVariable::GetColor(const char* name, Color_RGBA8 defaultValue
 }
 
 Color_RGB8 ConsoleVariable::GetColor24(const char* name, Color_RGB8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto variable = Get(name);
 
     if (variable != nullptr && variable->Type == ConsoleVariableType::Color24) {
@@ -89,6 +95,7 @@ Color_RGB8 ConsoleVariable::GetColor24(const char* name, Color_RGB8 defaultValue
 }
 
 void ConsoleVariable::SetInteger(const char* name, int32_t value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (variable == nullptr) {
         variable = std::make_shared<CVar>();
@@ -99,6 +106,7 @@ void ConsoleVariable::SetInteger(const char* name, int32_t value) {
 }
 
 void ConsoleVariable::SetFloat(const char* name, float value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (variable == nullptr) {
         variable = std::make_shared<CVar>();
@@ -109,6 +117,7 @@ void ConsoleVariable::SetFloat(const char* name, float value) {
 }
 
 void ConsoleVariable::SetString(const char* name, const char* value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (variable == nullptr) {
         variable = std::make_shared<CVar>();
@@ -122,6 +131,7 @@ void ConsoleVariable::SetString(const char* name, const char* value) {
 }
 
 void ConsoleVariable::SetColor(const char* name, Color_RGBA8 value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (!variable) {
         variable = std::make_shared<CVar>();
@@ -132,6 +142,7 @@ void ConsoleVariable::SetColor(const char* name, Color_RGBA8 value) {
 }
 
 void ConsoleVariable::SetColor24(const char* name, Color_RGB8 value) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variable = mVariables[name];
     if (!variable) {
         variable = std::make_shared<CVar>();
@@ -142,36 +153,42 @@ void ConsoleVariable::SetColor24(const char* name, Color_RGB8 value) {
 }
 
 void ConsoleVariable::RegisterInteger(const char* name, int32_t defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetInteger(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterFloat(const char* name, float defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetFloat(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterString(const char* name, const char* defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetString(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterColor(const char* name, Color_RGBA8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetColor(name, defaultValue);
     }
 }
 
 void ConsoleVariable::RegisterColor24(const char* name, Color_RGB8 defaultValue) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     if (Get(name) == nullptr) {
         SetColor24(name, defaultValue);
     }
 }
 
 void ConsoleVariable::ClearVariable(const char* name) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     auto var = Get(name);
     if (var != nullptr) {
@@ -202,12 +219,14 @@ void ConsoleVariable::ClearVariable(const char* name) {
 }
 
 void ConsoleVariable::ClearBlock(const char* name) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     conf->EraseBlock(StringHelper::Sprintf("CVars.%s", name));
     Load();
 }
 
 void ConsoleVariable::CopyVariable(const char* from, const char* to) {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     auto& variableFrom = mVariables[from];
     if (!variableFrom) {
         return;
@@ -241,6 +260,7 @@ void ConsoleVariable::CopyVariable(const char* from, const char* to) {
 }
 
 void ConsoleVariable::Save() {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
 
     for (const auto& variable : mVariables) {
@@ -277,6 +297,7 @@ void ConsoleVariable::Save() {
 }
 
 void ConsoleVariable::Load() {
+    std::lock_guard<std::recursive_mutex> lock(mVariablesMutex);
     std::shared_ptr<Config> conf = Context::GetRawInstance()->GetConfig();
     conf->Reload();
     if (!mVariables.empty()) {


### PR DESCRIPTION
Brings main's #1253 to port-maintenance. Same 24 lines; port-maintenance has no Component system, so the config lookups stay as they are.

Fixes the audio-thread crash. #1227 becomes an optimisation on top.