### PR TITLE
Restore the Windows and macOS includes SDL2 used to provide

### DIFF
--- a/include/fast/backends/gfx_direct3d_common.h
+++ b/include/fast/backends/gfx_direct3d_common.h
@@ -9,6 +9,7 @@
 #include <string>
 #include "gfx_rendering_api.h"
 #include "d3d11.h"
+#include <wrl/client.h>
 #include "d3dcompiler.h"
 
 namespace Ship {

--- a/include/fast/backends/gfx_dxgi.h
+++ b/include/fast/backends/gfx_dxgi.h
@@ -8,6 +8,7 @@
 #include <functional>
 
 #include <dxgi1_2.h>
+#include <wrl/client.h>
 
 namespace Ship {
 class Config;

--- a/src/fast/Fast3dGui.cpp
+++ b/src/fast/Fast3dGui.cpp
@@ -33,6 +33,10 @@
 #endif
 
 #if defined(ENABLE_DX11) || defined(ENABLE_DX12)
+// imgui deliberately omits its own WndProcHandler declaration to keep <windows.h> out of the
+// header, so the copy below - and the Win32 types it names - needs it here.
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #include <imgui_impl_dx11.h>
 #include <imgui_impl_win32.h>
 

--- a/src/ship/core/Context.cpp
+++ b/src/ship/core/Context.cpp
@@ -7,6 +7,7 @@
 #include <queue>
 #if defined(__APPLE__)
 #include <pwd.h>
+#include <unistd.h>
 #endif
 #include "ship/install_config.h"
 #include "ship/config/ConsoleVariable.h"


### PR DESCRIPTION
SDL2 pulled in `<windows.h>` and `<unistd.h>` transitively; SDL3 does not, so #1191 left three sites relying on includes that no longer arrive. Windows and macOS only — which is why it went unnoticed.

- `Fast3dGui.cpp` needs `<windows.h>` for the `ImGui_ImplWin32_WndProcHandler` declaration imgui deliberately omits from its own header. Scoped with `WIN32_LEAN_AND_MEAN`, as `FileDrop.cpp` already does; `NOMINMAX` is already global.
- `gfx_dxgi.h` and `gfx_direct3d_common.h` name `Microsoft::WRL::ComPtr` without `<wrl/client.h>`.
- `Context.cpp` calls `getuid()` without `<unistd.h>` on Apple.

Verified the DX headers with a mingw-w64 cross compile: 30 and 3 errors without `<wrl/client.h>`, 0 with it.