### PR TITLE
Never take mMutex in the WASAPI device-change callback (port-maintenance)

### DIFF
--- a/include/ship/audio/WasapiAudioPlayer.h
+++ b/include/ship/audio/WasapiAudioPlayer.h
@@ -6,6 +6,7 @@
 #include <wrl/client.h>
 #include <mmdeviceapi.h>
 #include <audioclient.h>
+#include <atomic>
 #include <mutex>
 
 using namespace Microsoft::WRL;
@@ -111,10 +112,11 @@ class WasapiAudioPlayer : public AudioPlayer, public IMMNotificationClient {
     ComPtr<IAudioRenderClient> mRenderClient;      ///< WASAPI render client for writing PCM data.
     LONG mRefCount = 1;                            ///< IUnknown reference count.
     UINT32 mBufferFrameCount = 0;                  ///< Size of the WASAPI render buffer in frames.
-    bool mInitialized = false;                     ///< True after DoInit() succeeds.
+    std::atomic<bool> mInitialized{ false };       ///< True while the stream on the current default device is usable.
+    std::atomic<uint32_t> mDeviceGeneration{ 0 };  ///< Bumped on every default-device change.
     bool mStarted = false;                         ///< True after IAudioClient::Start() is called.
     int32_t mNumChannels = 2;                      ///< Number of output channels (2 or 6).
-    std::mutex mMutex;                             ///< Serialises DoPlay() and device-change callbacks.
+    std::mutex mMutex;                             ///< Serialises DoPlay(), Buffered() and DoClose().
 };
 } // namespace Ship
 #endif

--- a/src/ship/audio/WasapiAudioPlayer.cpp
+++ b/src/ship/audio/WasapiAudioPlayer.cpp
@@ -25,15 +25,24 @@ void WasapiAudioPlayer::ThrowIfFailed(HRESULT res) {
 }
 
 WasapiAudioPlayer::~WasapiAudioPlayer() {
-    DoClose();
-
     if (mDeviceEnumerator) {
         mDeviceEnumerator->UnregisterEndpointNotificationCallback(this);
         mDeviceEnumerator.Reset();
     }
+
+    DoClose();
 }
 
 bool WasapiAudioPlayer::SetupStream() {
+    const uint32_t generation = mDeviceGeneration.load(std::memory_order_acquire);
+
+    // Dropping a running client without stopping it leaves the old endpoint streaming.
+    if (mClient) {
+        mClient->Stop();
+        mRenderClient.Reset();
+        mClient.Reset();
+    }
+
     try {
         ThrowIfFailed(mDeviceEnumerator->GetDefaultAudioEndpoint(eRender, eConsole, &mDevice));
         ThrowIfFailed(mDevice->Activate(IID_IAudioClient, CLSCTX_ALL, nullptr, IID_PPV_ARGS_Helper(&mClient)));
@@ -77,13 +86,14 @@ bool WasapiAudioPlayer::SetupStream() {
         ThrowIfFailed(mClient->GetService(IID_PPV_ARGS(&mRenderClient)));
 
         mStarted = false;
-        mInitialized = true;
+        // A device change during setup leaves this stream on the old endpoint, so discard it.
+        mInitialized.store(generation == mDeviceGeneration.load(std::memory_order_acquire), std::memory_order_release);
     } catch (const HResultException& e) {
         SPDLOG_ERROR("WasapiAudioPlayer::SetupStream failed: {}", e.what());
         return false;
     }
 
-    return true;
+    return mInitialized.load(std::memory_order_acquire);
 }
 
 bool WasapiAudioPlayer::DoInit() {
@@ -109,7 +119,7 @@ void WasapiAudioPlayer::DoClose() {
     mRenderClient.Reset();
     mClient.Reset();
     mDevice.Reset();
-    mInitialized = false;
+    mInitialized.store(false, std::memory_order_release);
     mStarted = false;
 }
 
@@ -177,9 +187,10 @@ HRESULT STDMETHODCALLTYPE WasapiAudioPlayer::OnDeviceRemoved(LPCWSTR pwstrDevice
 HRESULT STDMETHODCALLTYPE WasapiAudioPlayer::OnDefaultDeviceChanged(EDataFlow flow, ERole role,
                                                                     LPCWSTR pwstrDefaultDeviceId) {
     if (flow == eRender && role == eConsole) {
-        // This callback runs on a separate thread, so we need to protect mInitialized
-        std::lock_guard<std::mutex> lock(mMutex);
-        mInitialized = false;
+        // Taking mMutex here deadlocks: DoPlay() holds it across MMDevice calls that cannot
+        // complete until this callback returns.
+        mDeviceGeneration.fetch_add(1, std::memory_order_acq_rel);
+        mInitialized.store(false, std::memory_order_release);
     }
     return S_OK;
 }


### PR DESCRIPTION
Fixes #1211.

`OnDefaultDeviceChanged` runs on an MMDevice thread and takes `mMutex`. `DoPlay()` and `Buffered()` hold that same `mMutex` across `GetDefaultAudioEndpoint` / `Activate` / `Initialize`, which MMDevice cannot finish until the callback returns. The lock in the callback came in with #1001 (2026-02-28) — that is @garrettjoecox's "broke in the last 6 months".

Why the earlier attempts missed it: #1212 covers `SetupStream()` *failing*, #1271/#1272 cover a short device buffer. Both are the success path plus a lock, and the lock is the hang.

The generation counter is load-bearing: without it, a device change landing during `SetupStream()` leaves `mInitialized == true` on the endpoint that just went away and nothing retries.

Also here: `SetupStream()` stops the old client before dropping it. Re-setup previously released a running `IAudioClient` without `Stop()`.

Measured under Wine — mingw harness driving the real player, callback invoked from a second thread while the audio thread is in `DoPlay()`:

| device changes | callback block, mean / max |
| --- | --- |
| 5, 200 ms apart — before | 0.002 / 0.003 ms |
| 5, 200 ms apart — after | 0.000 / 0.000 ms |
| 100 per second — before | 7.877 / 12.531 ms |
| 100 per second — after | 0.000 / 0.001 ms |

Both recover to `Buffered() == 6400`. Under the 100/s storm the patched build serves 55 `DoPlay` calls against 9605, because every generation bump forces a full re-setup; at a realistic rate it is marginally ahead.

Wine does not reproduce the deadlock itself — no Windows machine here, same caveat as #1271. What is measured is that the callback no longer blocks on the audio path, which is the mechanism. @garrettjoecox narrowed this to the callback on real hardware.

`main` twin to follow.
