### PR TITLE
Create the bridge component CreateDefaultInstance's own caches depend on

### DIFF
--- a/src/ship/core/Context.cpp
+++ b/src/ship/core/Context.cpp
@@ -1,5 +1,7 @@
 #include "ship/core/Context.h"
 #include "ship/bridge/Bridge.h"
+#include "libultraship/bridge/UltraBridge.h"
+#include "fast/debug/GfxDebugger.h"
 #include "ship/core/TickableComponent.h"
 #include <cstring>
 #include <iostream>
@@ -176,6 +178,12 @@ std::shared_ptr<Context> Context::CreateDefaultInstance(const std::string& name,
     auto audio = std::make_shared<Audio>(audioSettings, config);
     shared->GetChildren().Add(audio);
 
+    // ---- Bridge ----
+    // The C bridge caches are populated from this component; without it every
+    // bridge accessor keeps returning null and the plain C API is dead.
+    shared->GetChildren().Add(std::make_shared<LUS::UltraBridge>());
+    shared->GetChildren().Add(std::make_shared<Fast::GfxDebugger>());
+
     // ---- Events ----
     shared->GetChildren().Add(std::make_shared<Events>());
 
@@ -189,6 +197,10 @@ std::shared_ptr<Context> Context::CreateDefaultInstance(const std::string& name,
         std::unordered_map<std::string, std::string>{}, 1, "-g -Wl", std::vector<std::string>{},
         std::vector<std::string>{}, std::vector<std::string>{}, resourceManager));
 #endif
+
+    // Components reach each other through the bridge during Init, so the caches have to
+    // be live before the first Init call; they are refreshed again once Init is done.
+    UpdateBridgeCachesIfPresent(shared);
 
     // ---- Init all components that need it ----
     try {


### PR DESCRIPTION
#1184 moved the bridge cache handling from a self-registering static hook into a `Bridge` component the application is expected to add — but nothing constructs one. Repo-wide, `UltraBridge` is referenced only by its own two files.

So `CreateDefaultInstance` returns a context whose entire C bridge API is dead: `ResourceGetDataByName` and every CVar, window, controller, audio and crash accessor return null for the life of the process. `GfxDebugger`, which the removed installer hook added, is never created either.

Shipwright dies on the first bridge call — `AudioLoad_Init` lists the sequence files through the component hierarchy, then dereferences the null that `ResourceGetDataByName` hands back.

Also refreshes the caches before the Init pass, since Init is when components reach each other.

One of three needed before `CreateDefaultInstance` produces a usable context; the others are the root-Context init and the dependency injection.