### PR TITLE
Wire up the components CreateDefaultInstance is handed

### DIFF
--- a/include/fast/Fast3dWindow.h
+++ b/include/fast/Fast3dWindow.h
@@ -129,6 +129,12 @@ class Fast3dWindow : public Ship::Window {
     GfxWindowBackend* mWindowManagerApi;
     std::shared_ptr<Interpreter> mInterpreter = nullptr;
     std::shared_ptr<Ship::ConsoleVariable> mConsoleVariables;
+
+  public:
+    /** @brief Injects the ConsoleVariable dependency created after this window. */
+    void SetConsoleVariables(std::shared_ptr<Ship::ConsoleVariable> consoleVariables) {
+        mConsoleVariables = std::move(consoleVariables);
+    }
     mutable std::shared_ptr<Ship::ControlDeck> mControlDeck;
     std::shared_ptr<GfxDebugger> mGfxDebugger;
 

--- a/include/ship/controller/controldeck/ControlDeck.h
+++ b/include/ship/controller/controldeck/ControlDeck.h
@@ -168,9 +168,7 @@ class ControlDeck : public Component {
      * Context::CreateDefaultInstance() takes a caller-constructed ControlDeck and creates the
      * ConsoleVariable component afterwards, so it cannot be supplied to the constructor.
      */
-    void SetConsoleVariables(std::shared_ptr<ConsoleVariable> consoleVariables) {
-        mConsoleVariables = std::move(consoleVariables);
-    }
+    void SetConsoleVariables(std::shared_ptr<ConsoleVariable> consoleVariables);
 
     /**
      * @brief Injects the Window dependency after construction.
@@ -178,9 +176,7 @@ class ControlDeck : public Component {
      * A port that builds its Window and its ControlDeck side by side has neither to give the
      * other, so whichever it constructs first reaches the factory without this.
      */
-    void SetWindow(std::shared_ptr<Window> window) {
-        mWindow = std::move(window);
-    }
+    void SetWindow(std::shared_ptr<Window> window);
     std::shared_ptr<WheelHandler> mWheelHandler;
 
     /** @brief Returns the cached Window component. */

--- a/include/ship/controller/controldeck/ControlDeck.h
+++ b/include/ship/controller/controldeck/ControlDeck.h
@@ -130,6 +130,15 @@ class ControlDeck : public Component {
 
   protected:
     /**
+     * @brief Resolves the console variables and builds the global SDL device settings.
+     *
+     * Deferred to here because a port may construct its own ControlDeck and hand it to
+     * Context::CreateDefaultInstance(), which creates the ConsoleVariable component
+     * afterwards; at construction time there is nothing to resolve against.
+     */
+    void OnInit(const nlohmann::json& initArgs = nlohmann::json::object()) override;
+
+    /**
      * @brief Returns true if *all* registered blockers have blocked game input.
      *
      * Used internally by WriteToPad() implementations to decide whether to pass
@@ -137,6 +146,10 @@ class ControlDeck : public Component {
      */
     bool AllGameInputBlocked();
     std::vector<std::shared_ptr<ControlPort>> mPorts = {}; ///< One entry per controller port.
+
+  protected:
+    /** @brief Builds GlobalSDLDeviceSettings once mConsoleVariables is available. */
+    void EnsureGlobalSDLDeviceSettings();
 
   private:
     uint8_t* mControllerBits = nullptr;
@@ -147,6 +160,17 @@ class ControlDeck : public Component {
     std::unordered_map<CONTROLLERBUTTONS_T, std::string> mButtonNames;
     std::shared_ptr<Window> mWindow;
     std::shared_ptr<ConsoleVariable> mConsoleVariables;
+
+  public:
+    /**
+     * @brief Injects the ConsoleVariable dependency after construction.
+     *
+     * Context::CreateDefaultInstance() takes a caller-constructed ControlDeck and creates the
+     * ConsoleVariable component afterwards, so it cannot be supplied to the constructor.
+     */
+    void SetConsoleVariables(std::shared_ptr<ConsoleVariable> consoleVariables) {
+        mConsoleVariables = std::move(consoleVariables);
+    }
     std::shared_ptr<WheelHandler> mWheelHandler;
 
     /** @brief Returns the cached Window component. */

--- a/include/ship/controller/controldeck/ControlDeck.h
+++ b/include/ship/controller/controldeck/ControlDeck.h
@@ -171,6 +171,16 @@ class ControlDeck : public Component {
     void SetConsoleVariables(std::shared_ptr<ConsoleVariable> consoleVariables) {
         mConsoleVariables = std::move(consoleVariables);
     }
+
+    /**
+     * @brief Injects the Window dependency after construction.
+     *
+     * A port that builds its Window and its ControlDeck side by side has neither to give the
+     * other, so whichever it constructs first reaches the factory without this.
+     */
+    void SetWindow(std::shared_ptr<Window> window) {
+        mWindow = std::move(window);
+    }
     std::shared_ptr<WheelHandler> mWheelHandler;
 
     /** @brief Returns the cached Window component. */

--- a/include/ship/controller/controldevice/controller/Controller.h
+++ b/include/ship/controller/controldevice/controller/Controller.h
@@ -39,6 +39,10 @@ class Controller : public ControlDevice {
   public:
     /** @brief Injects the owning ControlDeck into this controller and all of its subsystems. */
     void SetControlDeck(std::shared_ptr<ControlDeck> controlDeck);
+    /** @brief Injects the ConsoleVariable component into this controller and all of its subsystems. */
+    void SetConsoleVariable(std::shared_ptr<ConsoleVariable> consoleVariable);
+    /** @brief Injects the Window component into this controller and all of its subsystems. */
+    void SetWindow(std::shared_ptr<Window> window);
     /**
      * @brief Constructs a Controller for the given port with a set of button bitmasks.
      * @param portIndex       Zero-based port index.

--- a/include/ship/controller/controldevice/controller/ControllerButton.h
+++ b/include/ship/controller/controldevice/controller/ControllerButton.h
@@ -29,6 +29,14 @@ class ControllerButton {
     void SetControlDeck(std::shared_ptr<ControlDeck> controlDeck) {
         mControlDeck = std::move(controlDeck);
     }
+    /** @brief Injects the ConsoleVariable component. */
+    void SetConsoleVariable(std::shared_ptr<ConsoleVariable> consoleVariable) {
+        mConsoleVariable = std::move(consoleVariable);
+    }
+    /** @brief Injects the Window component. */
+    void SetWindow(std::shared_ptr<Window> window) {
+        mWindow = std::move(window);
+    }
     /**
      * @brief Constructs a ControllerButton for a specific port and bitmask.
      * @param portIndex       Zero-based port index.

--- a/include/ship/controller/controldevice/controller/ControllerGyro.h
+++ b/include/ship/controller/controldevice/controller/ControllerGyro.h
@@ -21,6 +21,10 @@ class ControllerGyro {
     void SetControlDeck(std::shared_ptr<ControlDeck> controlDeck) {
         mControlDeck = std::move(controlDeck);
     }
+    /** @brief Injects the ConsoleVariable component. */
+    void SetConsoleVariable(std::shared_ptr<ConsoleVariable> consoleVariable) {
+        mConsoleVariable = std::move(consoleVariable);
+    }
     /**
      * @brief Constructs a ControllerGyro for the given port.
      * @param portIndex Zero-based port index.

--- a/include/ship/controller/controldevice/controller/ControllerLED.h
+++ b/include/ship/controller/controldevice/controller/ControllerLED.h
@@ -25,6 +25,10 @@ class ControllerLED {
     void SetControlDeck(std::shared_ptr<ControlDeck> controlDeck) {
         mControlDeck = std::move(controlDeck);
     }
+    /** @brief Injects the ConsoleVariable component. */
+    void SetConsoleVariable(std::shared_ptr<ConsoleVariable> consoleVariable) {
+        mConsoleVariable = std::move(consoleVariable);
+    }
     /**
      * @brief Constructs a ControllerLED for the given port.
      * @param portIndex Zero-based port index.

--- a/include/ship/controller/controldevice/controller/ControllerRumble.h
+++ b/include/ship/controller/controldevice/controller/ControllerRumble.h
@@ -26,6 +26,10 @@ class ControllerRumble {
     void SetControlDeck(std::shared_ptr<ControlDeck> controlDeck) {
         mControlDeck = std::move(controlDeck);
     }
+    /** @brief Injects the ConsoleVariable component. */
+    void SetConsoleVariable(std::shared_ptr<ConsoleVariable> consoleVariable) {
+        mConsoleVariable = std::move(consoleVariable);
+    }
     /**
      * @brief Constructs a ControllerRumble for the given port.
      * @param portIndex Zero-based port index.

--- a/include/ship/controller/controldevice/controller/ControllerStick.h
+++ b/include/ship/controller/controldevice/controller/ControllerStick.h
@@ -35,6 +35,14 @@ class ControllerStick {
     void SetControlDeck(std::shared_ptr<ControlDeck> controlDeck) {
         mControlDeck = std::move(controlDeck);
     }
+    /** @brief Injects the ConsoleVariable component. */
+    void SetConsoleVariable(std::shared_ptr<ConsoleVariable> consoleVariable) {
+        mConsoleVariable = std::move(consoleVariable);
+    }
+    /** @brief Injects the Window component. */
+    void SetWindow(std::shared_ptr<Window> window) {
+        mWindow = std::move(window);
+    }
     /**
      * @brief Constructs a ControllerStick for a given port and stick index.
      * @param portIndex  Zero-based port index.

--- a/include/ship/window/Window.h
+++ b/include/ship/window/Window.h
@@ -303,6 +303,17 @@ class Window : public Component {
     // Hold a reference to Config because Window has a Save function called on Context destructor, where the singleton
     // is no longer available.
     std::shared_ptr<Config> mConfig;
+
+  public:
+    /**
+     * @brief Injects the Config dependency after construction.
+     *
+     * Context::CreateDefaultInstance() takes a caller-constructed Window and creates Config
+     * afterwards, so the dependency cannot be supplied to the constructor.
+     */
+    void SetConfig(std::shared_ptr<Config> config) {
+        mConfig = std::move(config);
+    }
     int32_t mFullscreenScancode;
     int32_t mMouseCaptureScancode;
 };

--- a/src/ship/controller/controldeck/ControlDeck.cpp
+++ b/src/ship/controller/controldeck/ControlDeck.cpp
@@ -175,6 +175,25 @@ std::string ControlDeck::GetButtonNameForBitmask(CONTROLLERBUTTONS_T bitmask) {
     return mButtonNames[bitmask];
 }
 
+void ControlDeck::SetConsoleVariables(std::shared_ptr<ConsoleVariable> consoleVariables) {
+    mConsoleVariables = std::move(consoleVariables);
+    // The ports were built in the constructor, before this existed.
+    for (const auto& port : mPorts) {
+        if (port != nullptr && port->GetConnectedController() != nullptr) {
+            port->GetConnectedController()->SetConsoleVariable(mConsoleVariables);
+        }
+    }
+}
+
+void ControlDeck::SetWindow(std::shared_ptr<Window> window) {
+    mWindow = std::move(window);
+    for (const auto& port : mPorts) {
+        if (port != nullptr && port->GetConnectedController() != nullptr) {
+            port->GetConnectedController()->SetWindow(mWindow);
+        }
+    }
+}
+
 std::shared_ptr<Window> ControlDeck::GetWindow() const {
     if (!mWindow) {
         throw std::runtime_error("ControlDeck requires Window dependency");

--- a/src/ship/controller/controldeck/ControlDeck.cpp
+++ b/src/ship/controller/controldeck/ControlDeck.cpp
@@ -17,7 +17,6 @@ ControlDeck::ControlDeck(std::vector<CONTROLLERBUTTONS_T> additionalBitmasks,
                          std::shared_ptr<Window> window, std::shared_ptr<ConsoleVariable> consoleVariable)
     : Component("ControlDeck"), mWindow(std::move(window)), mConsoleVariables(std::move(consoleVariable)) {
     mConnectedPhysicalDeviceManager = std::make_shared<ConnectedPhysicalDeviceManager>();
-    mGlobalSDLDeviceSettings = std::make_shared<GlobalSDLDeviceSettings>(mConsoleVariables);
     mControllerDefaultMappings = controllerDefaultMappings == nullptr ? std::make_shared<ControllerDefaultMappings>()
                                                                       : controllerDefaultMappings;
 }
@@ -29,6 +28,10 @@ ControlDeck::~ControlDeck() {
 void ControlDeck::Init(uint8_t* controllerBits) {
     mControllerBits = controllerBits;
     *mControllerBits |= 1 << 0;
+
+    // This overload marks the component initialized itself, so OnInit never runs for a deck
+    // brought up this way.
+    EnsureGlobalSDLDeviceSettings();
 
     mWheelHandler = std::make_shared<WheelHandler>(GetWindow());
 
@@ -122,6 +125,25 @@ void ControlDeck::UnblockGameInput(int32_t blockId) {
 
 std::shared_ptr<ConnectedPhysicalDeviceManager> ControlDeck::GetConnectedPhysicalDeviceManager() {
     return mConnectedPhysicalDeviceManager;
+}
+
+void ControlDeck::OnInit(const nlohmann::json& initArgs) {
+    Component::OnInit(initArgs);
+
+    if (mConsoleVariables == nullptr) {
+        auto context = GetFirstInParents<Context>();
+        if (context != nullptr) {
+            mConsoleVariables = context->GetFirstInChildren<ConsoleVariable>();
+        }
+    }
+
+    EnsureGlobalSDLDeviceSettings();
+}
+
+void ControlDeck::EnsureGlobalSDLDeviceSettings() {
+    if (mGlobalSDLDeviceSettings == nullptr) {
+        mGlobalSDLDeviceSettings = std::make_shared<GlobalSDLDeviceSettings>(mConsoleVariables);
+    }
 }
 
 std::shared_ptr<GlobalSDLDeviceSettings> ControlDeck::GetGlobalSDLDeviceSettings() {

--- a/src/ship/controller/controldevice/controller/Controller.cpp
+++ b/src/ship/controller/controldevice/controller/Controller.cpp
@@ -89,6 +89,41 @@ void Controller::SetControlDeck(std::shared_ptr<ControlDeck> controlDeck) {
     }
 }
 
+void Controller::SetConsoleVariable(std::shared_ptr<ConsoleVariable> consoleVariable) {
+    mConsoleVariable = consoleVariable;
+    for (auto& [bitmask, button] : mButtons) {
+        button->SetConsoleVariable(consoleVariable);
+    }
+    if (mLeftStick != nullptr) {
+        mLeftStick->SetConsoleVariable(consoleVariable);
+    }
+    if (mRightStick != nullptr) {
+        mRightStick->SetConsoleVariable(consoleVariable);
+    }
+    if (mGyro != nullptr) {
+        mGyro->SetConsoleVariable(consoleVariable);
+    }
+    if (mRumble != nullptr) {
+        mRumble->SetConsoleVariable(consoleVariable);
+    }
+    if (mLED != nullptr) {
+        mLED->SetConsoleVariable(consoleVariable);
+    }
+}
+
+void Controller::SetWindow(std::shared_ptr<Window> window) {
+    mWindow = window;
+    for (auto& [bitmask, button] : mButtons) {
+        button->SetWindow(window);
+    }
+    if (mLeftStick != nullptr) {
+        mLeftStick->SetWindow(window);
+    }
+    if (mRightStick != nullptr) {
+        mRightStick->SetWindow(window);
+    }
+}
+
 bool Controller::HasConfig() {
     const std::string hasConfigCvarKey =
         StringHelper::Sprintf(CVAR_PREFIX_CONTROLLERS ".Port%d.HasConfig", mPortIndex + 1);

--- a/src/ship/core/Context.cpp
+++ b/src/ship/core/Context.cpp
@@ -1,4 +1,5 @@
 #include "ship/core/Context.h"
+#include "fast/Fast3dWindow.h"
 #include "ship/bridge/Bridge.h"
 #include "ship/core/TickableComponent.h"
 #include <cstring>
@@ -129,7 +130,19 @@ std::shared_ptr<Context> Context::CreateDefaultInstance(const std::string& name,
     size_t threadCount = std::max(1, (int32_t)(std::thread::hardware_concurrency() - reservedThreadCount - 1));
 
     // ---- Console Variables ----
-    shared->GetChildren().Add(std::make_shared<ConsoleVariable>(config));
+    auto consoleVariables = std::make_shared<ConsoleVariable>(config);
+    shared->GetChildren().Add(consoleVariables);
+
+    // The caller built its Window and ControlDeck before these existed, so inject them now.
+    if (auto win = std::dynamic_pointer_cast<Window>(window)) {
+        win->SetConfig(config);
+    }
+    if (auto fastWin = std::dynamic_pointer_cast<Fast::Fast3dWindow>(window)) {
+        fastWin->SetConsoleVariables(consoleVariables);
+    }
+    if (auto deck = std::dynamic_pointer_cast<ControlDeck>(controlDeck)) {
+        deck->SetConsoleVariables(consoleVariables);
+    }
 
     // ---- Thread Pool ----
     auto threadPool = std::make_shared<ThreadPool>(threadCount);

--- a/src/ship/core/Context.cpp
+++ b/src/ship/core/Context.cpp
@@ -142,6 +142,7 @@ std::shared_ptr<Context> Context::CreateDefaultInstance(const std::string& name,
     }
     if (auto deck = std::dynamic_pointer_cast<ControlDeck>(controlDeck)) {
         deck->SetConsoleVariables(consoleVariables);
+        deck->SetWindow(std::dynamic_pointer_cast<Window>(window));
     }
 
     // ---- Thread Pool ----

--- a/src/ship/window/Window.cpp
+++ b/src/ship/window/Window.cpp
@@ -1,4 +1,5 @@
 #include "ship/window/Window.h"
+#include "ship/config/Config.h"
 #include "ship/window/gui/Gui.h"
 #include <string>
 #include <fstream>
@@ -40,6 +41,15 @@ Window::~Window() {
 
 void Window::OnInit(const nlohmann::json& initArgs) {
     Component::OnInit(initArgs);
+
+    // A port may construct its Window and hand it to Context::CreateDefaultInstance(), which
+    // creates Config afterwards, so there is nothing to inject at construction time.
+    if (mConfig == nullptr) {
+        auto context = GetFirstInParents<Context>();
+        if (context != nullptr) {
+            mConfig = context->GetFirstInChildren<Config>();
+        }
+    }
     // Mark the window as initialized before adding GUI to prevent access during GUI initialization
     MarkInitialized();
 


### PR DESCRIPTION
The factory takes a caller-built Window and ControlDeck, then creates `Config` and `ConsoleVariable` itself — so those cannot be passed to the callers' constructors, and nothing injected them afterwards.

Three consequences, one commit each:

1. `GlobalSDLDeviceSettings` dereferenced a null `ConsoleVariable` in ControlDeck's constructor, and Window/Fast3dWindow threw on their missing `Config`/`ConsoleVariables`. Adds the setters and calls them where both objects exist. `GlobalSDLDeviceSettings` moves to a helper called from both init paths, because `ControlDeck::Init(uint8_t*)` marks the component initialized itself and never runs `OnInit`.
2. A port builds its Window and ControlDeck side by side, so neither can be passed to the other's constructor. `ControlDeck::Init` then threw `ControlDeck requires Window dependency` building the WheelHandler.
3. Those setters only reached the deck. `LUS::ControlDeck` builds every `Controller` in its constructor from its own `window`/`consoleVariable` arguments, which default to `nullptr` — so the deck held valid dependencies while its controllers held null ones, and `Controller::HasConfig()` called `GetInteger` on a null `ConsoleVariable`. Both setters now walk `mPorts`, modelled on the existing `SetControlDeck`, which is injected after construction for exactly this reason.

One of three needed before `CreateDefaultInstance` produces a usable context; the others are the missing bridge component and the root-Context init.