### PR TITLE
don't try to parse strings as dlists

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -3702,11 +3702,27 @@ bool gfx_modify_vtx_handler_f3dex2(F3DGfx** cmd0) {
     return false;
 }
 
+static bool gfx_dl_target_is_resource_path(const F3DGfx* target) {
+    if (!gfx_check_image_signature((const char*)target)) {
+        return false;
+    }
+
+    static std::set<const F3DGfx*> reported;
+    if (reported.insert(target).second) {
+        SPDLOG_ERROR("Skipping dlist call that resolved to resource \"{}\"", (const char*)target);
+    }
+    return true;
+}
+
 // F3D, F3DEX, and F3DEX2 do the same thing but F3DEX2 has its own opcode number
 bool gfx_dl_handler_common(F3DGfx** cmd0) {
     Interpreter* gfx = mInstance.lock().get();
     F3DGfx* cmd = *cmd0;
     F3DGfx* subGFX = (F3DGfx*)gfx->SegAddr(cmd->words.w1);
+    if (gfx_dl_target_is_resource_path(subGFX)) {
+        return false;
+    }
+
     if (C0(16, 1) == 0) {
         // Push return address
         if (subGFX != nullptr) {
@@ -3752,6 +3768,10 @@ bool gfx_dl_index_handler(F3DGfx** cmd0) {
     uintptr_t segAddr = (segNum << 24) | (index * sizeof(F3DGfx)) + 1;
 
     F3DGfx* subGFX = (F3DGfx*)gfx->SegAddr(segAddr);
+    if (gfx_dl_target_is_resource_path(subGFX)) {
+        return false;
+    }
+
     if (C0(16, 1) == 0) {
         // Push return address
         if (subGFX != nullptr) {


### PR DESCRIPTION
djipi's latest 3ds experience pack loads from an address that ends up having an `__OTR__` something or other in there by the time a `<CallDisplayList Path=">0x0A000000"/>` command is run. this causes a crash in soh.

this fixes the crash by checking to see if a command we're about to parse is one of those `__OTR__` something strings, which doesn't feel ideal but i haven't found a better solution.

soh testing pr:
* https://github.com/HarbourMasters/Shipwright/pull/7161

i used claude to assist in the investigation
* logging used https://github.com/briaguya0/libultraship/commit/ce9f64e9f5eadf14002b0c746a1864ab5f66f355
* claude gist of findings https://gist.github.com/briaguya0/8975e76f1f6459a18f1fab487af7f49c