### PR TITLE
Never take mMutex in the WASAPI device-change callback (main)

### DIFF
--- a/include/ship/audio/WasapiAudioPlayer.h
+++ b/include/ship/audio/WasapiAudioPlayer.h
@@ -6,6 +6,7 @@
 #include <wrl/client.h>
 #include <mmdeviceapi.h>
 #include <audioclient.h>
+#include <atomic>
 #include <mutex>
 
 using namespace Microsoft::WRL;
@@ -111,10 +112,11 @@ class WasapiAudioPlayer : public AudioPlayer, public IMMNotificationClient {
     ComPtr<IAudioRenderClient> mRenderClient;      ///< WASAPI render client for writing PCM data.
     LONG mRefCount = 1;                            ///< IUnknown reference count.
     UINT32 mBufferFrameCount = 0;                  ///< Size of the WASAPI render buffer in frames.
-    bool mInitialized = false;                     ///< True after DoInit() succeeds.
+    std::atomic<bool> mInitialized{ false };       ///< True while the stream on the current default device is usable.
+    std::atomic<uint32_t> mDeviceGeneration{ 0 };  ///< Bumped on every default-device change.
     bool mStarted = false;                         ///< True after IAudioClient::Start() is called.
     int32_t mNumChannels = 2;                      ///< Number of output channels (2 or 6).
-    std::mutex mMutex;                             ///< Serialises DoPlay() and device-change callbacks.
+    std::mutex mMutex;                             ///< Serialises DoPlay(), Buffered() and DoClose().
 };
 } // namespace Ship
 #endif

--- a/src/ship/audio/CoreAudioAudioPlayer.cpp
+++ b/src/ship/audio/CoreAudioAudioPlayer.cpp
@@ -128,8 +128,7 @@ void CoreAudioAudioPlayer::DoPlay(const uint8_t* buf, size_t len) {
     size_t r = mRingBufferReadPos.load(std::memory_order_acquire);
     size_t w = mRingBufferWritePos.load(std::memory_order_relaxed);
     // free space leaves one frame reserved so write can never collide with read
-    size_t freeSpace = (w >= r) ? (mRingBufferSize - (w - r) - bytesPerFrame)
-                                : (r - w - bytesPerFrame);
+    size_t freeSpace = (w >= r) ? (mRingBufferSize - (w - r) - bytesPerFrame) : (r - w - bytesPerFrame);
 
     // Preserve producer chunk boundaries. Splitting an audio-engine buffer here
     // drops the tail of already-generated PCM and creates a discontinuity.
@@ -176,8 +175,7 @@ OSStatus CoreAudioAudioPlayer::CoreAudioRenderCallback(void* inRefCon, AudioUnit
                 memcpy(outputBuffer, player->mRingBuffer + r, firstChunk);
                 memcpy(outputBuffer + firstChunk, player->mRingBuffer, bytesToCopy - firstChunk);
             }
-            player->mRingBufferReadPos.store((r + bytesToCopy) % player->mRingBufferSize,
-                                             std::memory_order_release);
+            player->mRingBufferReadPos.store((r + bytesToCopy) % player->mRingBufferSize, std::memory_order_release);
         }
 
         if (bytesToCopy < bytesToWrite) {

--- a/src/ship/audio/WasapiAudioPlayer.cpp
+++ b/src/ship/audio/WasapiAudioPlayer.cpp
@@ -25,15 +25,24 @@ void WasapiAudioPlayer::ThrowIfFailed(HRESULT res) {
 }
 
 WasapiAudioPlayer::~WasapiAudioPlayer() {
-    DoClose();
-
     if (mDeviceEnumerator) {
         mDeviceEnumerator->UnregisterEndpointNotificationCallback(this);
         mDeviceEnumerator.Reset();
     }
+
+    DoClose();
 }
 
 bool WasapiAudioPlayer::SetupStream() {
+    const uint32_t generation = mDeviceGeneration.load(std::memory_order_acquire);
+
+    // Dropping a running client without stopping it leaves the old endpoint streaming.
+    if (mClient) {
+        mClient->Stop();
+        mRenderClient.Reset();
+        mClient.Reset();
+    }
+
     try {
         ThrowIfFailed(mDeviceEnumerator->GetDefaultAudioEndpoint(eRender, eConsole, &mDevice));
         ThrowIfFailed(mDevice->Activate(IID_IAudioClient, CLSCTX_ALL, nullptr, IID_PPV_ARGS_Helper(&mClient)));
@@ -77,13 +86,14 @@ bool WasapiAudioPlayer::SetupStream() {
         ThrowIfFailed(mClient->GetService(IID_PPV_ARGS(&mRenderClient)));
 
         mStarted = false;
-        mInitialized = true;
+        // A device change during setup leaves this stream on the old endpoint, so discard it.
+        mInitialized.store(generation == mDeviceGeneration.load(std::memory_order_acquire), std::memory_order_release);
     } catch (const HResultException& e) {
         SPDLOG_ERROR("WasapiAudioPlayer::SetupStream failed: {}", e.what());
         return false;
     }
 
-    return true;
+    return mInitialized.load(std::memory_order_acquire);
 }
 
 bool WasapiAudioPlayer::DoInit() {
@@ -109,7 +119,7 @@ void WasapiAudioPlayer::DoClose() {
     mRenderClient.Reset();
     mClient.Reset();
     mDevice.Reset();
-    mInitialized = false;
+    mInitialized.store(false, std::memory_order_release);
     mStarted = false;
 }
 
@@ -177,9 +187,10 @@ HRESULT STDMETHODCALLTYPE WasapiAudioPlayer::OnDeviceRemoved(LPCWSTR pwstrDevice
 HRESULT STDMETHODCALLTYPE WasapiAudioPlayer::OnDefaultDeviceChanged(EDataFlow flow, ERole role,
                                                                     LPCWSTR pwstrDefaultDeviceId) {
     if (flow == eRender && role == eConsole) {
-        // This callback runs on a separate thread, so we need to protect mInitialized
-        std::lock_guard<std::mutex> lock(mMutex);
-        mInitialized = false;
+        // Taking mMutex here deadlocks: DoPlay() holds it across MMDevice calls that cannot
+        // complete until this callback returns.
+        mDeviceGeneration.fetch_add(1, std::memory_order_acq_rel);
+        mInitialized.store(false, std::memory_order_release);
     }
     return S_OK;
 }


### PR DESCRIPTION
`main` twin of #1280 — same commit, files are identical between the two branches. #1280 is the half the ports consume; this one keeps `main` from regressing back into the deadlock.

`OnDefaultDeviceChanged` runs on an MMDevice thread and takes `mMutex`. `DoPlay()` and `Buffered()` hold that same `mMutex` across `GetDefaultAudioEndpoint` / `Activate` / `Initialize`, which MMDevice cannot finish until the callback returns. The lock in the callback came in with #1001.

Rationale, the generation counter, and the Wine measurements are in #1280 rather than repeated here.

Re #1211.

Second commit is whitespace only and unrelated: #1098 merged without `tidy-format` among its check runs, so `main` carries two lines clang-format-14 rewraps in `CoreAudioAudioPlayer.cpp`. `tidy-format` is red on every `main` PR until that lands — same fix as #1275's second commit. Drop it if you would rather take it separately.
