### PR TITLE
Derive the WASAPI start threshold and DesiredBuffered from GetBufferSize

### DIFF
--- a/src/ship/audio/WasapiAudioPlayer.cpp
+++ b/src/ship/audio/WasapiAudioPlayer.cpp
@@ -123,7 +123,10 @@ int WasapiAudioPlayer::Buffered() {
     try {
         UINT32 padding;
         ThrowIfFailed(mClient->GetCurrentPadding(&padding));
-        return padding;
+        // Initialize may allocate a buffer smaller than the caller's target, which the
+        // padding could then never reach; report the target as met once the endpoint
+        // buffer is genuinely full, the same way an unusable device does below.
+        return padding >= mBufferFrameCount ? GetDesiredBuffered() : static_cast<int>(padding);
     } catch (const HResultException& e) {
         SPDLOG_ERROR("WasapiAudioPlayer::Buffered failed: {}", e.what());
         return GetDesiredBuffered();
@@ -155,7 +158,10 @@ void WasapiAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
         memcpy(data, buf, frames * mNumChannels * sizeof(int16_t));
         ThrowIfFailed(mRenderClient->ReleaseBuffer(frames, 0));
 
-        if (!mStarted && padding + frames > 1500) {
+        // Initialize may allocate a smaller buffer than it was asked for, so a fixed prefill
+        // target can exceed the whole buffer and the stream then never starts at all.
+        const UINT32 prefill = mBufferFrameCount / 2 < 1500 ? mBufferFrameCount / 2 : 1500;
+        if (!mStarted && padding + frames > prefill) {
             mStarted = true;
             ThrowIfFailed(mClient->Start());
         }


### PR DESCRIPTION
Fixes #1211 — candidate, see the caveat below.

`Initialize` may allocate a smaller buffer than the requested duration ([docs](https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-getbuffersize): *"the actual size of the allocated buffer … might differ from the requested size"*). Two fixed constants then become unreachable:

- `padding + frames > 1500` gates `Start()`, but `frames` is clamped to `mBufferFrameCount - padding`, so a buffer ≤ 1500 frames never starts the stream at all.
- `DesiredBuffered` (4096 from SoH) is what callers pace on, and `Buffered()` saturates at `mBufferFrameCount`. A smaller buffer is never "full enough", so the producer loops forever.

Either one alone freezes the boot; they are independent, so both are fixed. `Buffered()` now reports the target as met once the endpoint buffer is genuinely full — the same idiom #1212 already uses for an unusable device — rather than mutating the caller's settings, so nothing is stateful and a later device change with a bigger buffer recovers on its own.

Measured by cross-compiling this file with MinGW and driving it exactly as SoH's `OTRAudio_Thread` does, varying the requested `hnsBufferDuration`:

| `mBufferFrameCount` | before | after |
|---|---|---|
| 6400 | 41 batches, 393 paced waits | 41 batches, 392 paced waits |
| 3200 | fine | unchanged |
| 960 | **8,386,205 batches, 0 paced waits** (hot spin) | 199 batches, 393 paced waits |

The 1500 predates SoH — it arrived with the 2022-03-22 libultraship subrepo import and was never revisited.

**Caveats, stated plainly:**

- Tested only under Wine. I have no Windows setup, so I could not observe a small buffer occurring naturally — I forced it. Whether @garrettjoecox's machine actually lands under 1500 frames is unverified; a one-line log of `mBufferFrameCount` on his box would confirm or kill it.
- A device whose buffer is smaller than the caller's batch still gets choppy audio, because `DoPlay` clamps a batch to the free space and drops the remainder. That predates this change and is the port's to solve by sizing batches to the device; libultraship's job here is to report reachable targets rather than hang.
- The fix follows the Win32 documentation regardless of whether it is #1211's cause: comparing a hardcoded frame count against a buffer the API says may be any size is wrong on its own terms.

Pairs with #1272 on `main`.