### PR TITLE
fix(audio): eliminate macOS CoreAudio crackling (port-maintenance)

### DIFF
--- a/include/ship/audio/CoreAudioAudioPlayer.h
+++ b/include/ship/audio/CoreAudioAudioPlayer.h
@@ -4,7 +4,7 @@
 
 #include "AudioPlayer.h"
 #include <AudioToolbox/AudioToolbox.h>
-#include <pthread.h>
+#include <atomic>
 
 namespace Ship {
 /**
@@ -55,7 +55,8 @@ class CoreAudioAudioPlayer : public AudioPlayer {
      * @brief Core Audio render callback that pulls samples from the ring buffer.
      *
      * Called on the audio thread by the output AudioUnit whenever it needs more
-     * sample data. Reads from the ring buffer under the mutex lock.
+     * sample data. Reads lock-free from the ring buffer using atomic read/write
+     * indices (SPSC).
      *
      * @param inRefCon Pointer to the owning CoreAudioAudioPlayer instance.
      * @param ioActionFlags Render action flags (unused).
@@ -71,11 +72,14 @@ class CoreAudioAudioPlayer : public AudioPlayer {
 
     AudioUnit mAudioUnit;
     int32_t mNumChannels;
-    uint8_t* mRingBuffer;       ///< Lock-protected circular buffer for audio samples.
-    size_t mRingBufferSize;     ///< Total size of the ring buffer in bytes.
-    size_t mRingBufferReadPos;  ///< Current read position in the ring buffer.
-    size_t mRingBufferWritePos; ///< Current write position in the ring buffer.
-    pthread_mutex_t mMutex;     ///< Guards concurrent access to the ring buffer.
+    uint8_t* mRingBuffer;   ///< SPSC circular buffer for audio samples (no locking).
+    size_t mRingBufferSize; ///< Total size of the ring buffer in bytes.
+    /// Read position. Written only by the consumer (render callback);
+    /// read by both with acquire/release ordering.
+    std::atomic<size_t> mRingBufferReadPos;
+    /// Write position. Written only by the producer (DoPlay);
+    /// read by both with acquire/release ordering.
+    std::atomic<size_t> mRingBufferWritePos;
     bool mInitialized;
 };
 } // namespace Ship

--- a/src/ship/audio/CoreAudioAudioPlayer.cpp
+++ b/src/ship/audio/CoreAudioAudioPlayer.cpp
@@ -5,14 +5,14 @@
 
 namespace Ship {
 
-CoreAudioAudioPlayer::CoreAudioAudioPlayer(AudioSettings settings) : AudioPlayer(settings), mInitialized(false) {
-    pthread_mutex_init(&mMutex, NULL);
+CoreAudioAudioPlayer::CoreAudioAudioPlayer(AudioSettings settings)
+    : AudioPlayer(settings), mAudioUnit(nullptr), mNumChannels(0), mRingBuffer(nullptr), mRingBufferSize(0),
+      mRingBufferReadPos(0), mRingBufferWritePos(0), mInitialized(false) {
 }
 
 CoreAudioAudioPlayer::~CoreAudioAudioPlayer() {
     SPDLOG_TRACE("destruct CoreAudio audio player");
     DoClose();
-    pthread_mutex_destroy(&mMutex);
 }
 
 void CoreAudioAudioPlayer::DoClose() {
@@ -32,15 +32,18 @@ void CoreAudioAudioPlayer::DoClose() {
 bool CoreAudioAudioPlayer::DoInit() {
     OSStatus status;
 
-    mNumChannels = this->GetAudioChannels() == AudioChannelsSetting::audioStereo ? 2 : 6;
+    mNumChannels = GetNumOutputChannels();
 
     const size_t bytesPerSample = sizeof(int16_t);
     const size_t bytesPerFrame = bytesPerSample * mNumChannels;
 
-    mRingBufferSize = 6000 * bytesPerFrame;
+    // Reserve one extra frame so write == read unambiguously means "empty";
+    // a buffer is full when (write + frame) % size == read. Usable capacity
+    // stays at 6000 frames, matching the prior implementation.
+    mRingBufferSize = (6000 + 1) * bytesPerFrame;
     mRingBuffer = new uint8_t[mRingBufferSize];
-    mRingBufferReadPos = 0;
-    mRingBufferWritePos = 0;
+    mRingBufferReadPos.store(0, std::memory_order_relaxed);
+    mRingBufferWritePos.store(0, std::memory_order_relaxed);
 
     AudioComponentDescription desc;
     desc.componentType = kAudioUnitType_Output;
@@ -114,50 +117,35 @@ bool CoreAudioAudioPlayer::DoInit() {
 }
 
 int CoreAudioAudioPlayer::Buffered() {
-    pthread_mutex_lock(&mMutex);
-    size_t buffered;
-
-    if (mRingBufferWritePos >= mRingBufferReadPos) {
-        buffered = mRingBufferWritePos - mRingBufferReadPos;
-    } else {
-        buffered = mRingBufferSize - (mRingBufferReadPos - mRingBufferWritePos);
-    }
-
-    const size_t bytesPerFrame = sizeof(int16_t) * mNumChannels;
-    int samples = buffered / bytesPerFrame;
-
-    pthread_mutex_unlock(&mMutex);
-    return samples;
+    size_t r = mRingBufferReadPos.load(std::memory_order_acquire);
+    size_t w = mRingBufferWritePos.load(std::memory_order_acquire);
+    size_t buffered = (w >= r) ? (w - r) : (mRingBufferSize - (r - w));
+    return buffered / (sizeof(int16_t) * mNumChannels);
 }
 
 void CoreAudioAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
-    pthread_mutex_lock(&mMutex);
-
     const size_t bytesPerFrame = sizeof(int16_t) * mNumChannels;
-    const size_t maxBuffered = 6000 * bytesPerFrame;
+    size_t r = mRingBufferReadPos.load(std::memory_order_acquire);
+    size_t w = mRingBufferWritePos.load(std::memory_order_relaxed);
+    // free space leaves one frame reserved so write can never collide with read
+    size_t freeSpace = (w >= r) ? (mRingBufferSize - (w - r) - bytesPerFrame)
+                                : (r - w - bytesPerFrame);
 
-    size_t available;
-    if (mRingBufferWritePos >= mRingBufferReadPos) {
-        available = mRingBufferSize - (mRingBufferWritePos - mRingBufferReadPos);
+    // Preserve producer chunk boundaries. Splitting an audio-engine buffer here
+    // drops the tail of already-generated PCM and creates a discontinuity.
+    if (len > freeSpace) {
+        return;
+    }
+
+    size_t writeEnd = w + len;
+    if (writeEnd <= mRingBufferSize) {
+        memcpy(mRingBuffer + w, buf, len);
     } else {
-        available = mRingBufferReadPos - mRingBufferWritePos;
+        size_t firstChunk = mRingBufferSize - w;
+        memcpy(mRingBuffer + w, buf, firstChunk);
+        memcpy(mRingBuffer, buf + firstChunk, len - firstChunk);
     }
-
-    if (available >= len) {
-        size_t writeEnd = mRingBufferWritePos + len;
-
-        if (writeEnd <= mRingBufferSize) {
-            memcpy(mRingBuffer + mRingBufferWritePos, buf, len);
-        } else {
-            size_t firstChunk = mRingBufferSize - mRingBufferWritePos;
-            memcpy(mRingBuffer + mRingBufferWritePos, buf, firstChunk);
-            memcpy(mRingBuffer, buf + firstChunk, len - firstChunk);
-        }
-
-        mRingBufferWritePos = (mRingBufferWritePos + len) % mRingBufferSize;
-    }
-
-    pthread_mutex_unlock(&mMutex);
+    mRingBufferWritePos.store((w + len) % mRingBufferSize, std::memory_order_release);
 }
 
 OSStatus CoreAudioAudioPlayer::CoreAudioRenderCallback(void* inRefCon, AudioUnitRenderActionFlags* ioActionFlags,
@@ -170,14 +158,9 @@ OSStatus CoreAudioAudioPlayer::CoreAudioRenderCallback(void* inRefCon, AudioUnit
         UInt8* outputBuffer = static_cast<UInt8*>(buffer->mData);
         UInt32 bytesToWrite = buffer->mDataByteSize;
 
-        pthread_mutex_lock(&player->mMutex);
-
-        size_t available;
-        if (player->mRingBufferWritePos >= player->mRingBufferReadPos) {
-            available = player->mRingBufferWritePos - player->mRingBufferReadPos;
-        } else {
-            available = player->mRingBufferSize - (player->mRingBufferReadPos - player->mRingBufferWritePos);
-        }
+        size_t r = player->mRingBufferReadPos.load(std::memory_order_relaxed);
+        size_t w = player->mRingBufferWritePos.load(std::memory_order_acquire);
+        size_t available = (w >= r) ? (w - r) : (player->mRingBufferSize - (r - w));
 
         UInt32 bytesToCopy = bytesToWrite;
         if (bytesToCopy > available) {
@@ -185,24 +168,21 @@ OSStatus CoreAudioAudioPlayer::CoreAudioRenderCallback(void* inRefCon, AudioUnit
         }
 
         if (bytesToCopy > 0) {
-            size_t readEnd = player->mRingBufferReadPos + bytesToCopy;
-
+            size_t readEnd = r + bytesToCopy;
             if (readEnd <= player->mRingBufferSize) {
-                memcpy(outputBuffer, player->mRingBuffer + player->mRingBufferReadPos, bytesToCopy);
+                memcpy(outputBuffer, player->mRingBuffer + r, bytesToCopy);
             } else {
-                size_t firstChunk = player->mRingBufferSize - player->mRingBufferReadPos;
-                memcpy(outputBuffer, player->mRingBuffer + player->mRingBufferReadPos, firstChunk);
+                size_t firstChunk = player->mRingBufferSize - r;
+                memcpy(outputBuffer, player->mRingBuffer + r, firstChunk);
                 memcpy(outputBuffer + firstChunk, player->mRingBuffer, bytesToCopy - firstChunk);
             }
-
-            player->mRingBufferReadPos = (player->mRingBufferReadPos + bytesToCopy) % player->mRingBufferSize;
+            player->mRingBufferReadPos.store((r + bytesToCopy) % player->mRingBufferSize,
+                                             std::memory_order_release);
         }
 
         if (bytesToCopy < bytesToWrite) {
             memset(outputBuffer + bytesToCopy, 0, bytesToWrite - bytesToCopy);
         }
-
-        pthread_mutex_unlock(&player->mMutex);
     }
 
     return noErr;

--- a/src/ship/audio/CoreAudioAudioPlayer.cpp
+++ b/src/ship/audio/CoreAudioAudioPlayer.cpp
@@ -128,8 +128,7 @@ void CoreAudioAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
     size_t r = mRingBufferReadPos.load(std::memory_order_acquire);
     size_t w = mRingBufferWritePos.load(std::memory_order_relaxed);
     // free space leaves one frame reserved so write can never collide with read
-    size_t freeSpace = (w >= r) ? (mRingBufferSize - (w - r) - bytesPerFrame)
-                                : (r - w - bytesPerFrame);
+    size_t freeSpace = (w >= r) ? (mRingBufferSize - (w - r) - bytesPerFrame) : (r - w - bytesPerFrame);
 
     // Preserve producer chunk boundaries. Splitting an audio-engine buffer here
     // drops the tail of already-generated PCM and creates a discontinuity.
@@ -176,8 +175,7 @@ OSStatus CoreAudioAudioPlayer::CoreAudioRenderCallback(void* inRefCon, AudioUnit
                 memcpy(outputBuffer, player->mRingBuffer + r, firstChunk);
                 memcpy(outputBuffer + firstChunk, player->mRingBuffer, bytesToCopy - firstChunk);
             }
-            player->mRingBufferReadPos.store((r + bytesToCopy) % player->mRingBufferSize,
-                                             std::memory_order_release);
+            player->mRingBufferReadPos.store((r + bytesToCopy) % player->mRingBufferSize, std::memory_order_release);
         }
 
         if (bytesToCopy < bytesToWrite) {


### PR DESCRIPTION
Cherry-pick of #1098 (@banteg), merged to `main` as 82d5ae8b. SoH pins `port-maintenance`,
so without this twin macOS users keep the crackling.

Applied clean - `GetNumOutputChannels()` already exists here, so the one line I expected to
conflict did not.

Second commit is whitespace only: `tidy-format` is not in 82d5ae8b's check runs, so `main`
merged two over-wrapped lines that clang-format-14 rejects here. `main` is the branch that
is out of format, not this one.

Not built locally - no macOS machine here. CI's build-macos and build-ios pass.
