### PR TITLE
Don't dereference past the end in GetPixelDepth

### DIFF
--- a/src/fast/interpreter.cpp
+++ b/src/fast/interpreter.cpp
@@ -5358,7 +5358,10 @@ uint16_t Interpreter::GetPixelDepth(float x, float y) {
     mGetPixelDepthCached.merge(res);
     mGetPixelDepthPending.clear();
 
-    return mGetPixelDepthCached.find(std::make_pair(x, y))->second;
+    // A backend that answers for fewer coordinates than it was asked about would otherwise be
+    // dereferenced past the end here.
+    auto it = mGetPixelDepthCached.find(std::make_pair(x, y));
+    return it != mGetPixelDepthCached.end() ? it->second : 0;
 }
 
 void gfx_push_current_dir(char* path) {


### PR DESCRIPTION
After merging the backend's reply into its cache, `Interpreter::GetPixelDepth` looks the coordinate up and dereferences the iterator unconditionally:

```cpp
return mGetPixelDepthCached.find(std::make_pair(x, y))->second;
```

Nothing requires a `GfxRenderingAPI::GetPixelDepth` implementation to answer for every coordinate it was asked about, and a backend that answers short crashes the game here rather than returning a wrong depth. The existing backends all happen to answer in full, so it has never fired.

Returns 0 on a miss instead.

Found while bringing up the Vulkan backend from #1265, whose implementation returns an empty map when queried outside a recorded frame — the first environment depth query then takes this path. That backend's own fix is proposed separately against its branch; this one stands on its own.