### PR TITLE
Load alt assets before falling back to a cached standard asset

### DIFF
--- a/src/ship/resource/ResourceManager.cpp
+++ b/src/ship/resource/ResourceManager.cpp
@@ -263,6 +263,12 @@ ResourceManager::CheckCache(const ResourceIdentifier& identifier, bool loadExact
         if (std::holds_alternative<std::shared_ptr<IResource>>(altCacheResult)) {
             return altCacheResult;
         }
+
+        // If the alternate asset has not been attempted yet, report a miss so it gets loaded before the standard
+        // asset is used.
+        if (std::get<ResourceLoadError>(altCacheResult) == ResourceLoadError::NotCached) {
+            return ResourceLoadError::NotCached;
+        }
     }
 
     const std::lock_guard<std::mutex> lock(mMutex);
@@ -357,7 +363,8 @@ void ResourceManager::DirtyResources(const ResourceFilter& filter) {
         auto list = GetArchiveManager()->ListFiles(filter.IncludeMasks, filter.ExcludeMasks);
 
         for (const auto& key : *list.get()) {
-            auto resource = GetCachedResource({ key, filter.Owner, filter.Parent });
+            // The key is the exact path of a file, so we do not want to redirect to an alternate asset here.
+            auto resource = GetCachedResource({ key, filter.Owner, filter.Parent }, true);
             // If it's a resource, we will set the dirty flag, else we will just unload it.
             if (resource != nullptr) {
                 resource->Dirty();


### PR DESCRIPTION
### Problem
Mods that replace scene headers or collision under `alt/` stop working after alt assets have been toggled off and then on. The alt textures come back, but the game keeps using the standard scene layout and collision until it is restarted.

The cause is in the resource cache. When alt assets are enabled and a standard asset is already cached, `CheckCache`  returns that standard asset even if the `alt/` version has never been loaded. Because `LoadResourceAsync` treats this as a cache hit, it never calls `LoadResourceProcess`, which is the only code that tries to load the `alt/` version. As a result, the `alt/` version is ignored for as long as the standard asset stays cached.

A user can hit this by turning alt assets off, entering a scene, and then turning alt assets back on. SoH clears all `alt/*` resources from the cache on every scene change, so the cached standard asset wins on every later visit to that scene.

### Changes
- Report a cache miss when the `alt/` version of an asset has not been tried yet, so it is loaded before the cached standard asset is used.
- Look up listed files by their exact path when marking resources dirty, so the `alt/` version is never mistaken for the standard one.
### Testing

Tested with SoH mods that replision under `alt/`. They nowswitch on and off together with the other alt assets.