### PR TITLE
Mark the root Context initialized

### DIFF
--- a/src/ship/core/Context.cpp
+++ b/src/ship/core/Context.cpp
@@ -246,6 +246,9 @@ std::shared_ptr<Context> Context::CreateInstance(const std::string& name, const 
 
 Context::Context(std::string name, std::string shortName)
     : Component(std::move(name)), mShortName(std::move(shortName)), mInitTime(std::chrono::steady_clock::now()) {
+    // The root has no initialization work of its own, but children reach it through
+    // RequireDependency<Context>, which rejects a component that was never initialized.
+    MarkInitialized();
 }
 
 const std::string& Context::GetShortName() const {


### PR DESCRIPTION
Components reach the root through `RequireDependency<Context>`, which rejects a dependency that was never initialized. Nothing initializes the root, so the first component to ask for it throws.

Shipwright dies in `Fast3dGui::Init` with `Component 'Gui' requires dependency 'Context' to be initialized before use`.

The root has no initialization work of its own, so it is ready as soon as it is constructed — same as `Config`, `ConsoleVariable` and `ThreadPool`, which already mark themselves in their constructors.

One of three needed before `CreateDefaultInstance` produces a usable context; the others are the missing bridge component and the dependency injection.